### PR TITLE
v0.2.0: OpenAPI spec, validate command, guided tutorial, init & apply UX

### DIFF
--- a/.cursor/rules/changelog.mdc
+++ b/.cursor/rules/changelog.mdc
@@ -1,0 +1,12 @@
+---
+description: Update CHANGELOG.md for user-visible changes (Keep a Changelog)
+alwaysApply: true
+---
+
+# Changelog
+
+When a change affects **users or operators** (API, CLI, behavior, docs readers care about, examples, defaults), add a bullet under **`## [Unreleased]`** in [CHANGELOG.md](CHANGELOG.md) in the right section: **Added**, **Changed**, **Deprecated**, **Removed**, **Fixed**, or **Security**.
+
+Skip changelog entries for internal refactors, test-only changes, and CI/tooling that does not change user-visible behavior. Full policy: [CONTRIBUTING.md](CONTRIBUTING.md) (section **Changelog**).
+
+If the PR already has a suitable `[Unreleased]` entry, do not duplicate; extend it.

--- a/.cursor/rules/openapi-sync.mdc
+++ b/.cursor/rules/openapi-sync.mdc
@@ -1,0 +1,25 @@
+---
+description: Keep OpenAPI in sync when the v1 API or CLI-exposed HTTP surface changes
+globs: api/**/*.go,cli/**/*.go,cmd/orlojctl/**/*.go,openapi/**/*,resources/**/*.go
+alwaysApply: false
+---
+
+# OpenAPI and API surface
+
+When you change any of the following, update **[openapi/](openapi/)** so paths and schemas stay accurate, then run the same check as CI:
+
+`npx --yes @redocly/cli@1.28.5 lint openapi/openapi.yaml`
+
+**Usually requires OpenAPI updates**
+
+- **`api/`** — new or changed routes, status codes, query params, or JSON bodies on the control-plane API.
+- **Resource JSON** shipped over the API — Go types in **`resources/`** (and related handlers) when they change serialized shape fields users or `orlojctl apply` send/receive.
+- **`orlojctl`** — new subcommands or flags that call **new or changed** HTTP endpoints or bodies (extend the spec to match what the server actually does).
+
+**Often does not require OpenAPI updates**
+
+- **Offline-only CLI** (e.g. manifest parse/validate with no new HTTP contract).
+- Internal refactors with identical wire format.
+- Docs-only changes outside the spec.
+
+When unsure, compare **`api/server.go`** route registration and handler payloads to **`openapi/openapi.yaml`** (and split schemas under **`openapi/schemas/`**). Regenerate the bundled root doc when your workflow uses **`openapi/build_openapi.py`**.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,14 @@ jobs:
       - name: Test
         run: go test ./... -count=1 -timeout 120s
 
+      - name: Validate example manifests (orlojctl)
+        run: go run ./cmd/orlojctl validate -f examples/
+
       - name: Vet
         run: go vet ./...
+
+      - name: Validate OpenAPI spec
+        run: npx --yes @redocly/cli@1.28.5 lint openapi/openapi.yaml
 
   reliability:
     needs: build-and-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to Orloj are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-03-29
+
+### Added
+
+- OpenAPI 3.1 specification for the full v1 API surface
+- `orlojctl validate` command for offline manifest validation
+- Guided "first agent system in 5 minutes" tutorial ([docs](https://docs.orloj.dev/guides/five-minute-tutorial)), linked from the docs home page, guides overview, README, and quickstart
+
+### Changed
+
+- `orlojctl init` now takes a positional `<name>` argument that sets both the output directory and resource prefix; `--blueprint` defaults to `pipeline`; `--name` and `--dir` flags removed
+- `orlojctl apply -f` accepts a manifest **file or directory** (same recursive discovery as `validate` for `.yaml`, `.yml`, and `.json`); applies each file and aggregates errors
+
+## [0.1.1] - 2026-03-27
+
+### Fixed
+
+- GoReleaser now produces per-binary archives (orlojd, orlojworker, orlojctl
+  are separate downloads instead of a single combined archive)
+
+### Added
+
+- `scripts/install.sh` for curl-based binary installation
+
+## [0.1.0] - 2026-03-26
+
+### Added
+
+- Initial public release
+- 15 resource kinds: Agent, AgentSystem, ModelEndpoint, Tool, Secret, Memory,
+  AgentPolicy, AgentRole, ToolPermission, ToolApproval, Task, TaskSchedule,
+  TaskWebhook, Worker, McpServer
+- Server (`orlojd`) with embedded web console, REST API, PostgreSQL and
+  in-memory storage backends
+- Distributed task execution (`orlojworker`) with lease-based claiming,
+  message-driven mode via NATS JetStream, and configurable tool isolation
+- CLI (`orlojctl`) with apply, get, delete, run, init, logs, trace, graph,
+  events, config subcommands
+- Model routing for OpenAI, Anthropic, Azure OpenAI, and Ollama providers
+- DAG-based orchestration: pipeline, hierarchical, and swarm-loop topologies
+  with fan-out/fan-in and configurable join semantics
+- Governance enforcement: policies, roles, tool permissions, and gated tool
+  approval workflows
+- MCP server integration with automatic tool discovery and sync
+- Memory resources with vector-backed retrieval (pgvector)
+- Task scheduling (cron) and webhook-triggered task creation
+- OpenTelemetry tracing, Prometheus metrics, and structured logging
+- Docker Compose stack for local multi-worker deployment
+- Homebrew tap distribution (`OrlojHQ/orloj`)
+- Blueprint scaffolding via `orlojctl init`
+
+[0.2.0]: https://github.com/OrlojHQ/orloj/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/OrlojHQ/orloj/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/OrlojHQ/orloj/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,16 @@ Please note that this project is governed by a
 - Keep docs and examples aligned with code changes.
 - Avoid unrelated refactors in feature/fix PRs.
 
+## Changelog
+
+Every PR that changes **user-visible** behavior should include a bullet under
+`[Unreleased]` in [CHANGELOG.md](./CHANGELOG.md). Use the appropriate section:
+**Added**, **Changed**, **Deprecated**, **Removed**, **Fixed**, or **Security**
+([Keep a Changelog](https://keepachangelog.com/) format).
+
+You do **not** need a changelog entry for internal refactors, test-only changes,
+or CI and tooling updates that do not affect users or operators.
+
 ## Commit Sign-off (DCO)
 
 By contributing, you certify the Developer Certificate of Origin (DCO).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Running AI agents in production today looks a lot like running containers before
 
 ## Quickstart
 
+**[Get started in 5 minutes](https://docs.orloj.dev/guides/five-minute-tutorial)** — scaffold with `orlojctl init`, add your API key, apply manifests, and run a pipeline with `orlojctl run`.
+
 Install **orlojctl** (CLI) via Homebrew:
 
 ```bash
@@ -72,7 +74,7 @@ go build -o orlojd ./cmd/orlojd
 go build -o orlojctl ./cmd/orlojctl
 ```
 
-When you are ready to scale, switch to message-driven mode with distributed workers and Postgres persistence. See the [Quickstart guide](https://docs.orloj.dev/getting-started/quickstart#scaling-to-production) for details.
+When you are ready to scale, switch to message-driven mode with distributed workers and Postgres persistence. See the [Quickstart guide](https://docs.orloj.dev/getting-started/quickstart#scaling-to-production) for details. Full walkthrough: [5-minute tutorial](https://docs.orloj.dev/guides/five-minute-tutorial).
 
 ## Architecture
 
@@ -114,6 +116,10 @@ When you are ready to scale, switch to message-driven mode with distributed work
 **Governance** -- AgentPolicy, AgentRole, and ToolPermission resources enforced inline during every tool call and model interaction.
 
 Persistence is backed by Postgres (or in-memory for local dev). Message-driven mode uses NATS JetStream for durable agent-to-agent messaging.
+
+## HTTP API (OpenAPI)
+
+The v1 REST API is described in [openapi/openapi.yaml](openapi/openapi.yaml) (OpenAPI 3.1, split schemas under [openapi/schemas/](openapi/schemas/)). CI runs `npx @redocly/cli lint openapi/openapi.yaml`. To regenerate the root document from [openapi/build_openapi.py](openapi/build_openapi.py), run `python3 openapi/build_openapi.py` from the repo root.
 
 ## Resources
 
@@ -159,6 +165,8 @@ Orloj manages 15 resource types, all defined as declarative YAML with `apiVersio
 
 Browse **[docs.orloj.dev](https://docs.orloj.dev)**.
 
+- [Changelog](CHANGELOG.md) -- notable changes by release
+- [5-minute tutorial](https://docs.orloj.dev/guides/five-minute-tutorial) -- scaffold, model key, first run
 - [Getting Started](https://docs.orloj.dev/getting-started/install) -- install, quickstart
 - [Concepts](https://docs.orloj.dev/concepts/architecture) -- architecture, agents, tasks, tools, model routing, governance
 - [Guides](https://docs.orloj.dev/guides/) -- deploy a pipeline, configure routing, build tools, set up governance

--- a/V0.2.0-PLAN.md
+++ b/V0.2.0-PLAN.md
@@ -1,0 +1,810 @@
+# Orloj v0.2.0 Implementation Plan
+
+**Theme: API contract and developer experience — "make it easy to adopt"**
+
+Release target: the first release someone can confidently build integrations against.
+
+---
+
+## Work Streams
+
+| # | Stream | Effort Est. | Dependencies |
+|---|--------|-------------|--------------|
+| 1 | OpenAPI spec | Large (3-5 days) | None |
+| 2 | `orlojctl validate` | Small (0.5-1 day) | None |
+| 3 | CHANGELOG | Small (0.5 day) | None |
+| 4 | Guided tutorial | Medium (2-3 days) | Streams 1-3 ideally done first |
+
+Streams 1, 2, and 3 can be worked in parallel. Stream 4 references the others so do it last.
+
+---
+
+## Stream 1: OpenAPI Specification
+
+### Goal
+
+A machine-readable `openapi.yaml` (OpenAPI 3.1) at the repo root that fully describes the v1 API surface. This is the foundation for future SDK generation, API documentation, and contract testing.
+
+### Approach: Hand-written spec, validated against the server
+
+Writing the spec by hand (rather than generating from code) is the right call here because:
+- The Go HTTP handlers use raw `http.ServeMux` with no framework annotations to generate from
+- A hand-written spec lets you make deliberate choices about what's public contract vs. internal
+- You can validate it against the running server with integration tests afterward
+
+### File structure
+
+```
+openapi/
+  openapi.yaml          # root spec file
+  schemas/              # $ref'd component schemas (one per resource kind)
+    agent.yaml
+    agent-system.yaml
+    model-endpoint.yaml
+    tool.yaml
+    secret.yaml
+    memory.yaml
+    agent-policy.yaml
+    agent-role.yaml
+    tool-permission.yaml
+    tool-approval.yaml
+    task.yaml
+    task-schedule.yaml
+    task-webhook.yaml
+    worker.yaml
+    mcp-server.yaml
+    common.yaml         # ObjectMeta, ListMeta, ErrorResponse, StatusResponse
+```
+
+Splitting schemas into separate files keeps individual files manageable and lets the future Python SDK generator operate on clean schema boundaries.
+
+### Schemas to define (derived from `resources/resource_types.go`)
+
+For each of the 15 resource kinds, define:
+
+```yaml
+# Pattern for every resource (using Agent as example):
+components:
+  schemas:
+    Agent:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion:
+          type: string
+          enum: ["orloj.dev/v1"]
+        kind:
+          type: string
+          enum: ["Agent"]
+        metadata:
+          $ref: '#/components/schemas/ObjectMeta'
+        spec:
+          $ref: '#/components/schemas/AgentSpec'
+        status:
+          $ref: '#/components/schemas/AgentStatus'
+
+    AgentList:
+      allOf:
+        - $ref: '#/components/schemas/ListMeta'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Agent'
+```
+
+**Common schemas** (`common.yaml`):
+
+```yaml
+ObjectMeta:
+  type: object
+  required: [name]
+  properties:
+    name:
+      type: string
+      pattern: '^[a-z0-9][a-z0-9-]*$'
+    namespace:
+      type: string
+      default: "default"
+    labels:
+      type: object
+      additionalProperties:
+        type: string
+    annotations:
+      type: object
+      additionalProperties:
+        type: string
+    uid:
+      type: string
+      readOnly: true
+    generation:
+      type: integer
+      readOnly: true
+
+ListMeta:
+  type: object
+  properties:
+    apiVersion:
+      type: string
+    kind:
+      type: string
+
+ErrorResponse:
+  type: object
+  properties:
+    error:
+      type: string
+    code:
+      type: integer
+```
+
+### Paths to define
+
+Every route registered in `api/server.go`. Organize by tag:
+
+**Tags** (one per resource group):
+- `agents`, `agent-systems`, `model-endpoints`, `tools`, `secrets`, `memories`
+- `agent-policies`, `agent-roles`, `tool-permissions`, `tool-approvals`
+- `tasks`, `task-schedules`, `task-webhooks`, `workers`, `mcp-servers`
+- `auth`, `system`, `events`
+
+**Per-resource CRUD pattern** (15 resources follow this):
+
+```yaml
+paths:
+  /v1/agents:
+    get:
+      tags: [agents]
+      summary: List agents
+      parameters:
+        - name: namespace
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentList'
+    post:
+      tags: [agents]
+      summary: Create or update an agent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Agent'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Agent'
+
+  /v1/agents/{name}:
+    get:
+      tags: [agents]
+      summary: Get agent by name
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Agent'
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      # same pattern...
+    delete:
+      # same pattern...
+```
+
+**Special endpoints to document:**
+
+| Endpoint | Notes |
+|----------|-------|
+| `GET /v1/tasks/{name}/logs` | SSE stream, document `text/event-stream` content type |
+| `GET /v1/tasks/{name}/messages` | Query params: `phase`, `from_agent`, `to_agent`, `branch_id`, `trace_id`, `limit` |
+| `GET /v1/tasks/{name}/metrics` | Returns execution metrics object |
+| `GET /v1/memories/{name}/entries` | Query params: `q`, `prefix`, `limit` |
+| `GET /v1/{agents,tasks,task-schedules,task-webhooks}/watch` | SSE streams (only these four resources have watch endpoints) |
+| `GET /v1/events/watch` | SSE stream for all resource events |
+| `POST /v1/webhook-deliveries/{endpoint_id}` | Document both signature profiles (`generic`, `github`) |
+| `GET /v1/capabilities` | Feature discovery |
+| `GET /v1/namespaces` | Returns string array |
+| Auth endpoints | `/v1/auth/config`, `setup`, `login`, `logout`, `me`, `change-password`, `admin/reset-password` |
+| `GET /healthz` | Outside `/v1` prefix |
+| `GET /metrics` | Prometheus format |
+
+### Authentication scheme
+
+```yaml
+components:
+  securitySchemes:
+    bearerToken:
+      type: http
+      scheme: bearer
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: orloj_session
+```
+
+### Validation
+
+Add a CI step to validate the spec:
+
+```yaml
+# .github/workflows/ci.yml addition
+- name: Validate OpenAPI spec
+  run: |
+    npm install -g @redocly/cli
+    redocly lint openapi/openapi.yaml
+```
+
+Optionally, add a Go test that starts the server, exercises every endpoint, and asserts response shapes match the spec using a library like `kin-openapi/openapiv3`.
+
+### Implementation steps
+
+1. Create `openapi/` directory structure
+2. Write `common.yaml` with shared schemas (ObjectMeta, ListMeta, ErrorResponse)
+3. Write schema files for each resource kind — derive directly from the Go struct definitions in `resources/resource_types.go`, matching JSON tags exactly
+4. Write the root `openapi.yaml` with all paths, referencing schema files
+5. Add Redocly lint to CI
+6. Add link to spec in README
+7. (Optional) Add a `/v1/openapi.yaml` endpoint to orlojd that serves the spec
+
+---
+
+## Stream 2: `orlojctl validate`
+
+### Goal
+
+Offline manifest validation: parse and validate YAML manifests without needing a running server. This catches errors before `apply`, works in CI pipelines, and supports multi-file directories.
+
+### Where it fits
+
+Add to the CLI dispatch in `cli/agentctl.go`:
+
+```go
+// cli/agentctl.go — add to the switch block (line ~62)
+case "validate":
+    return runValidate(args[1:])
+```
+
+### New file: `cli/validate.go`
+
+```go
+package cli
+
+import (
+    "errors"
+    "flag"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "github.com/OrlojHQ/orloj/resources"
+)
+
+func runValidate(args []string) error {
+    fs := flag.NewFlagSet("validate", flag.ContinueOnError)
+    manifestPath := fs.String("f", "", "path to manifest file or directory")
+    if err := fs.Parse(args); err != nil {
+        return err
+    }
+    if *manifestPath == "" {
+        return errors.New("-f is required: path to manifest file or directory")
+    }
+
+    info, err := os.Stat(*manifestPath)
+    if err != nil {
+        return fmt.Errorf("cannot access %s: %w", *manifestPath, err)
+    }
+
+    var files []string
+    if info.IsDir() {
+        entries, err := os.ReadDir(*manifestPath)
+        if err != nil {
+            return fmt.Errorf("read directory %s: %w", *manifestPath, err)
+        }
+        for _, e := range entries {
+            if e.IsDir() {
+                continue
+            }
+            name := e.Name()
+            if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".json") {
+                files = append(files, filepath.Join(*manifestPath, name))
+            }
+        }
+        if len(files) == 0 {
+            return fmt.Errorf("no manifest files found in %s", *manifestPath)
+        }
+    } else {
+        files = []string{*manifestPath}
+    }
+
+    var errs []string
+    valid := 0
+    for _, f := range files {
+        raw, err := os.ReadFile(f)
+        if err != nil {
+            errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+            continue
+        }
+
+        kind, err := resources.DetectKind(raw)
+        if err != nil {
+            errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+            continue
+        }
+
+        name, err := validateManifest(kind, raw)
+        if err != nil {
+            errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+            continue
+        }
+
+        fmt.Printf("  valid  %s/%s  (%s)\n", strings.ToLower(kind), name, f)
+        valid++
+    }
+
+    if len(errs) > 0 {
+        fmt.Printf("\n%d valid, %d invalid:\n", valid, len(errs))
+        for _, e := range errs {
+            fmt.Printf("  error  %s\n", e)
+        }
+        return fmt.Errorf("validation failed for %d file(s)", len(errs))
+    }
+
+    fmt.Printf("\n%d file(s) valid\n", valid)
+    return nil
+}
+
+// validateManifest parses and normalizes a manifest, returning the resource name.
+// This reuses the same parse+normalize pipeline as buildApplyRequest in agentctl.go
+// but without marshaling to JSON or making HTTP calls.
+func validateManifest(kind string, raw []byte) (string, error) {
+    switch strings.ToLower(strings.TrimSpace(kind)) {
+    case "agent":
+        obj, err := resources.ParseAgentManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "agentsystem":
+        obj, err := resources.ParseAgentSystemManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "modelendpoint":
+        obj, err := resources.ParseModelEndpointManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "tool":
+        obj, err := resources.ParseToolManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "secret":
+        obj, err := resources.ParseSecretManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "memory":
+        obj, err := resources.ParseMemoryManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "agentpolicy":
+        obj, err := resources.ParseAgentPolicyManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "agentrole":
+        obj, err := resources.ParseAgentRoleManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "toolpermission":
+        obj, err := resources.ParseToolPermissionManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "toolapproval":
+        obj, err := resources.ParseToolApprovalManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "task":
+        obj, err := resources.ParseTaskManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "taskschedule":
+        obj, err := resources.ParseTaskScheduleManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "taskwebhook":
+        obj, err := resources.ParseTaskWebhookManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "worker":
+        obj, err := resources.ParseWorkerManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    case "mcpserver":
+        obj, err := resources.ParseMcpServerManifest(raw)
+        if err != nil {
+            return "", err
+        }
+        return obj.Metadata.Name, nil
+    default:
+        return "", fmt.Errorf("unsupported kind %q", kind)
+    }
+}
+```
+
+### Refactoring note
+
+`validateManifest` and `buildApplyRequest` in `agentctl.go` (lines 304-406) share the same kind-switch logic. Consider extracting a shared helper:
+
+```go
+// resources/parse.go (new file or add to manifest_parser_ext.go)
+
+// ParsedResource is a kind-erased parsed resource with its metadata.
+type ParsedResource struct {
+    Kind string
+    Name string
+    Raw  interface{} // the typed resource struct
+}
+
+func ParseManifest(raw []byte) (*ParsedResource, error) {
+    kind, err := DetectKind(raw)
+    if err != nil {
+        return nil, err
+    }
+    // ... switch on kind, parse, return ParsedResource
+}
+```
+
+Then both `validate` and `apply` call `resources.ParseManifest()`.
+
+### Tests: `cli/validate_test.go`
+
+Test cases:
+- Valid manifest file (each kind) → exit 0, prints `valid <kind>/<name>`
+- Invalid YAML → exit 1, prints parse error with filename
+- Missing required field (no `metadata.name`) → exit 1, prints normalization error
+- Directory with mix of valid and invalid → prints summary with counts
+- Empty directory → error "no manifest files found"
+- Non-existent path → error
+
+### Usage help
+
+Update `printUsage()` in `agentctl.go` to include:
+
+```
+  validate  -f <file|dir>    Validate manifests offline (no server required)
+```
+
+### Docs
+
+Add to `docs/pages/reference/cli.md`:
+
+```markdown
+## validate
+
+Validate resource manifests locally without applying them.
+
+    orlojctl validate -f agent.yaml
+    orlojctl validate -f ./manifests/
+
+Accepts a single file or a directory. When given a directory, validates all
+`.yaml`, `.yml`, and `.json` files. Returns exit code 1 if any file is invalid.
+
+Useful in CI pipelines:
+
+    orlojctl validate -f ./deploy/manifests/ || exit 1
+```
+
+---
+
+## Stream 3: CHANGELOG
+
+### Goal
+
+Start a `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/) conventions. Backfill v0.1.0 and v0.1.1, then maintain going forward.
+
+### File: `CHANGELOG.md` (repo root)
+
+```markdown
+# Changelog
+
+All notable changes to Orloj are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- OpenAPI 3.1 specification for the full v1 API surface
+- `orlojctl validate` command for offline manifest validation
+- Guided "first agent system in 5 minutes" tutorial
+
+## [0.1.1] - 2026-03-27
+
+### Fixed
+- GoReleaser now produces per-binary archives (orlojd, orlojworker, orlojctl
+  are separate downloads instead of a single combined archive)
+
+### Added
+- `scripts/install.sh` for curl-based binary installation
+
+## [0.1.0] - 2026-03-26
+
+### Added
+- Initial public release
+- 15 resource kinds: Agent, AgentSystem, ModelEndpoint, Tool, Secret, Memory,
+  AgentPolicy, AgentRole, ToolPermission, ToolApproval, Task, TaskSchedule,
+  TaskWebhook, Worker, McpServer
+- Server (`orlojd`) with embedded web console, REST API, PostgreSQL and
+  in-memory storage backends
+- Distributed task execution (`orlojworker`) with lease-based claiming,
+  message-driven mode via NATS JetStream, and configurable tool isolation
+- CLI (`orlojctl`) with apply, get, delete, run, init, logs, trace, graph,
+  events, config subcommands
+- Model routing for OpenAI, Anthropic, Azure OpenAI, and Ollama providers
+- DAG-based orchestration: pipeline, hierarchical, and swarm-loop topologies
+  with fan-out/fan-in and configurable join semantics
+- Governance enforcement: policies, roles, tool permissions, and gated tool
+  approval workflows
+- MCP server integration with automatic tool discovery and sync
+- Memory resources with vector-backed retrieval (pgvector)
+- Task scheduling (cron) and webhook-triggered task creation
+- OpenTelemetry tracing, Prometheus metrics, and structured logging
+- Docker Compose stack for local multi-worker deployment
+- Homebrew tap distribution (`OrlojHQ/orloj`)
+- Blueprint scaffolding via `orlojctl init`
+
+[Unreleased]: https://github.com/OrlojHQ/orloj/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/OrlojHQ/orloj/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/OrlojHQ/orloj/releases/tag/v0.1.0
+```
+
+### Maintenance process
+
+Add to `CONTRIBUTING.md`:
+
+> Every PR that changes user-visible behavior must include a CHANGELOG entry
+> under `[Unreleased]`. Use the appropriate section heading: Added, Changed,
+> Deprecated, Removed, Fixed, or Security.
+
+---
+
+## Stream 4: Guided Tutorial
+
+### Goal
+
+A single walkthrough page that takes someone from zero to a running multi-agent pipeline in under 5 minutes. This is the highest-leverage documentation you can write — it's what people look for before deciding whether to invest time in a tool.
+
+### File: `docs/pages/guides/five-minute-tutorial.md`
+
+### Structure and content
+
+```markdown
+# Your First Agent System in 5 Minutes
+
+This tutorial walks you through deploying a three-agent content pipeline
+that takes a topic and produces a short article. You'll go from nothing
+to watching agents collaborate in the web console.
+
+## Prerequisites
+
+- orlojctl installed (`brew install OrlojHQ/orloj/orlojctl` or [install script])
+- orlojd binary or Docker
+- An OpenAI API key (or any supported provider)
+
+## 1. Start the server (30 seconds)
+
+One command, no database required:
+
+    orlojd --storage-backend=memory --embedded-worker
+
+Open http://localhost:8080 — you should see the dashboard.
+
+## 2. Scaffold a pipeline (30 seconds)
+
+    orlojctl init demo
+
+This creates:
+    agents/
+      planner_agent.yaml
+      research_agent.yaml
+      writer_agent.yaml
+    agent-system.yaml
+    task.yaml
+
+## 3. Configure your model endpoint (1 minute)
+
+Create `model-endpoint.yaml`:
+
+    apiVersion: orloj.dev/v1
+    kind: ModelEndpoint
+    metadata:
+      name: openai-default
+    spec:
+      provider: openai
+      default_model: gpt-4o
+      auth:
+        secret_ref: openai-key
+
+Create and apply the secret:
+
+    orlojctl create secret openai-key --from-literal OPENAI_API_KEY=sk-...
+    orlojctl apply -f model-endpoint.yaml
+
+## 4. Apply and run (1 minute)
+
+    orlojctl apply -f agents/
+    orlojctl apply -f agent-system.yaml
+    orlojctl run --system demo-pipeline topic="The future of open source AI"
+
+## 5. Watch it run (1 minute)
+
+    orlojctl logs task/<task-name> -f
+
+Or open the web console at http://localhost:8080 — click the task to see:
+- The DAG visualization showing planner → research → writer
+- Live log streaming as each agent executes
+- The final output in the task result
+
+## What just happened?
+
+[2-3 paragraphs explaining the execution model: task created, worker claimed
+it, planner agent ran first, output passed to research agent, then writer.
+Link to architecture docs for deeper understanding.]
+
+## Next steps
+
+- **Add a tool**: [Build a Custom Tool](/guides/build-custom-tool) to give
+  agents access to external APIs
+- **Add governance**: [Setup Governance](/guides/setup-governance) to enforce
+  token limits and tool permissions
+- **Deploy for real**: [Deploy to a VPS](/deploy/vps) with PostgreSQL and
+  distributed workers
+- **Try other topologies**: `orlojctl init myproject --blueprint hierarchical` or
+  `--blueprint swarm-loop`
+```
+
+### Also update these existing pages
+
+1. **`docs/pages/getting-started/quickstart.md`** — If this overlaps with the tutorial, either merge them or make quickstart link to the tutorial as the primary "get running" path.
+
+2. **`docs/pages/guides/index.md`** — Add the tutorial as the first entry, clearly marked as the starting point.
+
+3. **`docs/pages/index.md`** (landing page) — Add a prominent "Get started in 5 minutes" call-to-action linking to the tutorial.
+
+4. **`README.md`** — Add a "Quick Start" section near the top that shows the 5-command version and links to the full tutorial.
+
+---
+
+## Implementation Order
+
+```
+Week 1:
+  ├── [parallel] Stream 2: orlojctl validate (0.5-1 day)
+  │     1. Create cli/validate.go with runValidate
+  │     2. Add case to switch in agentctl.go
+  │     3. Write cli/validate_test.go
+  │     4. Update printUsage() and docs/pages/reference/cli.md
+  │
+  ├── [parallel] Stream 3: CHANGELOG (0.5 day)
+  │     1. Create CHANGELOG.md with backfilled entries
+  │     2. Add changelog policy to CONTRIBUTING.md
+  │
+  └── [parallel] Stream 1: OpenAPI spec — schemas (2 days)
+        1. Create openapi/ directory
+        2. Write common.yaml (ObjectMeta, ListMeta, ErrorResponse)
+        3. Write schema for each resource kind (derive from Go structs)
+
+Week 2:
+  ├── Stream 1: OpenAPI spec — paths + CI (2 days)
+  │     1. Write all path definitions in openapi.yaml
+  │     2. Document streaming endpoints (SSE), auth, webhooks
+  │     3. Add Redocly lint to CI
+  │     4. Update README with link to spec
+  │
+  └── Stream 4: Guided tutorial (2-3 days)
+        1. Write five-minute-tutorial.md
+        2. Test the exact commands end-to-end on a clean machine
+        3. Update quickstart.md, guides index, landing page, README
+        4. Build docs site and verify navigation
+
+Week 3:
+  ├── Integration testing + cleanup
+  │     1. End-to-end test of the tutorial flow
+  │     2. Validate all example manifests pass orlojctl validate
+  │     3. Optional: contract test asserting API matches OpenAPI spec
+  │
+  └── Release
+        1. Update CHANGELOG [Unreleased] → [0.2.0] with date
+        2. Tag v0.2.0
+        3. Write release notes highlighting the four deliverables
+```
+
+---
+
+## Acceptance Criteria
+
+### OpenAPI Spec
+- [ ] `openapi/openapi.yaml` passes `redocly lint` with no errors
+- [ ] Every route in `api/server.go` has a corresponding path in the spec
+- [ ] Every resource kind's schema matches its Go struct JSON serialization
+- [ ] Streaming endpoints (SSE) are documented with `text/event-stream` content type
+- [ ] Auth schemes (bearer token, session cookie) are defined
+- [ ] CI runs spec validation on every PR
+
+### `orlojctl validate`
+- [ ] `orlojctl validate -f <file>` validates a single manifest
+- [ ] `orlojctl validate -f <dir>` validates all manifests in a directory
+- [ ] Exit code 0 on all valid, exit code 1 on any invalid
+- [ ] Error messages include filename and specific validation failure
+- [ ] All 15 resource kinds are supported
+- [ ] Test coverage for valid, invalid, directory, and edge cases
+- [ ] Documented in CLI reference
+
+### CHANGELOG
+- [ ] `CHANGELOG.md` exists at repo root
+- [ ] Entries for v0.1.0 and v0.1.1 are backfilled
+- [ ] `[Unreleased]` section has v0.2.0 additions
+- [ ] `CONTRIBUTING.md` mentions changelog requirement
+
+### Guided Tutorial
+- [ ] `five-minute-tutorial.md` in docs/pages/guides/
+- [ ] Commands are tested end-to-end and produce the described output
+- [ ] Links to the tutorial from: guides index, quickstart, README
+- [ ] "Next steps" links all resolve to existing pages
+
+---
+
+## Out of Scope for v0.2.0
+
+These are explicitly deferred to keep the release focused:
+
+- **Python SDK** — Blocked on API stabilization (this release)
+- **OpenAPI-based code generation** — The spec enables this but generation is a v0.3.0+ concern
+- **API breaking changes** — If schema inconsistencies are found while writing the spec, document them and fix in a follow-up PR with migration notes
+- **Additional CLI commands** (rollback, diff, etc.) — Future releases
+- **Provider integration tests in CI** — Planned for v0.3.0 reliability release

--- a/api/server.go
+++ b/api/server.go
@@ -68,6 +68,7 @@ type Server struct {
 	extensions         agentruntime.Extensions
 	memoryBackends     *agentruntime.PersistentMemoryBackendRegistry
 	authRateLimiter    *authRateLimiter
+	requestRateLimiter *rate.Limiter // per-server; avoids test suites sharing one process-global bucket
 	uiBasePath         string
 }
 
@@ -136,6 +137,9 @@ func NewServerWithOptions(stores Stores, runtime *agentruntime.Manager, logger *
 		bus:                eventbus.NewMemoryBus(4096),
 		extensions:         extensions,
 		authRateLimiter:    newAuthRateLimiter(),
+		// 500 r/s sustained, burst 100 — same as previous package-global limiter, but per Server instance
+		// so concurrent httptest servers in tests do not share one token bucket.
+		requestRateLimiter: rate.NewLimiter(rate.Limit(500), 100),
 		uiBasePath:         uiBase,
 	}
 	s.routes()
@@ -173,14 +177,13 @@ func (s *Server) withBodyLimit(next http.Handler) http.Handler {
 	})
 }
 
-// globalRateLimiter caps the API server to 500 requests/second with a burst
-// of 100 to handle short spikes. This is a simple global limiter; deploy a
-// reverse proxy for per-client or per-IP limiting at scale.
-var globalRateLimiter = rate.NewLimiter(rate.Limit(500), 100)
-
-func withRateLimit(next http.Handler) http.Handler {
+func (s *Server) withRateLimit(next http.Handler) http.Handler {
+	lim := s.requestRateLimiter
+	if lim == nil {
+		lim = rate.NewLimiter(rate.Limit(500), 100)
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !globalRateLimiter.Allow() {
+		if !lim.Allow() {
 			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
 			return
 		}
@@ -192,7 +195,7 @@ func withRateLimit(next http.Handler) http.Handler {
 func (s *Server) UIBasePath() string { return s.uiBasePath }
 
 func (s *Server) Handler() http.Handler {
-	return withRequestTimeout(withRateLimit(s.withBodyLimit(s.withAuth(s.mux))))
+	return withRequestTimeout(s.withRateLimit(s.withBodyLimit(s.withAuth(s.mux))))
 }
 
 // normalizeUIBasePath ensures the path has a leading and trailing slash.
@@ -466,7 +469,9 @@ func (s *Server) handleAgentByName(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		current, ok, err := s.stores.Agents.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("agent %q not found", name), http.StatusNotFound)
 			return
@@ -509,7 +514,9 @@ func (s *Server) createOrUpdateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	existing, ok, err := s.stores.Agents.Get(r.Context(), store.ScopedName(agent.Metadata.Namespace, agent.Metadata.Name))
-	if writeStoreFetchError(w, err) { return }
+	if writeStoreFetchError(w, err) {
+		return
+	}
 	if ok {
 		agent.Status = existing.Status
 	}
@@ -532,7 +539,9 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 		nsFilter = ns
 	}
 	agents, err := s.stores.Agents.ListCursor(r.Context(), limit, after, nsFilter)
-	if writeStoreFetchError(w, err) { return }
+	if writeStoreFetchError(w, err) {
+		return
+	}
 	cont := listContinue(limit, len(agents), "")
 	if len(agents) > 0 {
 		cont = listContinue(limit, len(agents), agents[len(agents)-1].Metadata.Name)
@@ -560,7 +569,9 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getAgent(w http.ResponseWriter, ctx context.Context, key, name string) {
 	agent, ok, err := s.stores.Agents.Get(ctx, key)
-	if writeStoreFetchError(w, err) { return }
+	if writeStoreFetchError(w, err) {
+		return
+	}
 	if !ok {
 		http.Error(w, fmt.Sprintf("agent %q not found", name), http.StatusNotFound)
 		return
@@ -580,7 +591,9 @@ func (s *Server) deleteAgent(w http.ResponseWriter, r *http.Request, key, name s
 
 func (s *Server) getAgentLogs(w http.ResponseWriter, ctx context.Context, key, name string) {
 	_, ok, err := s.stores.Agents.Get(ctx, key)
-	if writeStoreFetchError(w, err) { return }
+	if writeStoreFetchError(w, err) {
+		return
+	}
 	if !ok {
 		http.Error(w, fmt.Sprintf("agent %q not found", name), http.StatusNotFound)
 		return
@@ -599,7 +612,9 @@ func (s *Server) handleAgentSystems(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.AgentSystems.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -636,7 +651,9 @@ func (s *Server) handleAgentSystems(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.AgentSystems.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -672,7 +689,9 @@ func (s *Server) handleAgentSystemByName(w http.ResponseWriter, r *http.Request)
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.AgentSystems.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("agentsystem %q not found", name), http.StatusNotFound)
 			return
@@ -697,7 +716,9 @@ func (s *Server) handleAgentSystemByName(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		current, ok, err := s.stores.AgentSystems.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("agentsystem %q not found", name), http.StatusNotFound)
 			return
@@ -735,7 +756,9 @@ func (s *Server) handleModelEndpoints(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.ModelEPs.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -772,7 +795,9 @@ func (s *Server) handleModelEndpoints(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.ModelEPs.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -808,7 +833,9 @@ func (s *Server) handleModelEndpointByName(w http.ResponseWriter, r *http.Reques
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.ModelEPs.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("modelendpoint %q not found", name), http.StatusNotFound)
 			return
@@ -833,7 +860,9 @@ func (s *Server) handleModelEndpointByName(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		current, ok, err := s.stores.ModelEPs.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("modelendpoint %q not found", name), http.StatusNotFound)
 			return
@@ -871,7 +900,9 @@ func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.Tools.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -908,7 +939,9 @@ func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.Tools.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -944,7 +977,9 @@ func (s *Server) handleToolByName(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.Tools.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("tool %q not found", name), http.StatusNotFound)
 			return
@@ -969,7 +1004,9 @@ func (s *Server) handleToolByName(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		current, ok, err := s.stores.Tools.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("tool %q not found", name), http.StatusNotFound)
 			return
@@ -1007,7 +1044,9 @@ func (s *Server) handleSecrets(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.Secrets.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -1047,7 +1086,9 @@ func (s *Server) handleSecrets(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.Secrets.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -1076,7 +1117,9 @@ func (s *Server) handleSecretByName(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.Secrets.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("secret %q not found", name), http.StatusNotFound)
 			return
@@ -1102,7 +1145,9 @@ func (s *Server) handleSecretByName(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		current, ok, err := s.stores.Secrets.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("secret %q not found", name), http.StatusNotFound)
 			return
@@ -1158,7 +1203,9 @@ func (s *Server) handleMemories(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.Memories.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -1195,7 +1242,9 @@ func (s *Server) handleMemories(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.Memories.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -1240,7 +1289,9 @@ func (s *Server) handleMemoryByName(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.Memories.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("memory %q not found", name), http.StatusNotFound)
 			return
@@ -1265,7 +1316,9 @@ func (s *Server) handleMemoryByName(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		current, ok, err := s.stores.Memories.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("memory %q not found", name), http.StatusNotFound)
 			return
@@ -1299,7 +1352,9 @@ func (s *Server) handleMemoryEntries(w http.ResponseWriter, r *http.Request, nam
 	}
 	key := scopedNameForRequest(r, name)
 	_, ok, err := s.stores.Memories.Get(r.Context(), key)
-	if writeStoreFetchError(w, err) { return }
+	if writeStoreFetchError(w, err) {
+		return
+	}
 	if !ok {
 		http.Error(w, fmt.Sprintf("memory %q not found", name), http.StatusNotFound)
 		return
@@ -1357,7 +1412,9 @@ func (s *Server) handlePolicies(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.Policies.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -1394,7 +1451,9 @@ func (s *Server) handlePolicies(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.Policies.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -1430,7 +1489,9 @@ func (s *Server) handlePolicyByName(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.Policies.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("agentpolicy %q not found", name), http.StatusNotFound)
 			return
@@ -1455,7 +1516,9 @@ func (s *Server) handlePolicyByName(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		current, ok, err := s.stores.Policies.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("agentpolicy %q not found", name), http.StatusNotFound)
 			return
@@ -1493,7 +1556,9 @@ func (s *Server) handleAgentRoles(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.AgentRoles.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -1530,7 +1595,9 @@ func (s *Server) handleAgentRoles(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.AgentRoles.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -1557,7 +1624,9 @@ func (s *Server) handleAgentRoleByName(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.AgentRoles.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("agentrole %q not found", name), http.StatusNotFound)
 			return
@@ -1582,7 +1651,9 @@ func (s *Server) handleAgentRoleByName(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		current, ok, err := s.stores.AgentRoles.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("agentrole %q not found", name), http.StatusNotFound)
 			return
@@ -1620,7 +1691,9 @@ func (s *Server) handleToolPermissions(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.ToolPerms.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -1657,7 +1730,9 @@ func (s *Server) handleToolPermissions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.ToolPerms.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -1684,7 +1759,9 @@ func (s *Server) handleToolPermissionByName(w http.ResponseWriter, r *http.Reque
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.ToolPerms.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("toolpermission %q not found", name), http.StatusNotFound)
 			return
@@ -1709,7 +1786,9 @@ func (s *Server) handleToolPermissionByName(w http.ResponseWriter, r *http.Reque
 			return
 		}
 		current, ok, err := s.stores.ToolPerms.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("toolpermission %q not found", name), http.StatusNotFound)
 			return
@@ -1747,7 +1826,9 @@ func (s *Server) handleToolApprovals(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.ToolApprovals.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -1784,7 +1865,9 @@ func (s *Server) handleToolApprovals(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.ToolApprovals.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -1822,7 +1905,9 @@ func (s *Server) handleToolApprovalByName(w http.ResponseWriter, r *http.Request
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.ToolApprovals.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("toolapproval %q not found", name), http.StatusNotFound)
 			return
@@ -1862,7 +1947,9 @@ func (s *Server) handleToolApprovalDecision(w http.ResponseWriter, r *http.Reque
 	// requests could both pass the Pending guard and both commit.
 	for attempt := 0; attempt < 5; attempt++ {
 		obj, ok, err := s.stores.ToolApprovals.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("toolapproval %q not found", name), http.StatusNotFound)
 			return
@@ -1907,7 +1994,9 @@ func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
 		} else {
 			items, err = s.stores.Tasks.ListPaged(r.Context(), limit, offset, nsFilter)
 		}
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -1944,7 +2033,9 @@ func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.Tasks.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -2034,7 +2125,9 @@ func (s *Server) handleTaskByName(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.Tasks.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("task %q not found", name), http.StatusNotFound)
 			return
@@ -2059,7 +2152,9 @@ func (s *Server) handleTaskByName(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		current, ok, err := s.stores.Tasks.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("task %q not found", name), http.StatusNotFound)
 			return
@@ -2119,7 +2214,9 @@ func (s *Server) handleTaskSchedules(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.TaskSchedules.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -2156,7 +2253,9 @@ func (s *Server) handleTaskSchedules(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.TaskSchedules.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -2202,7 +2301,9 @@ func (s *Server) handleTaskScheduleByName(w http.ResponseWriter, r *http.Request
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.TaskSchedules.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("taskschedule %q not found", name), http.StatusNotFound)
 			return
@@ -2227,7 +2328,9 @@ func (s *Server) handleTaskScheduleByName(w http.ResponseWriter, r *http.Request
 			return
 		}
 		current, ok, err := s.stores.TaskSchedules.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("taskschedule %q not found", name), http.StatusNotFound)
 			return
@@ -2265,7 +2368,9 @@ func (s *Server) handleWorkers(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.Workers.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -2302,7 +2407,9 @@ func (s *Server) handleWorkers(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.Workers.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -2338,7 +2445,9 @@ func (s *Server) handleWorkerByName(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.Workers.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("worker %q not found", name), http.StatusNotFound)
 			return
@@ -2363,7 +2472,9 @@ func (s *Server) handleWorkerByName(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		current, ok, err := s.stores.Workers.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("worker %q not found", name), http.StatusNotFound)
 			return
@@ -2422,7 +2533,9 @@ func (s *Server) handleMcpServers(w http.ResponseWriter, r *http.Request) {
 			nsFilter = ns
 		}
 		items, err := s.stores.McpServers.ListCursor(r.Context(), limit, after, nsFilter)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		cont := listContinue(limit, len(items), "")
 		if len(items) > 0 {
 			cont = listContinue(limit, len(items), items[len(items)-1].Metadata.Name)
@@ -2459,7 +2572,9 @@ func (s *Server) handleMcpServers(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		existing, ok, err := s.stores.McpServers.Get(r.Context(), store.ScopedName(obj.Metadata.Namespace, obj.Metadata.Name))
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if ok {
 			obj.Status = existing.Status
 		}
@@ -2486,7 +2601,9 @@ func (s *Server) handleMcpServerByName(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		obj, ok, err := s.stores.McpServers.Get(r.Context(), key)
-		if writeStoreFetchError(w, err) { return }
+		if writeStoreFetchError(w, err) {
+			return
+		}
 		if !ok {
 			http.Error(w, fmt.Sprintf("mcp-server %q not found", name), http.StatusNotFound)
 			return

--- a/cli/agentctl.go
+++ b/cli/agentctl.go
@@ -28,6 +28,11 @@ func Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	args = cleanArgs
+	if len(args) > 0 && args[0] == "validate" {
+		return runValidate(args[1:])
+	}
+
 	cfg, err := loadOrlojctlConfig()
 	if err != nil {
 		return fmt.Errorf("orlojctl config: %w", err)
@@ -44,7 +49,6 @@ func Run(args []string) error {
 		token = tokenFromProfile(cfg)
 	}
 	configureDefaultHTTPClient(token)
-	args = cleanArgs
 
 	if len(args) == 1 {
 		switch args[0] {
@@ -146,7 +150,7 @@ func extractGlobalAPIToken(args []string) ([]string, string, error) {
 
 func runApply(args []string) error {
 	fs := flag.NewFlagSet("apply", flag.ContinueOnError)
-	manifestPath := fs.String("f", "", "path to resource manifest")
+	manifestPath := fs.String("f", "", "path to resource manifest file or directory")
 	server := fs.String("server", defaultServerResolved(resolvedCliConfig), "Agent API server URL")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -155,33 +159,63 @@ func runApply(args []string) error {
 		return errors.New("-f is required")
 	}
 
-	raw, err := os.ReadFile(*manifestPath)
-	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", *manifestPath, err)
-	}
-
-	kind, err := resources.DetectKind(raw)
+	files, err := manifestPaths(*manifestPath)
 	if err != nil {
 		return err
 	}
-
-	endpoint, payload, name, err := buildApplyRequest(kind, raw)
-	if err != nil {
-		return err
+	if len(files) == 0 {
+		return fmt.Errorf("no manifest files found in %s", *manifestPath)
 	}
 
-	resp, err := http.Post(*server+endpoint, "application/json", bytes.NewReader(payload))
-	if err != nil {
-		return fmt.Errorf("apply request failed: %w", err)
-	}
-	defer resp.Body.Close()
+	var applyErrs []string
+	applied := 0
+	for _, f := range files {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			applyErrs = append(applyErrs, fmt.Sprintf("%s: %v", f, err))
+			continue
+		}
 
-	if resp.StatusCode >= 300 {
+		kind, err := resources.DetectKind(raw)
+		if err != nil {
+			applyErrs = append(applyErrs, fmt.Sprintf("%s: %v", f, err))
+			continue
+		}
+
+		endpoint, payload, name, err := buildApplyRequest(kind, raw)
+		if err != nil {
+			applyErrs = append(applyErrs, fmt.Sprintf("%s: %v", f, err))
+			continue
+		}
+
+		resp, err := http.Post(*server+endpoint, "application/json", bytes.NewReader(payload))
+		if err != nil {
+			applyErrs = append(applyErrs, fmt.Sprintf("%s: apply request failed: %v", f, err))
+			continue
+		}
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("apply failed: %s", bytes.TrimSpace(body))
+		resp.Body.Close()
+
+		if resp.StatusCode >= 300 {
+			applyErrs = append(applyErrs, fmt.Sprintf("%s: %s", f, bytes.TrimSpace(body)))
+			continue
+		}
+
+		fmt.Printf("applied %s/%s\n", strings.ToLower(kind), name)
+		applied++
 	}
 
-	fmt.Printf("applied %s/%s\n", strings.ToLower(kind), name)
+	if len(applyErrs) > 0 {
+		fmt.Printf("\n%d applied, %d failed:\n", applied, len(applyErrs))
+		for _, e := range applyErrs {
+			fmt.Printf("  error  %s\n", e)
+		}
+		return fmt.Errorf("apply failed for %d file(s)", len(applyErrs))
+	}
+
+	if applied > 1 {
+		fmt.Printf("\n%d file(s) applied\n", applied)
+	}
 	return nil
 }
 
@@ -301,109 +335,39 @@ func runCreateSecret(args []string) error {
 	return nil
 }
 
+// applyEndpoints maps normalized manifest kinds (see resources.ParseManifest) to POST paths.
+var applyEndpoints = map[string]string{
+	"agent":          "/v1/agents",
+	"agentsystem":    "/v1/agent-systems",
+	"modelendpoint":  "/v1/model-endpoints",
+	"tool":           "/v1/tools",
+	"secret":         "/v1/secrets",
+	"memory":         "/v1/memories",
+	"agentpolicy":    "/v1/agent-policies",
+	"agentrole":      "/v1/agent-roles",
+	"toolpermission": "/v1/tool-permissions",
+	"toolapproval":   "/v1/tool-approvals",
+	"task":           "/v1/tasks",
+	"taskschedule":   "/v1/task-schedules",
+	"taskwebhook":    "/v1/task-webhooks",
+	"worker":         "/v1/workers",
+	"mcpserver":      "/v1/mcp-servers",
+}
+
 func buildApplyRequest(kind string, raw []byte) (string, []byte, string, error) {
-	switch strings.ToLower(strings.TrimSpace(kind)) {
-	case "agent":
-		obj, err := resources.ParseAgentManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/agents", payload, obj.Metadata.Name, err
-	case "agentsystem":
-		obj, err := resources.ParseAgentSystemManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/agent-systems", payload, obj.Metadata.Name, err
-	case "modelendpoint":
-		obj, err := resources.ParseModelEndpointManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/model-endpoints", payload, obj.Metadata.Name, err
-	case "tool":
-		obj, err := resources.ParseToolManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/tools", payload, obj.Metadata.Name, err
-	case "secret":
-		obj, err := resources.ParseSecretManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/secrets", payload, obj.Metadata.Name, err
-	case "memory":
-		obj, err := resources.ParseMemoryManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/memories", payload, obj.Metadata.Name, err
-	case "agentpolicy":
-		obj, err := resources.ParseAgentPolicyManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/agent-policies", payload, obj.Metadata.Name, err
-	case "agentrole":
-		obj, err := resources.ParseAgentRoleManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/agent-roles", payload, obj.Metadata.Name, err
-	case "toolpermission":
-		obj, err := resources.ParseToolPermissionManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/tool-permissions", payload, obj.Metadata.Name, err
-	case "task":
-		obj, err := resources.ParseTaskManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/tasks", payload, obj.Metadata.Name, err
-	case "taskschedule":
-		obj, err := resources.ParseTaskScheduleManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/task-schedules", payload, obj.Metadata.Name, err
-	case "taskwebhook":
-		obj, err := resources.ParseTaskWebhookManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/task-webhooks", payload, obj.Metadata.Name, err
-	case "worker":
-		obj, err := resources.ParseWorkerManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/workers", payload, obj.Metadata.Name, err
-	case "mcpserver":
-		obj, err := resources.ParseMcpServerManifest(raw)
-		if err != nil {
-			return "", nil, "", err
-		}
-		payload, err := json.Marshal(obj)
-		return "/v1/mcp-servers", payload, obj.Metadata.Name, err
-	default:
-		return "", nil, "", fmt.Errorf("unsupported kind %q", kind)
+	normKind, name, obj, err := resources.ParseManifest(kind, raw)
+	if err != nil {
+		return "", nil, "", err
 	}
+	endpoint, ok := applyEndpoints[normKind]
+	if !ok {
+		return "", nil, "", fmt.Errorf("unsupported kind %q", normKind)
+	}
+	payload, err := json.Marshal(obj)
+	if err != nil {
+		return "", nil, "", err
+	}
+	return endpoint, payload, name, nil
 }
 
 func runGet(args []string) error {
@@ -1461,12 +1425,13 @@ func printUsage() {
 	fmt.Print(`orlojctl - Orloj CLI
 
 Usage:
-  orlojctl apply -f <resource.yaml>
+  orlojctl apply -f <file-or-directory>
+  orlojctl validate -f <file|dir>
   orlojctl create secret <name> --from-literal key=value [--from-literal key2=value2 ...]
   orlojctl get [-w] agents|agent-systems|model-endpoints|tools|secrets|memories|agent-policies|agent-roles|tool-permissions|tasks|task-schedules|task-webhooks|workers
   orlojctl delete <resource> <name>
   orlojctl run --system <name> [key=value ...]
-  orlojctl init --blueprint pipeline|hierarchical|swarm-loop [--name <prefix>] [--dir <path>]
+  orlojctl init <name> [--blueprint pipeline|hierarchical|swarm-loop]
   orlojctl logs <agent-name>|task/<task-name>
   orlojctl trace task <task-name>
   orlojctl graph system|task <name>

--- a/cli/init.go
+++ b/cli/init.go
@@ -11,38 +11,36 @@ import (
 
 func runInit(args []string) error {
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
-	blueprint := fs.String("blueprint", "", "blueprint to scaffold: pipeline, hierarchical, swarm-loop")
-	name := fs.String("name", "", "resource name prefix (defaults to blueprint name)")
-	dir := fs.String("dir", ".", "output directory")
+	blueprint := fs.String("blueprint", "pipeline", "blueprint to scaffold: pipeline, hierarchical, swarm-loop")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *blueprint == "" {
-		return errors.New("--blueprint is required (pipeline, hierarchical, swarm-loop)")
+
+	if fs.NArg() == 0 {
+		return errors.New("usage: orlojctl init <name> [--blueprint pipeline|hierarchical|swarm-loop]")
+	}
+	name := strings.TrimSpace(fs.Arg(0))
+	if name == "" {
+		return errors.New("name cannot be empty")
 	}
 
 	bp := strings.ToLower(strings.TrimSpace(*blueprint))
-	prefix := strings.TrimSpace(*name)
-	if prefix == "" {
-		prefix = bp
-	}
-
 	var files map[string]string
 	switch bp {
 	case "pipeline":
-		files = pipelineBlueprint(prefix)
+		files = pipelineBlueprint(name)
 	case "hierarchical":
-		files = hierarchicalBlueprint(prefix)
+		files = hierarchicalBlueprint(name)
 	case "swarm-loop":
-		files = swarmLoopBlueprint(prefix)
+		files = swarmLoopBlueprint(name)
 	default:
 		return fmt.Errorf("unknown blueprint %q (expected: pipeline, hierarchical, swarm-loop)", bp)
 	}
 
-	outDir := *dir
+	outDir := name
 	agentsDir := filepath.Join(outDir, "agents")
 	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
-		return fmt.Errorf("create agents directory: %w", err)
+		return fmt.Errorf("create directory %s: %w", outDir, err)
 	}
 
 	for path, content := range files {
@@ -50,10 +48,10 @@ func runInit(args []string) error {
 		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
 			return fmt.Errorf("write %s: %w", path, err)
 		}
-		fmt.Printf("  created %s\n", path)
+		fmt.Printf("  created %s/%s\n", outDir, path)
 	}
 
-	fmt.Printf("\nScaffolded %s blueprint with prefix %q in %s\n", bp, prefix, outDir)
+	fmt.Printf("\nScaffolded %s blueprint %q in %s/\n", bp, name, outDir)
 	fmt.Printf("\nTo apply:\n  orlojctl apply -f %s\n", outDir)
 	return nil
 }

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/OrlojHQ/orloj/resources"
+)
+
+func runValidate(args []string) error {
+	fsFlags := flag.NewFlagSet("validate", flag.ContinueOnError)
+	manifestPath := fsFlags.String("f", "", "path to manifest file or directory")
+	if err := fsFlags.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*manifestPath) == "" {
+		return errors.New("-f is required: path to manifest file or directory")
+	}
+
+	files, err := manifestPaths(*manifestPath)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("no manifest files found in %s", *manifestPath)
+	}
+
+	var errs []string
+	valid := 0
+	for _, f := range files {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
+		}
+
+		kind, err := resources.DetectKind(raw)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
+		}
+
+		normKind, name, _, err := resources.ParseManifest(kind, raw)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", f, err))
+			continue
+		}
+
+		fmt.Printf("  valid  %s/%s  (%s)\n", normKind, name, f)
+		valid++
+	}
+
+	if len(errs) > 0 {
+		fmt.Printf("\n%d valid, %d invalid:\n", valid, len(errs))
+		for _, e := range errs {
+			fmt.Printf("  error  %s\n", e)
+		}
+		return fmt.Errorf("validation failed for %d file(s)", len(errs))
+	}
+
+	fmt.Printf("\n%d file(s) valid\n", valid)
+	return nil
+}
+
+func manifestPaths(path string) ([]string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot access %s: %w", path, err)
+	}
+
+	if !info.IsDir() {
+		return []string{path}, nil
+	}
+
+	var out []string
+	err = filepath.WalkDir(path, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		switch strings.ToLower(filepath.Ext(p)) {
+		case ".yaml", ".yml", ".json":
+			out = append(out, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk %s: %w", path, err)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/cli/validate_test.go
+++ b/cli/validate_test.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const minimalAgentYAML = `apiVersion: orloj.dev/v1
+kind: Agent
+metadata:
+  name: test-agent
+spec:
+  model_ref: openai-default
+  prompt: hello
+`
+
+func TestRunValidate_SkipsConfigLoad(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir := t.TempDir()
+	f := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(f, []byte(minimalAgentYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Run([]string{"validate", "-f", f}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunValidate_MissingFlag(t *testing.T) {
+	err := Run([]string{"validate"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "-f is required") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestRunValidate_NonexistentPath(t *testing.T) {
+	err := Run([]string{"validate", "-f", filepath.Join(t.TempDir(), "nope.yaml")})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cannot access") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestRunValidate_EmptyDirectory(t *testing.T) {
+	err := Run([]string{"validate", "-f", t.TempDir()})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no manifest files found") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestRunValidate_ValidFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	f := filepath.Join(t.TempDir(), "a.yaml")
+	if err := os.WriteFile(f, []byte(minimalAgentYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Run([]string{"validate", "-f", f}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunValidate_InvalidYAML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	f := filepath.Join(t.TempDir(), "bad.yaml")
+	if err := os.WriteFile(f, []byte("{not yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := Run([]string{"validate", "-f", f})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestRunValidate_MissingMetadataName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	raw := `apiVersion: orloj.dev/v1
+kind: Agent
+metadata:
+  namespace: default
+spec:
+  prompt: x
+`
+	f := filepath.Join(t.TempDir(), "noname.yaml")
+	if err := os.WriteFile(f, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := Run([]string{"validate", "-f", f})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestRunValidate_UnrecognizedKind(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	raw := `apiVersion: orloj.dev/v1
+kind: NotAnOrlojKind
+metadata:
+  name: x
+spec: {}
+`
+	f := filepath.Join(t.TempDir(), "unknown.yaml")
+	if err := os.WriteFile(f, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := Run([]string{"validate", "-f", f})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Fatalf("got %v", err)
+	}
+	// Per-file detail (unsupported kind) is printed to stdout; see resources.TestParseManifest_UnsupportedKind.
+}
+
+func TestRunValidate_NestedDirectory(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	sub := filepath.Join(root, "nested")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "inner.yaml"), []byte(minimalAgentYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Run([]string{"validate", "-f", root}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunValidate_MixedValidInvalid(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "good.yaml"), []byte(minimalAgentYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "bad.yaml"), []byte("kind: Agent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := Run([]string{"validate", "-f", root})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestManifestPaths_SingleFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "one.yaml")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	paths, err := manifestPaths(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 1 || paths[0] != f {
+		t.Fatalf("got %v", paths)
+	}
+}

--- a/docs/pages/getting-started/quickstart.md
+++ b/docs/pages/getting-started/quickstart.md
@@ -2,6 +2,8 @@
 
 Get a multi-agent pipeline running in under five minutes. This quickstart uses sequential execution mode -- the simplest way to run Orloj with a single process and no external dependencies.
 
+> **Using Homebrew or release binaries?** Use the guided [5-minute tutorial](../guides/five-minute-tutorial.md) instead: it covers `orlojctl init`, a real OpenAI secret (`value=…`), and `orlojctl run` against `demo-system`. This page is aimed at **from-source** development with `go run` and the checked-in `examples/` blueprints.
+
 ## Before You Begin
 
 - Go `1.24+` is installed.

--- a/docs/pages/guides/five-minute-tutorial.md
+++ b/docs/pages/guides/five-minute-tutorial.md
@@ -1,0 +1,102 @@
+# Your First Agent System in 5 Minutes
+
+This tutorial walks you through a three-agent **pipeline**: planner → research → writer. You will go from an empty directory to a running task with real model calls, using the web console to watch progress.
+
+If you prefer to work from the repository’s checked-in examples instead of scaffolding, see [Quickstart](../getting-started/quickstart.md).
+
+## Prerequisites
+
+- **orlojctl** installed — [Homebrew](../getting-started/install.md#homebrew-macos--linux) (`brew tap OrlojHQ/orloj && brew install orlojctl`) or the [install script](../getting-started/install.md#install-script-all-binaries)
+- **orlojd** — same install script, [release binaries](https://github.com/OrlojHQ/orloj/releases), or `go run ./cmd/orlojd` from a clone
+- An **OpenAI API key** (or change the scaffolded `model-endpoint.yaml` to another [supported provider](../guides/configure-model-routing.md))
+
+## 1. Start the server
+
+In one terminal, run the API server with an embedded worker and in-memory storage (no database required):
+
+```bash
+orlojd --storage-backend=memory --embedded-worker
+```
+
+The default task execution mode is **sequential**, which is ideal for this walkthrough.
+
+Open the web console at [http://127.0.0.1:8080/](http://127.0.0.1:8080/) — you should see the dashboard.
+
+## 2. Scaffold a pipeline
+
+In another terminal, scaffold the manifests:
+
+```bash
+orlojctl init demo
+```
+
+This creates a `demo/` directory containing:
+
+- `agents/planner_agent.yaml`, `agents/research_agent.yaml`, `agents/writer_agent.yaml`
+- `agent-system.yaml` — graph wiring the three agents in order
+- `model-endpoint.yaml` — OpenAI endpoint named `openai-default` referencing a secret
+- `task.yaml` — a sample task (you will use `orlojctl run` instead in the next steps)
+
+The **AgentSystem** resource is named **`demo-system`** (prefix `demo` plus `-system`). You will pass that name to `orlojctl run`.
+
+## 3. Add your API key
+
+The scaffold expects a Secret named **`openai-api-key`** with the default key **`value`** (this is what the model gateway reads):
+
+```bash
+orlojctl create secret openai-api-key --from-literal value=sk-your-key-here
+```
+
+You do not need to edit `model-endpoint.yaml` unless you want a different secret name or provider. See [Configure Model Routing](./configure-model-routing.md) for Anthropic, Azure OpenAI, Ollama, and more.
+
+## 4. Apply manifests
+
+Apply every manifest in the scaffolded directory at once:
+
+```bash
+orlojctl apply -f demo/
+```
+
+Or apply resources individually:
+
+```bash
+orlojctl apply -f demo/agents/
+orlojctl apply -f demo/model-endpoint.yaml
+orlojctl apply -f demo/agent-system.yaml
+```
+
+The first form also applies `task.yaml`, which creates a sample **Task** named `demo-task`. You can leave it, delete it from the UI, or ignore it — `orlojctl run` in the next step still creates a **new** task with your topic.
+
+## 5. Run the pipeline
+
+Submit a task with input for the agents (the scaffold uses a `topic` field):
+
+```bash
+orlojctl run --system demo-system topic="The future of open source AI"
+```
+
+The CLI prints a line like `task run-demo-system-… created, watching…`, waits until the task finishes, and prints the final **output** on success.
+
+## 6. Watch execution
+
+- **Web console:** Open the task from the UI to see topology, status, and streaming detail.
+- **Logs snapshot:** After `run` reports the task name, fetch stored log lines (no live follow flag):
+
+```bash
+orlojctl logs task/<task-name>
+```
+
+Use the exact task name printed when the task was created (for example `run-demo-system-1730000000000`).
+
+## What just happened?
+
+Orloj stored your **Agent**, **AgentSystem**, **ModelEndpoint**, and **Secret** resources, then created a **Task** that references `demo-system`. The embedded worker **claimed** the task, executed the graph in order (planner, then research, then writer), routed each step through the **model gateway** using `openai-default`, and recorded status and output.
+
+Handoffs between agents follow the **execution and messaging** rules for your mode (here, sequential). For a deeper picture of components and scaling, read [Architecture](../concepts/architecture.md) and [Execution & Messaging](../concepts/execution-model.md).
+
+## Next steps
+
+- [Build a Custom Tool](./build-custom-tool.md) — give agents callable tools
+- [Set Up Multi-Agent Governance](./setup-governance.md) — policies, roles, and tool permissions
+- [Deploy to a VPS](../deploy/vps.md) — Postgres, TLS, and production-like operation
+- [Starter Blueprints](./starter-blueprints.md) — try `orlojctl init myproject --blueprint hierarchical` or `--blueprint swarm-loop`

--- a/docs/pages/guides/index.md
+++ b/docs/pages/guides/index.md
@@ -1,12 +1,17 @@
 # Guides
 
-Step-by-step tutorials for common Orloj workflows. Each guide walks through a complete use case from start to finish, using real manifests from the `examples/` directory.
+Step-by-step tutorials for common Orloj workflows.
 
-For **ready-made scenario folders** (full YAML sets you can copy into your environment), see [examples/use-cases/](https://github.com/OrlojHQ/orloj/tree/main/examples/use-cases).
+**Start here:** **[Your First Agent System in 5 Minutes](./five-minute-tutorial.md)** — install `orlojctl` and `orlojd`, scaffold a pipeline with `orlojctl init`, add an API key, apply manifests, and run a task end-to-end with the web console.
 
-If you have not installed Orloj yet, start with the [Install](../getting-started/install.md) and [Quickstart](../getting-started/quickstart.md) pages first.
+Other guides use real manifests from the `examples/` directory or walk through authoring resources by hand. For **ready-made scenario folders** (full YAML sets you can copy into your environment), see [examples/use-cases/](https://github.com/OrlojHQ/orloj/tree/main/examples/use-cases).
+
+If you have not installed Orloj yet, begin with [Install](../getting-started/install.md). Developers building from a clone may prefer the [Quickstart](../getting-started/quickstart.md) (`go run` + checked-in blueprints).
 
 ## Available Guides
+
+**[Your First Agent System in 5 Minutes](./five-minute-tutorial.md)**
+*The fastest path from zero to a running multi-agent pipeline with a real model.*
 
 **[Deploy Your First Pipeline](./deploy-pipeline.md)**
 *For platform engineers who want to run a multi-agent pipeline end-to-end.*

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -44,7 +44,11 @@ You interact with Orloj through `orlojctl` (the CLI), the REST API, or the built
 
 ## Get Started
 
+**[Get started in 5 minutes](./guides/five-minute-tutorial.md)** — scaffold a pipeline, configure a model endpoint, and run your first task (binaries or install script).
+
+Then:
+
 1. [Install Orloj](./getting-started/install.md) -- run from source, build binaries, or use Docker Compose.
-2. [Quickstart](./getting-started/quickstart.md) -- deploy a multi-agent pipeline in under five minutes.
+2. [Quickstart](./getting-started/quickstart.md) -- from-source `go run` with the checked-in pipeline blueprint.
 3. [Explore Concepts](./concepts/agents/agent.md) -- understand agents, tasks, tools, governance, and the execution model.
 4. [Follow a Guide](./guides/) -- step-by-step tutorials for common workflows.

--- a/docs/pages/reference/cli.md
+++ b/docs/pages/reference/cli.md
@@ -15,12 +15,13 @@ This page is the canonical reference for CLI flags across all Orloj binaries.
 Usage patterns:
 
 ```text
-orlojctl apply -f <resource.yaml>
+orlojctl apply -f <file-or-directory>
+orlojctl validate -f <file|dir>
 orlojctl create secret <name> --from-literal key=value [...]
 orlojctl get [-w] <resource>
 orlojctl delete <resource> <name>
 orlojctl run --system <name> [key=value ...]
-orlojctl init --blueprint pipeline|hierarchical|swarm-loop [--name <prefix>] [--dir <path>]
+orlojctl init <name> [--blueprint pipeline|hierarchical|swarm-loop]
 orlojctl logs <agent-name>|task/<task-name>
 orlojctl trace task <task-name>
 orlojctl graph system|task <name>
@@ -48,8 +49,30 @@ orlojctl config path|get|use <name>|set-profile <name> [--server URL] [--token v
 
 | Flag | Default | Description |
 |---|---|---|
-| `-f` | none | Path to resource manifest (required). |
+| `-f` | none | Path to a manifest file or directory (required). |
 | `--server` | resolved server | API server URL. |
+
+- **File:** applies that manifest.
+- **Directory:** walks recursively (skips `.git` dirs) and applies every `.yaml`, `.yml`, and `.json` file in sorted path order. Failures are collected; the command exits with an error if any file failed.
+
+### `orlojctl validate`
+
+Parse and normalize manifests **offline** (no API server, no `orlojctl` config file required). Use in CI or before `apply` to catch schema and normalization errors early.
+
+| Flag | Default | Description |
+|---|---|---|
+| `-f` | none | Path to a manifest file or a directory (required). |
+
+- **File:** validates that one manifest.
+- **Directory:** walks recursively (skips `.git` dirs) and validates every `.yaml`, `.yml`, and `.json` file.
+- **Exit code:** `0` if every file is valid; `1` if any file fails. Failed files are listed with path and error on stdout.
+
+Examples:
+
+```bash
+orlojctl validate -f agent.yaml
+orlojctl validate -f ./manifests/
+```
 
 ### `orlojctl create secret`
 
@@ -163,11 +186,11 @@ Other config subcommands:
 
 ### `orlojctl init`
 
+Positional argument `<name>` is required. It sets both the output directory and the resource name prefix.
+
 | Flag | Default | Description |
 |---|---|---|
-| `--blueprint` | none | Required blueprint: `pipeline`, `hierarchical`, `swarm-loop`. |
-| `--name` | blueprint name | Prefix for generated resource names. |
-| `--dir` | `.` | Output directory. |
+| `--blueprint` | `pipeline` | Blueprint topology: `pipeline`, `hierarchical`, `swarm-loop`. |
 
 ## `orlojd`
 

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -106,6 +106,10 @@ export default defineConfig({
     {
       text: "Guides",
       items: [
+        {
+          text: "5-Minute Tutorial",
+          link: "/guides/five-minute-tutorial",
+        },
         { text: "Overview", link: "/guides/" },
         {
           text: "Deploy Your First Pipeline",

--- a/openapi/build_openapi.py
+++ b/openapi/build_openapi.py
@@ -1,0 +1,1008 @@
+#!/usr/bin/env python3
+"""Regenerate openapi/openapi.yaml from structured path definitions."""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+
+
+def schema_ref(path: str) -> dict:
+    return {"$ref": path}
+
+
+def json_body(ref_path: str) -> dict:
+    return {"application/json": {"schema": schema_ref(ref_path)}}
+
+
+def text_plain_error() -> dict:
+    return {
+        "text/plain": {
+            "schema": schema_ref("./schemas/common.yaml#/components/schemas/PlainTextError")
+        }
+    }
+
+
+SEC_READER = [{"bearerAuth": []}, {"sessionCookie": []}]
+SEC_WRITER = [{"bearerAuth": []}, {"sessionCookie": []}]
+SEC_ADMIN = [{"bearerAuth": []}, {"sessionCookie": []}]
+SEC_CTRL = [{"bearerAuth": []}, {"sessionCookie": []}]
+
+
+def list_op(tag: str, list_ref: str) -> dict:
+    return {
+        "tags": [tag],
+        "parameters": [
+            {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+            {
+                "name": "limit",
+                "in": "query",
+                "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
+            },
+            {"name": "after", "in": "query", "schema": {"type": "string"}},
+            {"name": "labelSelector", "in": "query", "schema": {"type": "string"}},
+        ],
+        "security": SEC_READER,
+        "responses": {
+            "200": {"description": "OK", "content": json_body(list_ref)},
+            "503": {"description": "Store unavailable", "content": text_plain_error()},
+            "default": {"description": "Error", "content": text_plain_error()},
+        },
+    }
+
+
+def list_tasks(tag: str, list_ref: str) -> dict:
+    op = list_op(tag, list_ref)
+    op["parameters"].insert(
+        3,
+        {"name": "offset", "in": "query", "schema": {"type": "integer", "minimum": 0}},
+    )
+    return op
+
+
+def post_create(tag: str, item_ref: str) -> dict:
+    return {
+        "tags": [tag],
+        "security": SEC_WRITER,
+        "requestBody": {"required": True, "content": json_body(item_ref)},
+        "responses": {
+            "201": {"description": "Created", "content": json_body(item_ref)},
+            "400": {"description": "Bad request", "content": text_plain_error()},
+            "503": {"description": "Store unavailable", "content": text_plain_error()},
+            "default": {"description": "Error", "content": text_plain_error()},
+        },
+    }
+
+
+def get_one(tag: str, item_ref: str) -> dict:
+    return {
+        "tags": [tag],
+        "parameters": [
+            {"name": "name", "in": "path", "required": True, "schema": {"type": "string"}},
+            {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+        ],
+        "security": SEC_READER,
+        "responses": {
+            "200": {"description": "OK", "content": json_body(item_ref)},
+            "404": {"description": "Not found", "content": text_plain_error()},
+            "503": {"description": "Store unavailable", "content": text_plain_error()},
+            "default": {"description": "Error", "content": text_plain_error()},
+        },
+    }
+
+
+def put_one(tag: str, item_ref: str) -> dict:
+    return {
+        "tags": [tag],
+        "parameters": [
+            {"name": "name", "in": "path", "required": True, "schema": {"type": "string"}},
+            {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+            {
+                "name": "If-Match",
+                "in": "header",
+                "required": False,
+                "schema": {"type": "string"},
+            },
+        ],
+        "security": SEC_WRITER,
+        "requestBody": {"required": True, "content": json_body(item_ref)},
+        "responses": {
+            "200": {"description": "OK", "content": json_body(item_ref)},
+            "400": {"description": "Bad request", "content": text_plain_error()},
+            "404": {"description": "Not found", "content": text_plain_error()},
+            "409": {"description": "Conflict", "content": text_plain_error()},
+            "503": {"description": "Store unavailable", "content": text_plain_error()},
+            "default": {"description": "Error", "content": text_plain_error()},
+        },
+    }
+
+
+def delete_one(tag: str) -> dict:
+    return {
+        "tags": [tag],
+        "parameters": [
+            {"name": "name", "in": "path", "required": True, "schema": {"type": "string"}},
+            {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+        ],
+        "security": SEC_WRITER,
+        "responses": {
+            "204": {"description": "Deleted"},
+            "404": {"description": "Not found", "content": text_plain_error()},
+            "503": {"description": "Store unavailable", "content": text_plain_error()},
+            "default": {"description": "Error", "content": text_plain_error()},
+        },
+    }
+
+
+def status_get_put(tag: str) -> tuple[dict, dict]:
+    base_params = [
+        {"name": "name", "in": "path", "required": True, "schema": {"type": "string"}},
+        {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+    ]
+    env = "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+    get_op = {
+        "tags": [tag],
+        "parameters": base_params,
+        "security": SEC_READER,
+        "responses": {
+            "200": {"description": "OK", "content": json_body(env)},
+            "404": {"description": "Not found", "content": text_plain_error()},
+            "503": {"description": "Store unavailable", "content": text_plain_error()},
+            "default": {"description": "Error", "content": text_plain_error()},
+        },
+    }
+    put_op = {
+        "tags": [tag],
+        "parameters": base_params
+        + [
+            {
+                "name": "If-Match",
+                "in": "header",
+                "required": False,
+                "schema": {"type": "string"},
+            }
+        ],
+        "security": SEC_CTRL,
+        "requestBody": {"required": True, "content": json_body(env)},
+        "responses": {
+            "200": {"description": "OK", "content": json_body(env)},
+            "400": {"description": "Bad request", "content": text_plain_error()},
+            "404": {"description": "Not found", "content": text_plain_error()},
+            "409": {"description": "Conflict", "content": text_plain_error()},
+            "503": {"description": "Store unavailable", "content": text_plain_error()},
+            "default": {"description": "Error", "content": text_plain_error()},
+        },
+    }
+    return get_op, put_op
+
+
+def sse_response(desc: str) -> dict:
+    return {
+        "200": {
+            "description": desc,
+            "content": {"text/event-stream": {"schema": {"type": "string"}}},
+        },
+        "default": {"description": "Error", "content": text_plain_error()},
+    }
+
+
+def watch_params() -> list:
+    return [
+        {"name": "resourceVersion", "in": "query", "schema": {"type": "string"}},
+        {"name": "name", "in": "query", "schema": {"type": "string"}},
+        {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+    ]
+
+
+def add_crud(
+    paths: dict,
+    base: str,
+    tag: str,
+    list_ref: str,
+    item_ref: str,
+    *,
+    with_status: bool = False,
+) -> None:
+    paths[base] = {"get": list_op(tag, list_ref), "post": post_create(tag, item_ref)}
+    if with_status:
+        g, p = status_get_put(tag)
+        paths[f"{base}/{{name}}/status"] = {"get": g, "put": p}
+    paths[f"{base}/{{name}}"] = {
+        "get": get_one(tag, item_ref),
+        "put": put_one(tag, item_ref),
+        "delete": delete_one(tag),
+    }
+
+
+def build() -> dict:
+    paths: dict = {}
+
+    paths["/v1/agents"] = {
+        "get": list_op("agents", "./schemas/agent.yaml#/components/schemas/AgentList"),
+        "post": post_create("agents", "./schemas/agent.yaml#/components/schemas/Agent"),
+    }
+    paths["/v1/agents/watch"] = {
+        "get": {
+            "tags": ["agents"],
+            "security": SEC_READER,
+            "parameters": watch_params(),
+            "responses": sse_response(
+                "SSE; `event: resource` with WatchResourceEvent JSON in data"
+            ),
+        }
+    }
+    g, p = status_get_put("agents")
+    paths["/v1/agents/{name}/status"] = {"get": g, "put": p}
+    paths["/v1/agents/{name}/logs"] = {
+        "get": {
+            "tags": ["agents"],
+            "security": SEC_READER,
+            "parameters": [
+                {
+                    "name": "name",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                },
+                {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+            ],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/NamedLogsResponse"
+                    ),
+                },
+                "404": {"description": "Not found", "content": text_plain_error()},
+                "503": {"description": "Store unavailable", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/agents/{name}"] = {
+        "get": get_one("agents", "./schemas/agent.yaml#/components/schemas/Agent"),
+        "put": put_one("agents", "./schemas/agent.yaml#/components/schemas/Agent"),
+        "delete": delete_one("agents"),
+    }
+
+    add_crud(
+        paths,
+        "/v1/agent-systems",
+        "agent-systems",
+        "./schemas/agent-system.yaml#/components/schemas/AgentSystemList",
+        "./schemas/agent-system.yaml#/components/schemas/AgentSystem",
+        with_status=True,
+    )
+    add_crud(
+        paths,
+        "/v1/model-endpoints",
+        "model-endpoints",
+        "./schemas/model-endpoint.yaml#/components/schemas/ModelEndpointList",
+        "./schemas/model-endpoint.yaml#/components/schemas/ModelEndpoint",
+        with_status=True,
+    )
+    add_crud(
+        paths,
+        "/v1/tools",
+        "tools",
+        "./schemas/tool.yaml#/components/schemas/ToolList",
+        "./schemas/tool.yaml#/components/schemas/Tool",
+        with_status=True,
+    )
+    add_crud(
+        paths,
+        "/v1/secrets",
+        "secrets",
+        "./schemas/secret.yaml#/components/schemas/SecretList",
+        "./schemas/secret.yaml#/components/schemas/Secret",
+        with_status=False,
+    )
+    add_crud(
+        paths,
+        "/v1/memories",
+        "memories",
+        "./schemas/memory.yaml#/components/schemas/MemoryList",
+        "./schemas/memory.yaml#/components/schemas/Memory",
+        with_status=True,
+    )
+
+    paths["/v1/memories/{name}/entries"] = {
+        "get": {
+            "tags": ["memories"],
+            "security": SEC_READER,
+            "parameters": [
+                {
+                    "name": "name",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                },
+                {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+                {"name": "q", "in": "query", "schema": {"type": "string"}},
+                {"name": "prefix", "in": "query", "schema": {"type": "string"}},
+                {"name": "limit", "in": "query", "schema": {"type": "integer"}},
+            ],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/MemoryEntriesResponse"
+                    ),
+                },
+                "404": {"description": "Not found", "content": text_plain_error()},
+                "500": {"description": "Backend error", "content": text_plain_error()},
+                "503": {"description": "Store unavailable", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+
+    add_crud(
+        paths,
+        "/v1/agent-policies",
+        "agent-policies",
+        "./schemas/agent-policy.yaml#/components/schemas/AgentPolicyList",
+        "./schemas/agent-policy.yaml#/components/schemas/AgentPolicy",
+        with_status=True,
+    )
+    add_crud(
+        paths,
+        "/v1/agent-roles",
+        "agent-roles",
+        "./schemas/agent-role.yaml#/components/schemas/AgentRoleList",
+        "./schemas/agent-role.yaml#/components/schemas/AgentRole",
+        with_status=False,
+    )
+    add_crud(
+        paths,
+        "/v1/tool-permissions",
+        "tool-permissions",
+        "./schemas/tool-permission.yaml#/components/schemas/ToolPermissionList",
+        "./schemas/tool-permission.yaml#/components/schemas/ToolPermission",
+        with_status=False,
+    )
+
+    paths["/v1/tool-approvals"] = {
+        "get": list_op(
+            "tool-approvals",
+            "./schemas/tool-approval.yaml#/components/schemas/ToolApprovalList",
+        ),
+        "post": post_create(
+            "tool-approvals",
+            "./schemas/tool-approval.yaml#/components/schemas/ToolApproval",
+        ),
+    }
+    paths["/v1/tool-approvals/{name}"] = {
+        "get": get_one(
+            "tool-approvals",
+            "./schemas/tool-approval.yaml#/components/schemas/ToolApproval",
+        ),
+        "delete": delete_one("tool-approvals"),
+        "put": {
+            "tags": ["tool-approvals"],
+            "summary": "Not supported",
+            "parameters": [
+                {"name": "name", "in": "path", "required": True, "schema": {"type": "string"}}
+            ],
+            "security": SEC_WRITER,
+            "responses": {
+                "405": {
+                    "description": "Method not allowed",
+                    "content": text_plain_error(),
+                },
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        },
+    }
+    for suf, title in [
+        ("approve", "Approve pending tool invocation"),
+        ("deny", "Deny pending tool invocation"),
+    ]:
+        paths[f"/v1/tool-approvals/{{name}}/{suf}"] = {
+            "post": {
+                "tags": ["tool-approvals"],
+                "summary": title,
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    },
+                    {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+                ],
+                "security": SEC_WRITER,
+                "requestBody": {
+                    "required": False,
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/ToolApprovalDecisionRequest"
+                    ),
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": json_body(
+                            "./schemas/tool-approval.yaml#/components/schemas/ToolApproval"
+                        ),
+                    },
+                    "404": {"description": "Not found", "content": text_plain_error()},
+                    "409": {"description": "Conflict", "content": text_plain_error()},
+                    "503": {
+                        "description": "Store unavailable",
+                        "content": text_plain_error(),
+                    },
+                    "default": {"description": "Error", "content": text_plain_error()},
+                },
+            }
+        }
+
+    paths["/v1/tasks"] = {
+        "get": list_tasks("tasks", "./schemas/task.yaml#/components/schemas/TaskList"),
+        "post": post_create("tasks", "./schemas/task.yaml#/components/schemas/Task"),
+    }
+    paths["/v1/tasks/watch"] = {
+        "get": {
+            "tags": ["tasks"],
+            "security": SEC_READER,
+            "parameters": watch_params(),
+            "responses": sse_response("SSE resource watch for tasks"),
+        }
+    }
+    tg, tp = status_get_put("tasks")
+    paths["/v1/tasks/{name}/status"] = {"get": tg, "put": tp}
+
+    msg_params = [
+        {
+            "name": "name",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string"},
+        },
+        {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+        {"name": "phase", "in": "query", "schema": {"type": "string"}},
+        {"name": "lifecycle", "in": "query", "schema": {"type": "string"}},
+        {"name": "from_agent", "in": "query", "schema": {"type": "string"}},
+        {"name": "to_agent", "in": "query", "schema": {"type": "string"}},
+        {"name": "branch_id", "in": "query", "schema": {"type": "string"}},
+        {"name": "trace_id", "in": "query", "schema": {"type": "string"}},
+        {"name": "limit", "in": "query", "schema": {"type": "integer", "minimum": 0}},
+    ]
+
+    paths["/v1/tasks/{name}/logs"] = {
+        "get": {
+            "tags": ["tasks"],
+            "security": SEC_READER,
+            "parameters": msg_params[:2],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/NamedLogsResponse"
+                    ),
+                },
+                "404": {"description": "Not found", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/tasks/{name}/messages"] = {
+        "get": {
+            "tags": ["tasks"],
+            "security": SEC_READER,
+            "parameters": msg_params,
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/TaskMessageListResponse"
+                    ),
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "404": {"description": "Not found", "content": text_plain_error()},
+                "503": {"description": "Store unavailable", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/tasks/{name}/metrics"] = {
+        "get": {
+            "tags": ["tasks"],
+            "security": SEC_READER,
+            "parameters": msg_params,
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/TaskMessageMetricsResponse"
+                    ),
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "404": {"description": "Not found", "content": text_plain_error()},
+                "503": {"description": "Store unavailable", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/tasks/{name}"] = {
+        "get": get_one("tasks", "./schemas/task.yaml#/components/schemas/Task"),
+        "put": put_one("tasks", "./schemas/task.yaml#/components/schemas/Task"),
+        "delete": delete_one("tasks"),
+    }
+
+    add_crud(
+        paths,
+        "/v1/task-schedules",
+        "task-schedules",
+        "./schemas/task-schedule.yaml#/components/schemas/TaskScheduleList",
+        "./schemas/task-schedule.yaml#/components/schemas/TaskSchedule",
+        with_status=True,
+    )
+    paths["/v1/task-schedules/watch"] = {
+        "get": {
+            "tags": ["task-schedules"],
+            "security": SEC_READER,
+            "parameters": watch_params(),
+            "responses": sse_response("SSE resource watch for task schedules"),
+        }
+    }
+
+    paths["/v1/task-webhooks"] = {
+        "get": {
+            "tags": ["task-webhooks"],
+            "security": SEC_READER,
+            "parameters": [
+                {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+                {"name": "labelSelector", "in": "query", "schema": {"type": "string"}},
+            ],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/task-webhook.yaml#/components/schemas/TaskWebhookList"
+                    ),
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "503": {"description": "Store unavailable", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        },
+        "post": post_create(
+            "task-webhooks",
+            "./schemas/task-webhook.yaml#/components/schemas/TaskWebhook",
+        ),
+    }
+    paths["/v1/task-webhooks/watch"] = {
+        "get": {
+            "tags": ["task-webhooks"],
+            "security": SEC_READER,
+            "parameters": watch_params(),
+            "responses": sse_response("SSE resource watch for task webhooks"),
+        }
+    }
+    wg, wp = status_get_put("task-webhooks")
+    paths["/v1/task-webhooks/{name}/status"] = {"get": wg, "put": wp}
+    paths["/v1/task-webhooks/{name}"] = {
+        "get": get_one(
+            "task-webhooks",
+            "./schemas/task-webhook.yaml#/components/schemas/TaskWebhook",
+        ),
+        "put": put_one(
+            "task-webhooks",
+            "./schemas/task-webhook.yaml#/components/schemas/TaskWebhook",
+        ),
+        "delete": delete_one("task-webhooks"),
+    }
+
+    add_crud(
+        paths,
+        "/v1/workers",
+        "workers",
+        "./schemas/worker.yaml#/components/schemas/WorkerList",
+        "./schemas/worker.yaml#/components/schemas/Worker",
+        with_status=True,
+    )
+
+    paths["/v1/mcp-servers"] = {
+        "get": list_op(
+            "mcp-servers",
+            "./schemas/mcp-server.yaml#/components/schemas/McpServerList",
+        ),
+        "post": {
+            **post_create(
+                "mcp-servers",
+                "./schemas/mcp-server.yaml#/components/schemas/McpServer",
+            ),
+            "security": SEC_ADMIN,
+        },
+    }
+    paths["/v1/mcp-servers/{name}"] = {
+        "get": get_one(
+            "mcp-servers",
+            "./schemas/mcp-server.yaml#/components/schemas/McpServer",
+        ),
+        "put": {
+            **put_one(
+                "mcp-servers",
+                "./schemas/mcp-server.yaml#/components/schemas/McpServer",
+            ),
+            "security": SEC_ADMIN,
+        },
+        "delete": {
+            "tags": ["mcp-servers"],
+            "security": SEC_ADMIN,
+            "parameters": [
+                {
+                    "name": "name",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                },
+                {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+            ],
+            "responses": {
+                "200": {
+                    "description": "Deleted",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/McpServerDeletedResponse"
+                    ),
+                },
+                "404": {"description": "Not found", "content": text_plain_error()},
+                "503": {"description": "Store unavailable", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        },
+    }
+
+    wh_body = {
+        "required": True,
+        "content": {
+            "application/json": {
+                "schema": {"type": "object", "additionalProperties": True},
+            },
+            "application/octet-stream": {
+                "schema": {"type": "string", "format": "binary"},
+            },
+        },
+    }
+    paths["/v1/webhook-deliveries/{endpoint_id}"] = {
+        "post": {
+            "tags": ["task-webhooks"],
+            "summary": "Inbound webhook (HMAC per TaskWebhook auth profile generic|github)",
+            "security": SEC_WRITER,
+            "parameters": [
+                {
+                    "name": "endpoint_id",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            ],
+            "requestBody": wh_body,
+            "responses": {
+                "202": {
+                    "description": "Accepted",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/WebhookDeliveryResponse"
+                    ),
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "401": {
+                    "description": "Signature verification failed",
+                    "content": text_plain_error(),
+                },
+                "404": {"description": "Unknown endpoint", "content": text_plain_error()},
+                "409": {"description": "Suspended or conflict", "content": text_plain_error()},
+                "500": {"description": "Server error", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+
+    paths["/v1/events/watch"] = {
+        "get": {
+            "tags": ["events"],
+            "security": SEC_READER,
+            "parameters": [
+                {"name": "since", "in": "query", "schema": {"type": "string"}},
+                {"name": "source", "in": "query", "schema": {"type": "string"}},
+                {"name": "type", "in": "query", "schema": {"type": "string"}},
+                {"name": "kind", "in": "query", "schema": {"type": "string"}},
+                {"name": "name", "in": "query", "schema": {"type": "string"}},
+                {"name": "namespace", "in": "query", "schema": {"type": "string"}},
+            ],
+            "responses": {
+                "200": {
+                    "description": "SSE; `event: event` with BusEvent JSON",
+                    "content": {"text/event-stream": {"schema": {"type": "string"}}},
+                },
+                "503": {
+                    "description": "Event bus unavailable",
+                    "content": text_plain_error(),
+                },
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+
+    paths["/v1/namespaces"] = {
+        "get": {
+            "tags": ["system"],
+            "security": SEC_READER,
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/NamespacesResponse"
+                    ),
+                },
+                "503": {"description": "Store unavailable", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/capabilities"] = {
+        "get": {
+            "tags": ["system"],
+            "security": SEC_READER,
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/CapabilitySnapshot"
+                    ),
+                },
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+
+    paths["/healthz"] = {
+        "get": {
+            "tags": ["system"],
+            "security": [],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/HealthResponse"
+                    ),
+                }
+            },
+        }
+    }
+    paths["/metrics"] = {
+        "get": {
+            "tags": ["system"],
+            "security": SEC_READER,
+            "responses": {
+                "200": {
+                    "description": "Prometheus text exposition",
+                    "content": {"text/plain": {"schema": {"type": "string"}}},
+                },
+                "401": {"description": "Unauthorized", "content": text_plain_error()},
+                "403": {"description": "Forbidden", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+
+    paths["/v1/auth/config"] = {
+        "get": {
+            "tags": ["auth"],
+            "security": [],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/AuthConfigResponse"
+                    ),
+                },
+                "500": {"description": "Server error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/auth/setup"] = {
+        "post": {
+            "tags": ["auth"],
+            "security": [],
+            "requestBody": {
+                "required": True,
+                "content": json_body(
+                    "./schemas/common.yaml#/components/schemas/AuthCredentialsRequest"
+                ),
+            },
+            "responses": {
+                "201": {
+                    "description": "Created session",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/AuthMeResponse"
+                    ),
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "403": {"description": "Forbidden", "content": text_plain_error()},
+                "409": {"description": "Already configured", "content": text_plain_error()},
+                "429": {"description": "Rate limited", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/auth/login"] = {
+        "post": {
+            "tags": ["auth"],
+            "security": [],
+            "requestBody": {
+                "required": True,
+                "content": json_body(
+                    "./schemas/common.yaml#/components/schemas/AuthCredentialsRequest"
+                ),
+            },
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/AuthMeResponse"
+                    ),
+                },
+                "401": {"description": "Invalid credentials", "content": text_plain_error()},
+                "409": {"description": "Setup required", "content": text_plain_error()},
+                "429": {"description": "Rate limited", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/auth/logout"] = {
+        "post": {
+            "tags": ["auth"],
+            "security": [],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/OkStatusMessage"
+                    ),
+                },
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/auth/me"] = {
+        "get": {
+            "tags": ["auth"],
+            "security": [],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/AuthMeResponse"
+                    ),
+                }
+            },
+        }
+    }
+    pwd_status = {
+        "type": "object",
+        "properties": {"status": {"type": "string"}},
+    }
+    paths["/v1/auth/change-password"] = {
+        "post": {
+            "tags": ["auth"],
+            "security": [],
+            "requestBody": {
+                "required": True,
+                "content": json_body(
+                    "./schemas/common.yaml#/components/schemas/AuthChangePasswordRequest"
+                ),
+            },
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": {"application/json": {"schema": pwd_status}},
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "401": {"description": "Unauthorized", "content": text_plain_error()},
+                "429": {"description": "Rate limited", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/auth/admin/reset-password"] = {
+        "post": {
+            "tags": ["auth"],
+            "security": SEC_ADMIN,
+            "requestBody": {
+                "required": True,
+                "content": json_body(
+                    "./schemas/common.yaml#/components/schemas/AuthResetPasswordRequest"
+                ),
+            },
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": {"application/json": {"schema": pwd_status}},
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "403": {"description": "Forbidden", "content": text_plain_error()},
+                "429": {"description": "Rate limited", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+
+    return {
+        "openapi": "3.1.0",
+        "servers": [
+            {"url": "/", "description": "Server root (set host/port when calling the API)"}
+        ],
+        "info": {
+            "title": "Orloj API",
+            "version": "1.0.0",
+            "license": {"name": "Apache-2.0", "identifier": "Apache-2.0"},
+            "description": (
+                "Control plane HTTP API for Orloj (v1).\n\n"
+                "Most error responses use `text/plain` bodies. A future release may "
+                "standardize errors as JSON for clients and tooling.\n\n"
+                "Authentication: bearer token (`Authorization: Bearer ...`) and/or "
+                "session cookie (`orloj_session`, or `__Host-orloj_session` over HTTPS). "
+                "Effective requirements depend on server configuration "
+                "(`ORLOJ_API_TOKEN` / `ORLOJ_API_TOKENS`, native auth mode, etc.)."
+            ),
+        },
+        "tags": [
+            {"name": "agents"},
+            {"name": "agent-systems"},
+            {"name": "model-endpoints"},
+            {"name": "tools"},
+            {"name": "secrets"},
+            {"name": "memories"},
+            {"name": "agent-policies"},
+            {"name": "agent-roles"},
+            {"name": "tool-permissions"},
+            {"name": "tool-approvals"},
+            {"name": "tasks"},
+            {"name": "task-schedules"},
+            {"name": "task-webhooks"},
+            {"name": "workers"},
+            {"name": "mcp-servers"},
+            {"name": "auth"},
+            {"name": "system"},
+            {"name": "events"},
+        ],
+        "paths": paths,
+        "components": {
+            "securitySchemes": {
+                "bearerAuth": {"type": "http", "scheme": "bearer"},
+                "sessionCookie": {
+                    "type": "apiKey",
+                    "in": "cookie",
+                    "name": "orloj_session",
+                    "description": "Session cookie; `__Host-orloj_session` is used for secure sites.",
+                },
+            }
+        },
+    }
+
+
+def main() -> None:
+    root = pathlib.Path(__file__).resolve().parent
+    doc = build()
+    tmp = root / "openapi.tmp.json"
+    tmp.write_text(json.dumps(doc, indent=2))
+    yaml_path = root / "openapi.yaml"
+    subprocess.run(
+        [
+            "ruby",
+            "-rjson",
+            "-ryaml",
+            "-e",
+            "File.write(ARGV[1], YAML.dump(JSON.parse(File.read(ARGV[0]))))",
+            str(tmp),
+            str(yaml_path),
+        ],
+        check=True,
+    )
+    tmp.unlink()
+    print(f"Wrote {yaml_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,5422 @@
+---
+openapi: 3.1.0
+servers:
+- url: "/"
+  description: Server root (set host/port when calling the API)
+info:
+  title: Orloj API
+  version: 1.0.0
+  license:
+    name: Apache-2.0
+    identifier: Apache-2.0
+  description: |-
+    Control plane HTTP API for Orloj (v1).
+
+    Most error responses use `text/plain` bodies. A future release may standardize errors as JSON for clients and tooling.
+
+    Authentication: bearer token (`Authorization: Bearer ...`) and/or session cookie (`orloj_session`, or `__Host-orloj_session` over HTTPS). Effective requirements depend on server configuration (`ORLOJ_API_TOKEN` / `ORLOJ_API_TOKENS`, native auth mode, etc.).
+tags:
+- name: agents
+- name: agent-systems
+- name: model-endpoints
+- name: tools
+- name: secrets
+- name: memories
+- name: agent-policies
+- name: agent-roles
+- name: tool-permissions
+- name: tool-approvals
+- name: tasks
+- name: task-schedules
+- name: task-webhooks
+- name: workers
+- name: mcp-servers
+- name: auth
+- name: system
+- name: events
+paths:
+  "/v1/agents":
+    get:
+      tags:
+      - agents
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent.yaml#/components/schemas/AgentList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - agents
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/agent.yaml#/components/schemas/Agent"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent.yaml#/components/schemas/Agent"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agents/watch":
+    get:
+      tags:
+      - agents
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: resourceVersion
+        in: query
+        schema:
+          type: string
+      - name: name
+        in: query
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: 'SSE; `event: resource` with WatchResourceEvent JSON in data'
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agents/{name}/status":
+    get:
+      tags:
+      - agents
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - agents
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agents/{name}/logs":
+    get:
+      tags:
+      - agents
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/NamedLogsResponse"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agents/{name}":
+    get:
+      tags:
+      - agents
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent.yaml#/components/schemas/Agent"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - agents
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/agent.yaml#/components/schemas/Agent"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent.yaml#/components/schemas/Agent"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - agents
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agent-systems":
+    get:
+      tags:
+      - agent-systems
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-system.yaml#/components/schemas/AgentSystemList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - agent-systems
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/agent-system.yaml#/components/schemas/AgentSystem"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-system.yaml#/components/schemas/AgentSystem"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agent-systems/{name}/status":
+    get:
+      tags:
+      - agent-systems
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - agent-systems
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agent-systems/{name}":
+    get:
+      tags:
+      - agent-systems
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-system.yaml#/components/schemas/AgentSystem"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - agent-systems
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/agent-system.yaml#/components/schemas/AgentSystem"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-system.yaml#/components/schemas/AgentSystem"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - agent-systems
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/model-endpoints":
+    get:
+      tags:
+      - model-endpoints
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/model-endpoint.yaml#/components/schemas/ModelEndpointList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - model-endpoints
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/model-endpoint.yaml#/components/schemas/ModelEndpoint"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/model-endpoint.yaml#/components/schemas/ModelEndpoint"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/model-endpoints/{name}/status":
+    get:
+      tags:
+      - model-endpoints
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - model-endpoints
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/model-endpoints/{name}":
+    get:
+      tags:
+      - model-endpoints
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/model-endpoint.yaml#/components/schemas/ModelEndpoint"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - model-endpoints
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/model-endpoint.yaml#/components/schemas/ModelEndpoint"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/model-endpoint.yaml#/components/schemas/ModelEndpoint"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - model-endpoints
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tools":
+    get:
+      tags:
+      - tools
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool.yaml#/components/schemas/ToolList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - tools
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/tool.yaml#/components/schemas/Tool"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool.yaml#/components/schemas/Tool"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tools/{name}/status":
+    get:
+      tags:
+      - tools
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - tools
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tools/{name}":
+    get:
+      tags:
+      - tools
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool.yaml#/components/schemas/Tool"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - tools
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/tool.yaml#/components/schemas/Tool"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool.yaml#/components/schemas/Tool"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - tools
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/secrets":
+    get:
+      tags:
+      - secrets
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/secret.yaml#/components/schemas/SecretList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - secrets
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/secret.yaml#/components/schemas/Secret"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/secret.yaml#/components/schemas/Secret"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/secrets/{name}":
+    get:
+      tags:
+      - secrets
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/secret.yaml#/components/schemas/Secret"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - secrets
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/secret.yaml#/components/schemas/Secret"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/secret.yaml#/components/schemas/Secret"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - secrets
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/memories":
+    get:
+      tags:
+      - memories
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/memory.yaml#/components/schemas/MemoryList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - memories
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/memory.yaml#/components/schemas/Memory"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/memory.yaml#/components/schemas/Memory"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/memories/{name}/status":
+    get:
+      tags:
+      - memories
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - memories
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/memories/{name}":
+    get:
+      tags:
+      - memories
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/memory.yaml#/components/schemas/Memory"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - memories
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/memory.yaml#/components/schemas/Memory"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/memory.yaml#/components/schemas/Memory"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - memories
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/memories/{name}/entries":
+    get:
+      tags:
+      - memories
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: q
+        in: query
+        schema:
+          type: string
+      - name: prefix
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/MemoryEntriesResponse"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '500':
+          description: Backend error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agent-policies":
+    get:
+      tags:
+      - agent-policies
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-policy.yaml#/components/schemas/AgentPolicyList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - agent-policies
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/agent-policy.yaml#/components/schemas/AgentPolicy"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-policy.yaml#/components/schemas/AgentPolicy"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agent-policies/{name}/status":
+    get:
+      tags:
+      - agent-policies
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - agent-policies
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agent-policies/{name}":
+    get:
+      tags:
+      - agent-policies
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-policy.yaml#/components/schemas/AgentPolicy"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - agent-policies
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/agent-policy.yaml#/components/schemas/AgentPolicy"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-policy.yaml#/components/schemas/AgentPolicy"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - agent-policies
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agent-roles":
+    get:
+      tags:
+      - agent-roles
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-role.yaml#/components/schemas/AgentRoleList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - agent-roles
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/agent-role.yaml#/components/schemas/AgentRole"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-role.yaml#/components/schemas/AgentRole"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agent-roles/{name}":
+    get:
+      tags:
+      - agent-roles
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-role.yaml#/components/schemas/AgentRole"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - agent-roles
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/agent-role.yaml#/components/schemas/AgentRole"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/agent-role.yaml#/components/schemas/AgentRole"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - agent-roles
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tool-permissions":
+    get:
+      tags:
+      - tool-permissions
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool-permission.yaml#/components/schemas/ToolPermissionList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - tool-permissions
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/tool-permission.yaml#/components/schemas/ToolPermission"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool-permission.yaml#/components/schemas/ToolPermission"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tool-permissions/{name}":
+    get:
+      tags:
+      - tool-permissions
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool-permission.yaml#/components/schemas/ToolPermission"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - tool-permissions
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/tool-permission.yaml#/components/schemas/ToolPermission"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool-permission.yaml#/components/schemas/ToolPermission"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - tool-permissions
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tool-approvals":
+    get:
+      tags:
+      - tool-approvals
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool-approval.yaml#/components/schemas/ToolApprovalList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - tool-approvals
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/tool-approval.yaml#/components/schemas/ToolApproval"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool-approval.yaml#/components/schemas/ToolApproval"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tool-approvals/{name}":
+    get:
+      tags:
+      - tool-approvals
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool-approval.yaml#/components/schemas/ToolApproval"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - tool-approvals
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - tool-approvals
+      summary: Not supported
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '405':
+          description: Method not allowed
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tool-approvals/{name}/approve":
+    post:
+      tags:
+      - tool-approvals
+      summary: Approve pending tool invocation
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/ToolApprovalDecisionRequest"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool-approval.yaml#/components/schemas/ToolApproval"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tool-approvals/{name}/deny":
+    post:
+      tags:
+      - tool-approvals
+      summary: Deny pending tool invocation
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/ToolApprovalDecisionRequest"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/tool-approval.yaml#/components/schemas/ToolApproval"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tasks":
+    get:
+      tags:
+      - tasks
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: offset
+        in: query
+        schema:
+          type: integer
+          minimum: 0
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task.yaml#/components/schemas/TaskList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - tasks
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/task.yaml#/components/schemas/Task"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task.yaml#/components/schemas/Task"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tasks/watch":
+    get:
+      tags:
+      - tasks
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: resourceVersion
+        in: query
+        schema:
+          type: string
+      - name: name
+        in: query
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: SSE resource watch for tasks
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tasks/{name}/status":
+    get:
+      tags:
+      - tasks
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - tasks
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tasks/{name}/logs":
+    get:
+      tags:
+      - tasks
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/NamedLogsResponse"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tasks/{name}/messages":
+    get:
+      tags:
+      - tasks
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: phase
+        in: query
+        schema:
+          type: string
+      - name: lifecycle
+        in: query
+        schema:
+          type: string
+      - name: from_agent
+        in: query
+        schema:
+          type: string
+      - name: to_agent
+        in: query
+        schema:
+          type: string
+      - name: branch_id
+        in: query
+        schema:
+          type: string
+      - name: trace_id
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/TaskMessageListResponse"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tasks/{name}/metrics":
+    get:
+      tags:
+      - tasks
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: phase
+        in: query
+        schema:
+          type: string
+      - name: lifecycle
+        in: query
+        schema:
+          type: string
+      - name: from_agent
+        in: query
+        schema:
+          type: string
+      - name: to_agent
+        in: query
+        schema:
+          type: string
+      - name: branch_id
+        in: query
+        schema:
+          type: string
+      - name: trace_id
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/TaskMessageMetricsResponse"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tasks/{name}":
+    get:
+      tags:
+      - tasks
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task.yaml#/components/schemas/Task"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - tasks
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/task.yaml#/components/schemas/Task"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task.yaml#/components/schemas/Task"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - tasks
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/task-schedules":
+    get:
+      tags:
+      - task-schedules
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task-schedule.yaml#/components/schemas/TaskScheduleList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - task-schedules
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/task-schedule.yaml#/components/schemas/TaskSchedule"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task-schedule.yaml#/components/schemas/TaskSchedule"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/task-schedules/{name}/status":
+    get:
+      tags:
+      - task-schedules
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - task-schedules
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/task-schedules/{name}":
+    get:
+      tags:
+      - task-schedules
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task-schedule.yaml#/components/schemas/TaskSchedule"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - task-schedules
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/task-schedule.yaml#/components/schemas/TaskSchedule"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task-schedule.yaml#/components/schemas/TaskSchedule"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - task-schedules
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/task-schedules/watch":
+    get:
+      tags:
+      - task-schedules
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: resourceVersion
+        in: query
+        schema:
+          type: string
+      - name: name
+        in: query
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: SSE resource watch for task schedules
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/task-webhooks":
+    get:
+      tags:
+      - task-webhooks
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task-webhook.yaml#/components/schemas/TaskWebhookList"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - task-webhooks
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/task-webhook.yaml#/components/schemas/TaskWebhook"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task-webhook.yaml#/components/schemas/TaskWebhook"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/task-webhooks/watch":
+    get:
+      tags:
+      - task-webhooks
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: resourceVersion
+        in: query
+        schema:
+          type: string
+      - name: name
+        in: query
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: SSE resource watch for task webhooks
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/task-webhooks/{name}/status":
+    get:
+      tags:
+      - task-webhooks
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - task-webhooks
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/task-webhooks/{name}":
+    get:
+      tags:
+      - task-webhooks
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task-webhook.yaml#/components/schemas/TaskWebhook"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - task-webhooks
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/task-webhook.yaml#/components/schemas/TaskWebhook"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/task-webhook.yaml#/components/schemas/TaskWebhook"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - task-webhooks
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/workers":
+    get:
+      tags:
+      - workers
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/worker.yaml#/components/schemas/WorkerList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - workers
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/worker.yaml#/components/schemas/Worker"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/worker.yaml#/components/schemas/Worker"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/workers/{name}/status":
+    get:
+      tags:
+      - workers
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - workers
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/StatusEnvelope"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/workers/{name}":
+    get:
+      tags:
+      - workers
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/worker.yaml#/components/schemas/Worker"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - workers
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/worker.yaml#/components/schemas/Worker"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/worker.yaml#/components/schemas/Worker"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - workers
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/mcp-servers":
+    get:
+      tags:
+      - mcp-servers
+      parameters:
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+      - name: after
+        in: query
+        schema:
+          type: string
+      - name: labelSelector
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/mcp-server.yaml#/components/schemas/McpServerList"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - mcp-servers
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/mcp-server.yaml#/components/schemas/McpServer"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/mcp-server.yaml#/components/schemas/McpServer"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/mcp-servers/{name}":
+    get:
+      tags:
+      - mcp-servers
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/mcp-server.yaml#/components/schemas/McpServer"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    put:
+      tags:
+      - mcp-servers
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      - name: If-Match
+        in: header
+        required: false
+        schema:
+          type: string
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/mcp-server.yaml#/components/schemas/McpServer"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/mcp-server.yaml#/components/schemas/McpServer"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    delete:
+      tags:
+      - mcp-servers
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/McpServerDeletedResponse"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/webhook-deliveries/{endpoint_id}":
+    post:
+      tags:
+      - task-webhooks
+      summary: Inbound webhook (HMAC per TaskWebhook auth profile generic|github)
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: endpoint_id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/WebhookDeliveryResponse"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '401':
+          description: Signature verification failed
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Unknown endpoint
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Suspended or conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '500':
+          description: Server error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/events/watch":
+    get:
+      tags:
+      - events
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: since
+        in: query
+        schema:
+          type: string
+      - name: source
+        in: query
+        schema:
+          type: string
+      - name: type
+        in: query
+        schema:
+          type: string
+      - name: kind
+        in: query
+        schema:
+          type: string
+      - name: name
+        in: query
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: 'SSE; `event: event` with BusEvent JSON'
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        '503':
+          description: Event bus unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/namespaces":
+    get:
+      tags:
+      - system
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/NamespacesResponse"
+        '503':
+          description: Store unavailable
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/capabilities":
+    get:
+      tags:
+      - system
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/CapabilitySnapshot"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/healthz":
+    get:
+      tags:
+      - system
+      security: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/HealthResponse"
+  "/metrics":
+    get:
+      tags:
+      - system
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: Prometheus text exposition
+          content:
+            text/plain:
+              schema:
+                type: string
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '403':
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/auth/config":
+    get:
+      tags:
+      - auth
+      security: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/AuthConfigResponse"
+        '500':
+          description: Server error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/auth/setup":
+    post:
+      tags:
+      - auth
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/AuthCredentialsRequest"
+      responses:
+        '201':
+          description: Created session
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/AuthMeResponse"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '403':
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Already configured
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '429':
+          description: Rate limited
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/auth/login":
+    post:
+      tags:
+      - auth
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/AuthCredentialsRequest"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/AuthMeResponse"
+        '401':
+          description: Invalid credentials
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Setup required
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '429':
+          description: Rate limited
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/auth/logout":
+    post:
+      tags:
+      - auth
+      security: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/OkStatusMessage"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/auth/me":
+    get:
+      tags:
+      - auth
+      security: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/AuthMeResponse"
+  "/v1/auth/change-password":
+    post:
+      tags:
+      - auth
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/AuthChangePasswordRequest"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '429':
+          description: Rate limited
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/auth/admin/reset-password":
+    post:
+      tags:
+      - auth
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/AuthResetPasswordRequest"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '403':
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '429':
+          description: Rate limited
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: orloj_session
+      description: Session cookie; `__Host-orloj_session` is used for secure sites.

--- a/openapi/schemas/agent-policy.yaml
+++ b/openapi/schemas/agent-policy.yaml
@@ -1,0 +1,43 @@
+components:
+  schemas:
+    AgentPolicySpec:
+      type: object
+      properties:
+        max_tokens_per_run: { type: integer }
+        allowed_models:
+          type: array
+          items: { type: string }
+        blocked_tools:
+          type: array
+          items: { type: string }
+        apply_mode: { type: string }
+        target_systems:
+          type: array
+          items: { type: string }
+        target_tasks:
+          type: array
+          items: { type: string }
+    PolicyStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    AgentPolicy:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [AgentPolicy] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/AgentPolicySpec" }
+        status: { $ref: "#/components/schemas/PolicyStatus" }
+    AgentPolicyList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/AgentPolicy" }

--- a/openapi/schemas/agent-role.yaml
+++ b/openapi/schemas/agent-role.yaml
@@ -1,0 +1,33 @@
+components:
+  schemas:
+    AgentRoleSpec:
+      type: object
+      properties:
+        description: { type: string }
+        permissions:
+          type: array
+          items: { type: string }
+    AgentRoleStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    AgentRole:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [AgentRole] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/AgentRoleSpec" }
+        status: { $ref: "#/components/schemas/AgentRoleStatus" }
+    AgentRoleList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/AgentRole" }

--- a/openapi/schemas/agent-system.yaml
+++ b/openapi/schemas/agent-system.yaml
@@ -1,0 +1,56 @@
+components:
+  schemas:
+    GraphRoute:
+      type: object
+      properties:
+        to: { type: string }
+        labels: { type: object, additionalProperties: { type: string } }
+        policy: { type: object, additionalProperties: { type: string } }
+    GraphJoin:
+      type: object
+      properties:
+        mode: { type: string }
+        quorum_count: { type: integer }
+        quorum_percent: { type: integer }
+        on_failure: { type: string }
+    GraphEdge:
+      type: object
+      properties:
+        next: { type: string }
+        edges:
+          type: array
+          items: { $ref: "#/components/schemas/GraphRoute" }
+        join: { $ref: "#/components/schemas/GraphJoin" }
+    AgentSystemSpec:
+      type: object
+      properties:
+        agents:
+          type: array
+          items: { type: string }
+        graph:
+          type: object
+          additionalProperties: { $ref: "#/components/schemas/GraphEdge" }
+    AgentSystemStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    AgentSystem:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [AgentSystem] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/AgentSystemSpec" }
+        status: { $ref: "#/components/schemas/AgentSystemStatus" }
+    AgentSystemList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/AgentSystem" }

--- a/openapi/schemas/agent.yaml
+++ b/openapi/schemas/agent.yaml
@@ -1,0 +1,70 @@
+components:
+  schemas:
+    AgentLimits:
+      type: object
+      properties:
+        max_steps: { type: integer }
+        timeout: { type: string }
+    MemorySpecInline:
+      type: object
+      properties:
+        ref: { type: string }
+        type: { type: string }
+        provider: { type: string }
+        allow:
+          type: array
+          items: { type: string }
+    AgentExecutionSpec:
+      type: object
+      properties:
+        profile: { type: string }
+        tool_sequence:
+          type: array
+          items: { type: string }
+        required_output_markers:
+          type: array
+          items: { type: string }
+        duplicate_tool_call_policy: { type: string }
+        on_contract_violation: { type: string }
+        tool_use_behavior: { type: string }
+    AgentSpec:
+      type: object
+      properties:
+        model_ref: { type: string }
+        prompt: { type: string }
+        tools:
+          type: array
+          items: { type: string }
+        allowed_tools:
+          type: array
+          items: { type: string }
+        roles:
+          type: array
+          items: { type: string }
+        memory: { $ref: "#/components/schemas/MemorySpecInline" }
+        execution: { $ref: "#/components/schemas/AgentExecutionSpec" }
+        limits: { $ref: "#/components/schemas/AgentLimits" }
+    AgentStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    Agent:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [Agent] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/AgentSpec" }
+        status: { $ref: "#/components/schemas/AgentStatus" }
+    AgentList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/Agent" }

--- a/openapi/schemas/common.yaml
+++ b/openapi/schemas/common.yaml
@@ -1,0 +1,208 @@
+# Shared schemas (JSON names match Go json tags).
+components:
+  schemas:
+    ObjectMeta:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        namespace: { type: string, default: default }
+        labels: { type: object, additionalProperties: { type: string } }
+        annotations: { type: object, additionalProperties: { type: string } }
+        resourceVersion: { type: string }
+        generation: { type: integer, format: int64 }
+        createdAt: { type: string }
+    ListMeta:
+      type: object
+      properties:
+        continue:
+          type: string
+          description: Cursor for next page (last item name); empty if none.
+    PlainTextError:
+      type: string
+      description: Error body when Content-Type is text/plain.
+    HealthResponse:
+      type: object
+      required: [status]
+      properties:
+        status: { type: string, enum: [ok] }
+    NamespacesResponse:
+      type: object
+      required: [namespaces]
+      properties:
+        namespaces: { type: array, items: { type: string } }
+    Capability:
+      type: object
+      required: [id, enabled]
+      properties:
+        id: { type: string }
+        enabled: { type: boolean }
+        description: { type: string }
+        source: { type: string }
+    CapabilitySnapshot:
+      type: object
+      required: [generated_at, capabilities]
+      properties:
+        generated_at: { type: string }
+        capabilities:
+          type: array
+          items: { $ref: "#/components/schemas/Capability" }
+    AuthConfigResponse:
+      type: object
+      properties:
+        mode: { type: string }
+        setup_required: { type: boolean }
+        login_methods: { type: array, items: { type: string } }
+    AuthMeResponse:
+      type: object
+      properties:
+        authenticated: { type: boolean }
+        username: { type: string }
+        method: { type: string }
+    AuthCredentialsRequest:
+      type: object
+      properties:
+        username: { type: string }
+        password: { type: string }
+        setup_token: { type: string }
+    AuthChangePasswordRequest:
+      type: object
+      properties:
+        current_password: { type: string }
+        new_password: { type: string }
+    AuthResetPasswordRequest:
+      type: object
+      properties:
+        username: { type: string }
+        new_password: { type: string }
+    OkStatusMessage:
+      type: object
+      properties:
+        status: { type: string }
+    WebhookDeliveryResponse:
+      type: object
+      properties:
+        accepted: { type: boolean }
+        duplicate: { type: boolean }
+        event_id: { type: string }
+        task: { type: string }
+        message: { type: string }
+    WatchResourceEvent:
+      type: object
+      properties:
+        type: { type: string }
+        resource: { type: object, additionalProperties: true }
+    BusEvent:
+      type: object
+      properties:
+        id: { type: integer, format: int64 }
+        timestamp: { type: string }
+        source: { type: string }
+        type: { type: string }
+        kind: { type: string }
+        name: { type: string }
+        namespace: { type: string }
+        action: { type: string }
+        message: { type: string }
+        data: { nullable: true }
+    ToolApprovalDecisionRequest:
+      type: object
+      properties:
+        decided_by: { type: string }
+    MemoryEntriesResponse:
+      type: object
+      properties:
+        entries:
+          type: array
+          items: { type: object, additionalProperties: true }
+        count: { type: integer }
+    NamedLogsResponse:
+      type: object
+      properties:
+        name: { type: string }
+        logs:
+          type: array
+          items: { type: string }
+    TaskMessageListResponse:
+      type: object
+      properties:
+        name: { type: string }
+        namespace: { type: string }
+        total: { type: integer }
+        filtered_from: { type: integer }
+        lifecycle_counts: { type: object, additionalProperties: { type: integer } }
+        messages:
+          type: array
+          items: { $ref: "task.yaml#/components/schemas/TaskMessage" }
+    TaskMessageTotals:
+      type: object
+      properties:
+        messages: { type: integer }
+        queued: { type: integer }
+        running: { type: integer }
+        retrypending: { type: integer }
+        succeeded: { type: integer }
+        deadletter: { type: integer }
+        in_flight: { type: integer }
+        retry_count: { type: integer }
+        deadletters: { type: integer }
+        latency_ms_avg: { type: integer, format: int64 }
+        latency_ms_p95: { type: integer, format: int64 }
+        latency_sample_size: { type: integer }
+    TaskMessageAgentMetric:
+      type: object
+      properties:
+        agent: { type: string }
+        inbound: { type: integer }
+        outbound: { type: integer }
+        queued: { type: integer }
+        running: { type: integer }
+        retrypending: { type: integer }
+        succeeded: { type: integer }
+        deadletter: { type: integer }
+        in_flight: { type: integer }
+        retry_count: { type: integer }
+        deadletters: { type: integer }
+        latency_ms_avg: { type: integer, format: int64 }
+        latency_ms_p95: { type: integer, format: int64 }
+        latency_sample_size: { type: integer }
+    TaskMessageEdgeMetric:
+      type: object
+      properties:
+        from_agent: { type: string }
+        to_agent: { type: string }
+        messages: { type: integer }
+        queued: { type: integer }
+        running: { type: integer }
+        retrypending: { type: integer }
+        succeeded: { type: integer }
+        deadletter: { type: integer }
+        in_flight: { type: integer }
+        retry_count: { type: integer }
+        deadletters: { type: integer }
+        latency_ms_avg: { type: integer, format: int64 }
+        latency_ms_p95: { type: integer, format: int64 }
+        latency_sample_size: { type: integer }
+    TaskMessageMetricsResponse:
+      type: object
+      properties:
+        name: { type: string }
+        namespace: { type: string }
+        generated_at: { type: string }
+        totals: { $ref: "#/components/schemas/TaskMessageTotals" }
+        per_agent:
+          type: array
+          items: { $ref: "#/components/schemas/TaskMessageAgentMetric" }
+        per_edge:
+          type: array
+          items: { $ref: "#/components/schemas/TaskMessageEdgeMetric" }
+        filters: { type: object, additionalProperties: true }
+    McpServerDeletedResponse:
+      type: object
+      properties:
+        deleted: { type: string }
+    StatusEnvelope:
+      type: object
+      properties:
+        metadata: { $ref: "#/components/schemas/ObjectMeta" }
+        status: { type: object, additionalProperties: true }

--- a/openapi/schemas/mcp-server.yaml
+++ b/openapi/schemas/mcp-server.yaml
@@ -1,0 +1,67 @@
+components:
+  schemas:
+    McpServerEnvVar:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        value: { type: string }
+        secretRef: { type: string }
+    McpToolFilter:
+      type: object
+      properties:
+        include:
+          type: array
+          items: { type: string }
+    McpReconnectPolicy:
+      type: object
+      properties:
+        max_attempts: { type: integer }
+        backoff: { type: string }
+    McpServerSpec:
+      type: object
+      required: [transport]
+      properties:
+        transport: { type: string, enum: [stdio, http] }
+        command: { type: string }
+        args:
+          type: array
+          items: { type: string }
+        env:
+          type: array
+          items: { $ref: "#/components/schemas/McpServerEnvVar" }
+        endpoint: { type: string }
+        auth: { $ref: "tool.yaml#/components/schemas/ToolAuth" }
+        tool_filter: { $ref: "#/components/schemas/McpToolFilter" }
+        reconnect: { $ref: "#/components/schemas/McpReconnectPolicy" }
+    McpServerStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        discoveredTools:
+          type: array
+          items: { type: string }
+        generatedTools:
+          type: array
+          items: { type: string }
+        lastSyncedAt: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    McpServer:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [McpServer] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/McpServerSpec" }
+        status: { $ref: "#/components/schemas/McpServerStatus" }
+    McpServerList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/McpServer" }

--- a/openapi/schemas/memory.yaml
+++ b/openapi/schemas/memory.yaml
@@ -1,0 +1,38 @@
+components:
+  schemas:
+    MemoryAuthConfig:
+      type: object
+      properties:
+        secretRef: { type: string }
+    MemoryConfig:
+      type: object
+      properties:
+        type: { type: string }
+        provider: { type: string }
+        embedding_model: { type: string }
+        endpoint: { type: string }
+        auth: { $ref: "#/components/schemas/MemoryAuthConfig" }
+    MemoryStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    Memory:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [Memory] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/MemoryConfig" }
+        status: { $ref: "#/components/schemas/MemoryStatus" }
+    MemoryList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/Memory" }

--- a/openapi/schemas/model-endpoint.yaml
+++ b/openapi/schemas/model-endpoint.yaml
@@ -1,0 +1,38 @@
+components:
+  schemas:
+    ModelEndpointAuth:
+      type: object
+      properties:
+        secretRef: { type: string }
+    ModelEndpointSpec:
+      type: object
+      properties:
+        provider: { type: string }
+        base_url: { type: string }
+        default_model: { type: string }
+        options: { type: object, additionalProperties: { type: string } }
+        auth: { $ref: "#/components/schemas/ModelEndpointAuth" }
+    ModelEndpointStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    ModelEndpoint:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [ModelEndpoint] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/ModelEndpointSpec" }
+        status: { $ref: "#/components/schemas/ModelEndpointStatus" }
+    ModelEndpointList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/ModelEndpoint" }

--- a/openapi/schemas/secret.yaml
+++ b/openapi/schemas/secret.yaml
@@ -1,0 +1,31 @@
+components:
+  schemas:
+    SecretSpec:
+      type: object
+      properties:
+        data: { type: object, additionalProperties: { type: string } }
+        stringData: { type: object, additionalProperties: { type: string } }
+    SecretStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    Secret:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [Secret] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/SecretSpec" }
+        status: { $ref: "#/components/schemas/SecretStatus" }
+    SecretList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/Secret" }

--- a/openapi/schemas/task-schedule.yaml
+++ b/openapi/schemas/task-schedule.yaml
@@ -1,0 +1,44 @@
+components:
+  schemas:
+    TaskScheduleSpec:
+      type: object
+      properties:
+        task_ref: { type: string }
+        schedule: { type: string }
+        time_zone: { type: string }
+        suspend: { type: boolean }
+        starting_deadline_seconds: { type: integer }
+        concurrency_policy: { type: string }
+        successful_history_limit: { type: integer }
+        failed_history_limit: { type: integer }
+    TaskScheduleStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        lastScheduleTime: { type: string }
+        lastSuccessfulTime: { type: string }
+        nextScheduleTime: { type: string }
+        lastTriggeredTask: { type: string }
+        activeRuns:
+          type: array
+          items: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    TaskSchedule:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [TaskSchedule] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/TaskScheduleSpec" }
+        status: { $ref: "#/components/schemas/TaskScheduleStatus" }
+    TaskScheduleList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/TaskSchedule" }

--- a/openapi/schemas/task-webhook.yaml
+++ b/openapi/schemas/task-webhook.yaml
@@ -1,0 +1,58 @@
+components:
+  schemas:
+    TaskWebhookAuthSpec:
+      type: object
+      properties:
+        profile: { type: string, description: generic or github }
+        secret_ref: { type: string }
+        signature_header: { type: string }
+        signature_prefix: { type: string }
+        timestamp_header: { type: string }
+        max_skew_seconds: { type: integer }
+    TaskWebhookIdempotency:
+      type: object
+      properties:
+        event_id_header: { type: string }
+        dedupe_window_seconds: { type: integer }
+    TaskWebhookPayloadSpec:
+      type: object
+      properties:
+        mode: { type: string }
+        input_key: { type: string }
+    TaskWebhookSpec:
+      type: object
+      properties:
+        task_ref: { type: string }
+        suspend: { type: boolean }
+        auth: { $ref: "#/components/schemas/TaskWebhookAuthSpec" }
+        idempotency: { $ref: "#/components/schemas/TaskWebhookIdempotency" }
+        payload: { $ref: "#/components/schemas/TaskWebhookPayloadSpec" }
+    TaskWebhookStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+        endpointID: { type: string }
+        endpointPath: { type: string }
+        lastDeliveryTime: { type: string }
+        lastEventID: { type: string }
+        lastTriggeredTask: { type: string }
+        acceptedCount: { type: integer, format: int64 }
+        duplicateCount: { type: integer, format: int64 }
+        rejectedCount: { type: integer, format: int64 }
+    TaskWebhook:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [TaskWebhook] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/TaskWebhookSpec" }
+        status: { $ref: "#/components/schemas/TaskWebhookStatus" }
+    TaskWebhookList:
+      type: object
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/TaskWebhook" }

--- a/openapi/schemas/task.yaml
+++ b/openapi/schemas/task.yaml
@@ -1,0 +1,171 @@
+components:
+  schemas:
+    TaskRetryPolicy:
+      type: object
+      properties:
+        max_attempts: { type: integer }
+        backoff: { type: string }
+    TaskMessageRetryPolicy:
+      type: object
+      properties:
+        max_attempts: { type: integer }
+        backoff: { type: string }
+        max_backoff: { type: string }
+        jitter: { type: string }
+        non_retryable:
+          type: array
+          items: { type: string }
+    TaskRequirements:
+      type: object
+      properties:
+        region: { type: string }
+        gpu: { type: boolean }
+        model: { type: string }
+    TaskSpec:
+      type: object
+      properties:
+        system: { type: string }
+        mode: { type: string }
+        input: { type: object, additionalProperties: { type: string } }
+        priority: { type: string }
+        max_turns: { type: integer }
+        retry: { $ref: "#/components/schemas/TaskRetryPolicy" }
+        message_retry: { $ref: "#/components/schemas/TaskMessageRetryPolicy" }
+        requirements: { $ref: "#/components/schemas/TaskRequirements" }
+    TaskTraceEvent:
+      type: object
+      properties:
+        timestamp: { type: string }
+        step_id: { type: string }
+        attempt: { type: integer }
+        step: { type: integer }
+        branch_id: { type: string }
+        type: { type: string }
+        agent: { type: string }
+        tool: { type: string }
+        tool_contract_version: { type: string }
+        tool_request_id: { type: string }
+        tool_attempt: { type: integer }
+        error_code: { type: string }
+        error_reason: { type: string }
+        retryable: { type: boolean }
+        message: { type: string }
+        latency_ms: { type: integer, format: int64 }
+        tokens: { type: integer }
+        input_tokens: { type: integer }
+        output_tokens: { type: integer }
+        token_usage_source: { type: string }
+        tool_calls: { type: integer }
+        memory_writes: { type: integer }
+        tool_auth_profile: { type: string }
+        tool_auth_secret_ref: { type: string }
+    TaskHistoryEvent:
+      type: object
+      properties:
+        timestamp: { type: string }
+        type: { type: string }
+        worker: { type: string }
+        message: { type: string }
+    TaskMessage:
+      type: object
+      properties:
+        timestamp: { type: string }
+        message_id: { type: string }
+        idempotency_key: { type: string }
+        task_id: { type: string }
+        attempt: { type: integer }
+        system: { type: string }
+        from_agent: { type: string }
+        to_agent: { type: string }
+        branch_id: { type: string }
+        parent_branch_id: { type: string }
+        type: { type: string }
+        content: { type: string }
+        trace_id: { type: string }
+        parent_id: { type: string }
+        phase: { type: string }
+        attempts: { type: integer }
+        max_attempts: { type: integer }
+        last_error: { type: string }
+        worker: { type: string }
+        processed_at: { type: string }
+        next_attempt_at: { type: string }
+    TaskMessageIdempotency:
+      type: object
+      properties:
+        key: { type: string }
+        message_id: { type: string }
+        state: { type: string }
+        updated_at: { type: string }
+        expires_at: { type: string }
+        worker: { type: string }
+    TaskJoinSource:
+      type: object
+      properties:
+        message_id: { type: string }
+        from_agent: { type: string }
+        branch_id: { type: string }
+        timestamp: { type: string }
+        payload: { type: string }
+    TaskJoinState:
+      type: object
+      properties:
+        attempt: { type: integer }
+        node: { type: string }
+        mode: { type: string }
+        expected: { type: integer }
+        quorum_required: { type: integer }
+        activated: { type: boolean }
+        activated_at: { type: string }
+        activated_by: { type: string }
+        sources:
+          type: array
+          items: { $ref: "#/components/schemas/TaskJoinSource" }
+    TaskStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        startedAt: { type: string }
+        completedAt: { type: string }
+        nextAttemptAt: { type: string }
+        attempts: { type: integer }
+        output: { type: object, additionalProperties: { type: string } }
+        assignedWorker: { type: string }
+        claimedBy: { type: string }
+        leaseUntil: { type: string }
+        lastHeartbeat: { type: string }
+        trace:
+          type: array
+          items: { $ref: "#/components/schemas/TaskTraceEvent" }
+        history:
+          type: array
+          items: { $ref: "#/components/schemas/TaskHistoryEvent" }
+        messages:
+          type: array
+          items: { $ref: "#/components/schemas/TaskMessage" }
+        message_idempotency:
+          type: array
+          items: { $ref: "#/components/schemas/TaskMessageIdempotency" }
+        join_states:
+          type: array
+          items: { $ref: "#/components/schemas/TaskJoinState" }
+        observedGeneration: { type: integer, format: int64 }
+    Task:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [Task] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/TaskSpec" }
+        status: { $ref: "#/components/schemas/TaskStatus" }
+    TaskList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/Task" }

--- a/openapi/schemas/tool-approval.yaml
+++ b/openapi/schemas/tool-approval.yaml
@@ -1,0 +1,39 @@
+components:
+  schemas:
+    ToolApprovalSpec:
+      type: object
+      required: [task_ref, tool]
+      properties:
+        task_ref: { type: string }
+        tool: { type: string }
+        operation_class: { type: string }
+        agent: { type: string }
+        input: { type: string }
+        reason: { type: string }
+        ttl: { type: string }
+    ToolApprovalStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        decision: { type: string }
+        decided_by: { type: string }
+        decided_at: { type: string }
+        expires_at: { type: string }
+    ToolApproval:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [ToolApproval] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/ToolApprovalSpec" }
+        status: { $ref: "#/components/schemas/ToolApprovalStatus" }
+    ToolApprovalList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/ToolApproval" }

--- a/openapi/schemas/tool-permission.yaml
+++ b/openapi/schemas/tool-permission.yaml
@@ -1,0 +1,47 @@
+components:
+  schemas:
+    OperationRule:
+      type: object
+      properties:
+        operation_class: { type: string }
+        verdict: { type: string }
+    ToolPermissionSpec:
+      type: object
+      properties:
+        tool_ref: { type: string }
+        action: { type: string }
+        required_permissions:
+          type: array
+          items: { type: string }
+        match_mode: { type: string }
+        apply_mode: { type: string }
+        target_agents:
+          type: array
+          items: { type: string }
+        operation_rules:
+          type: array
+          items: { $ref: "#/components/schemas/OperationRule" }
+    ToolPermissionStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    ToolPermission:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [ToolPermission] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/ToolPermissionSpec" }
+        status: { $ref: "#/components/schemas/ToolPermissionStatus" }
+    ToolPermissionList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/ToolPermission" }

--- a/openapi/schemas/tool.yaml
+++ b/openapi/schemas/tool.yaml
@@ -1,0 +1,67 @@
+components:
+  schemas:
+    ToolRetryPolicy:
+      type: object
+      properties:
+        max_attempts: { type: integer }
+        backoff: { type: string }
+        max_backoff: { type: string }
+        jitter: { type: string }
+    ToolRuntimePolicy:
+      type: object
+      properties:
+        timeout: { type: string }
+        isolation_mode: { type: string }
+        retry: { $ref: "#/components/schemas/ToolRetryPolicy" }
+    ToolAuth:
+      type: object
+      properties:
+        profile: { type: string }
+        secretRef: { type: string }
+        headerName: { type: string }
+        tokenURL: { type: string }
+        scopes:
+          type: array
+          items: { type: string }
+    ToolSpec:
+      type: object
+      properties:
+        type: { type: string }
+        endpoint: { type: string }
+        description: { type: string }
+        input_schema: { type: object, additionalProperties: true }
+        mcp_server_ref: { type: string }
+        mcp_tool_name: { type: string }
+        capabilities:
+          type: array
+          items: { type: string }
+        operation_classes:
+          type: array
+          items: { type: string }
+        risk_level: { type: string }
+        runtime: { $ref: "#/components/schemas/ToolRuntimePolicy" }
+        auth: { $ref: "#/components/schemas/ToolAuth" }
+    ToolStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+    Tool:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [Tool] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/ToolSpec" }
+        status: { $ref: "#/components/schemas/ToolStatus" }
+    ToolList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/Tool" }

--- a/openapi/schemas/worker.yaml
+++ b/openapi/schemas/worker.yaml
@@ -1,0 +1,41 @@
+components:
+  schemas:
+    WorkerCapabilities:
+      type: object
+      properties:
+        gpu: { type: boolean }
+        supported_models:
+          type: array
+          items: { type: string }
+    WorkerSpec:
+      type: object
+      properties:
+        region: { type: string }
+        capabilities: { $ref: "#/components/schemas/WorkerCapabilities" }
+        max_concurrent_tasks: { type: integer }
+    WorkerStatus:
+      type: object
+      properties:
+        phase: { type: string }
+        lastError: { type: string }
+        lastHeartbeat: { type: string }
+        observedGeneration: { type: integer, format: int64 }
+        currentTasks: { type: integer }
+    Worker:
+      type: object
+      required: [apiVersion, kind, metadata, spec]
+      properties:
+        apiVersion: { type: string, enum: [orloj.dev/v1] }
+        kind: { type: string, enum: [Worker] }
+        metadata: { $ref: "common.yaml#/components/schemas/ObjectMeta" }
+        spec: { $ref: "#/components/schemas/WorkerSpec" }
+        status: { $ref: "#/components/schemas/WorkerStatus" }
+    WorkerList:
+      allOf:
+        - { $ref: "common.yaml#/components/schemas/ListMeta" }
+        - type: object
+          required: [items]
+          properties:
+            items:
+              type: array
+              items: { $ref: "#/components/schemas/Worker" }

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,8 @@
+extends:
+  - recommended
+
+rules:
+  operation-summary: off
+  tag-description: off
+  operation-operationId: off
+  operation-4xx-response: off

--- a/resources/manifest_parser_ext.go
+++ b/resources/manifest_parser_ext.go
@@ -893,6 +893,102 @@ func ParseToolPermissionManifest(data []byte) (ToolPermission, error) {
 	return out, nil
 }
 
+// ParseToolApprovalManifest parses ToolApproval resources from JSON or constrained YAML.
+func ParseToolApprovalManifest(data []byte) (ToolApproval, error) {
+	var out ToolApproval
+	if json.Valid(data) {
+		if err := json.Unmarshal(data, &out); err != nil {
+			return ToolApproval{}, fmt.Errorf("failed to decode JSON manifest: %w", err)
+		}
+		if err := out.Normalize(); err != nil {
+			return ToolApproval{}, err
+		}
+		return out, nil
+	}
+
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	section := ""
+	subsection := ""
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		indent := leadingSpaces(line)
+		if section == "metadata" && indent <= 2 && !strings.HasSuffix(trimmed, ":") && !strings.HasPrefix(trimmed, "- ") {
+			subsection = ""
+		}
+		if section == "spec" && indent <= 2 && !strings.HasSuffix(trimmed, ":") && !strings.HasPrefix(trimmed, "- ") {
+			subsection = ""
+		}
+		if section == "status" && indent <= 2 && !strings.HasSuffix(trimmed, ":") && !strings.HasPrefix(trimmed, "- ") {
+			subsection = ""
+		}
+
+		if strings.HasSuffix(trimmed, ":") {
+			switch strings.TrimSuffix(trimmed, ":") {
+			case "metadata":
+				section = "metadata"
+				subsection = ""
+			case "spec":
+				section = "spec"
+				subsection = ""
+			case "status":
+				section = "status"
+				subsection = ""
+			case "labels":
+				if section == "metadata" {
+					subsection = "labels"
+				}
+			}
+			continue
+		}
+
+		key, value, ok := parseKeyValue(trimmed)
+		if !ok {
+			continue
+		}
+		value = stripQuotes(value)
+
+		switch {
+		case key == "apiVersion":
+			out.APIVersion = value
+		case key == "kind":
+			out.Kind = value
+		case section == "metadata" && subsection == "labels" && indent >= 4:
+			if out.Metadata.Labels == nil {
+				out.Metadata.Labels = make(map[string]string)
+			}
+			out.Metadata.Labels[key] = value
+		case section == "metadata":
+			if err := applyObjectMetaField(&out.Metadata, key, value); err != nil {
+				return ToolApproval{}, err
+			}
+		case section == "spec" && (key == "task_ref" || key == "taskRef"):
+			out.Spec.TaskRef = value
+		case section == "spec" && key == "tool":
+			out.Spec.Tool = value
+		case section == "spec" && (key == "operation_class" || key == "operationClass"):
+			out.Spec.OperationClass = value
+		case section == "spec" && key == "agent":
+			out.Spec.Agent = value
+		case section == "spec" && key == "input":
+			out.Spec.Input = value
+		case section == "spec" && key == "reason":
+			out.Spec.Reason = value
+		case section == "spec" && key == "ttl":
+			out.Spec.TTL = value
+		case section == "status" && key == "phase":
+			out.Status.Phase = value
+		}
+	}
+
+	if err := out.Normalize(); err != nil {
+		return ToolApproval{}, err
+	}
+	return out, nil
+}
+
 // ParseTaskManifest parses Task resources from JSON or constrained YAML.
 func ParseTaskManifest(data []byte) (Task, error) {
 	var out Task

--- a/resources/parse_manifest.go
+++ b/resources/parse_manifest.go
@@ -1,0 +1,108 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseManifest parses and normalizes a manifest of a supported kind. kind should be the
+// value from DetectKind (any casing); it is normalized with strings.ToLower(strings.TrimSpace(kind)).
+// On success, normKind is the normalized kind string, name is metadata.name, and obj is the
+// typed resource suitable for json.Marshal (same shape as apply uses).
+func ParseManifest(kind string, raw []byte) (normKind string, name string, obj any, err error) {
+	normKind = strings.ToLower(strings.TrimSpace(kind))
+	switch normKind {
+	case "agent":
+		o, e := ParseAgentManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "agentsystem":
+		o, e := ParseAgentSystemManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "modelendpoint":
+		o, e := ParseModelEndpointManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "tool":
+		o, e := ParseToolManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "secret":
+		o, e := ParseSecretManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "memory":
+		o, e := ParseMemoryManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "agentpolicy":
+		o, e := ParseAgentPolicyManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "agentrole":
+		o, e := ParseAgentRoleManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "toolpermission":
+		o, e := ParseToolPermissionManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "toolapproval":
+		o, e := ParseToolApprovalManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "task":
+		o, e := ParseTaskManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "taskschedule":
+		o, e := ParseTaskScheduleManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "taskwebhook":
+		o, e := ParseTaskWebhookManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "worker":
+		o, e := ParseWorkerManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	case "mcpserver":
+		o, e := ParseMcpServerManifest(raw)
+		if e != nil {
+			return "", "", nil, e
+		}
+		return normKind, o.Metadata.Name, o, nil
+	default:
+		return "", "", nil, fmt.Errorf("unsupported kind %q", normKind)
+	}
+}

--- a/resources/parse_manifest_test.go
+++ b/resources/parse_manifest_test.go
@@ -1,0 +1,62 @@
+package resources
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseManifest_UnsupportedKind(t *testing.T) {
+	raw := []byte(`apiVersion: orloj.dev/v1
+kind: NotAnOrlojKind
+metadata:
+  name: x
+spec: {}
+`)
+	_, _, _, err := ParseManifest("NotAnOrlojKind", raw)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unsupported kind") {
+		t.Fatalf("expected unsupported kind in error, got %v", err)
+	}
+}
+
+func TestParseToolApprovalManifest_JSONMinimal(t *testing.T) {
+	raw := []byte(`{
+  "apiVersion": "orloj.dev/v1",
+  "kind": "ToolApproval",
+  "metadata": { "name": "approval-one" },
+  "spec": { "task_ref": "task/default/t1", "tool": "deploy" }
+}`)
+	a, err := ParseToolApprovalManifest(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Metadata.Name != "approval-one" {
+		t.Fatalf("name %q", a.Metadata.Name)
+	}
+	if a.Spec.TaskRef != "task/default/t1" || a.Spec.Tool != "deploy" {
+		t.Fatalf("spec %+v", a.Spec)
+	}
+}
+
+func TestParseManifest_NormalizesKindCasing(t *testing.T) {
+	raw := []byte(`apiVersion: orloj.dev/v1
+kind: Agent
+metadata:
+  name: casing-test
+spec:
+  model_ref: mep
+  prompt: hi
+`)
+	norm, name, _, err := ParseManifest("AgEnT", raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if norm != "agent" {
+		t.Fatalf("norm kind: got %q", norm)
+	}
+	if name != "casing-test" {
+		t.Fatalf("name: got %q", name)
+	}
+}

--- a/resources/resource_types.go
+++ b/resources/resource_types.go
@@ -215,10 +215,10 @@ func (t *Tool) Normalize() error {
 		toolType = "http"
 	}
 	switch toolType {
-	case "http", "external", "grpc", "queue", "webhook-callback", "mcp":
+	case "http", "external", "grpc", "queue", "webhook-callback", "mcp", "wasm":
 		t.Spec.Type = toolType
 	default:
-		return fmt.Errorf("invalid spec.type %q: expected http, external, grpc, queue, webhook-callback, or mcp", t.Spec.Type)
+		return fmt.Errorf("invalid spec.type %q: expected http, external, grpc, queue, webhook-callback, mcp, or wasm", t.Spec.Type)
 	}
 	t.Spec.McpServerRef = strings.TrimSpace(t.Spec.McpServerRef)
 	t.Spec.McpToolName = strings.TrimSpace(t.Spec.McpToolName)


### PR DESCRIPTION
- Ship OpenAPI 3.1 for the v1 API (lint in CI; schemas/paths as added)
- orlojctl apply -f accepts files or directories (manifestPaths + aggregated errors)
- Add five-minute tutorial; link from docs home, guides, README, quickstart
- CHANGELOG [Unreleased] updates