### PR TITLE
feat(auth): native multi-user mode, API tokens, and admin surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Native multi-user authentication** (`--auth-mode native`): local username/password auth with bcrypt-hashed passwords, session cookies, and role-based access control.
+- **API token management**: named bearer tokens stored with SHA-256 hashes. CRUD via `POST /v1/tokens`, `GET /v1/tokens`, `DELETE /v1/tokens/{name}` (admin-only).
+- **Multi-user admin API**: `POST /v1/auth/users`, `GET /v1/auth/users`, `DELETE /v1/auth/users/{username}` for managing local accounts (admin-only). Server-generated passwords returned once on creation.
+- **Named bearer token format**: `name:token:role` alongside the existing legacy `token:role` format; env tokens (`ORLOJ_API_TOKENS`) checked first, then store-managed tokens.
+- **First-user bootstrap**: `/v1/auth/setup` creates the initial admin account; optionally protected by `ORLOJ_SETUP_TOKEN` env var.
+- **Auth identity propagation**: bearer and session callers carry `AuthIdentity` (name, role, method) through request context for audit logging. Bearer principals logged as `token-name` or `bearer:<role>`.
+- **Audit logging for admin operations**: token and user create/delete events emitted via the audit extension with principal, resource kind, and action.
+- `orlojctl`: `create token`, `get tokens`, `delete token` commands for API token lifecycle.
+- `orlojctl`: `admin create-user`, `admin list-users`, `admin delete-user` commands for local user management.
+- `orlojctl`: `auth whoami` queries `/v1/auth/me` and prints current identity.
+- `orlojctl`: `admin reset-password --username ... --new-password ...` for targeted password resets (invalidates target sessions).
 - `orlojctl`: global `--namespace` / `-n` default for namespace-aware commands; `apply` supports `--dry-run` and optional namespace override on manifest payloads.
 - `orlojctl`: `approve` / `deny` for pending tool approvals (`tool-approval`), with optional `--decided-by`, `--reason`, and namespace flags.
 - `orlojctl`: richer `get` (fetch by resource name, `-o table|json|yaml`, `tool-approvals` list view, memory entry listing, namespace filter for task watch).
 - `orlojctl`: `describe`, `edit`, `diff`, `wait`, `cancel task`, `retry task`, `top`, `messages`, `metrics`, `health`, `status`, and shell `completion` (bash/zsh/fish).
 - OpenAPI: optional `reason` on the tool approval decision request body (`openapi/schemas/common.yaml`).
+- OpenAPI: full schema and endpoint documentation for all OSS auth and token endpoints.
+- PostgreSQL migration `009_auth_users_and_tokens` creating `auth_local_users` and `auth_api_tokens` tables with backfill from env-configured admin credentials.
+- Startup warning when `--auth-mode native` is active but `ORLOJ_SETUP_TOKEN` is not set.
 
 ### Changed
 
+- `/v1/auth/me` now returns identity fields (`method`, `name`, `role`, compat `username`) for UI/CLI bootstrap.
+- `/v1/auth/admin/reset-password` requires an explicit `username` field and invalidates the target user's sessions.
+- Native session authorization now uses the actual logged-in user's role instead of a hardcoded default.
 - `orlojctl`: `main` exits with `cli.ExitCode(err)` so coded CLI errors can use non-default exit statuses.
+
+### Fixed
+
+- API: SSE watch endpoints (`/v1/events/watch`, resource `…/watch` URLs) work again when requests use bearer authentication (the auth middleware response wrapper now forwards `Flush` to the underlying connection).
+- API: session deletion failures after password change, password reset, and user deletion are now logged instead of silently ignored.
+- OpenAPI: `/v1/auth/change-password` spec now correctly declares authentication as required (matching the actual server behavior).
 
 ## [0.3.0] - 2026-03-29
 

--- a/api/auth_admin_handlers.go
+++ b/api/auth_admin_handlers.go
@@ -1,0 +1,303 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	agentruntime "github.com/OrlojHQ/orloj/runtime"
+	"github.com/OrlojHQ/orloj/store"
+)
+
+type createTokenRequest struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+type tokenMetadataResponse struct {
+	Name      string `json:"name"`
+	Role      string `json:"role"`
+	CreatedAt string `json:"created_at"`
+}
+
+type tokenCreateResponse struct {
+	Name      string `json:"name"`
+	Role      string `json:"role"`
+	CreatedAt string `json:"created_at"`
+	Token     string `json:"token"`
+}
+
+type tokenListResponse struct {
+	Items []tokenMetadataResponse `json:"items"`
+}
+
+type createAuthUserRequest struct {
+	Username string `json:"username"`
+	Role     string `json:"role"`
+}
+
+type authUserResponse struct {
+	Username  string `json:"username"`
+	Role      string `json:"role"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type authUserCreateResponse struct {
+	Username  string `json:"username"`
+	Role      string `json:"role"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+	Password  string `json:"password"`
+}
+
+type authUserListResponse struct {
+	Items []authUserResponse `json:"items"`
+}
+
+func (s *Server) handleTokens(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		records, err := s.stores.APITokens.List()
+		if err != nil {
+			http.Error(w, "token store error", http.StatusInternalServerError)
+			return
+		}
+		resp := tokenListResponse{Items: make([]tokenMetadataResponse, 0, len(records))}
+		for _, record := range records {
+			resp.Items = append(resp.Items, tokenMetadataResponse{
+				Name:      record.Name,
+				Role:      record.Role,
+				CreatedAt: record.CreatedAt,
+			})
+		}
+		writeJSON(w, http.StatusOK, resp)
+	case http.MethodPost:
+		var req createTokenRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		req.Name = strings.TrimSpace(req.Name)
+		if req.Name == "" {
+			http.Error(w, "name is required", http.StatusBadRequest)
+			return
+		}
+		rawToken, err := store.GenerateOpaqueCredential(32)
+		if err != nil {
+			http.Error(w, "failed to generate token", http.StatusInternalServerError)
+			return
+		}
+		record, err := s.stores.APITokens.Create(req.Name, hashToken(rawToken), req.Role, time.Now().UTC())
+		if err != nil {
+			switch {
+			case errors.Is(err, store.ErrAPITokenExists):
+				http.Error(w, "token already exists", http.StatusConflict)
+			case errors.Is(err, store.ErrInvalidAuthRole):
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			default:
+				http.Error(w, "failed to create token", http.StatusInternalServerError)
+			}
+			return
+		}
+		s.emitAdminAudit(r, "token.create", "api-token", record.Name, fmt.Sprintf("created API token %q with role %s", record.Name, record.Role))
+		writeJSON(w, http.StatusCreated, tokenCreateResponse{
+			Name:      record.Name,
+			Role:      record.Role,
+			CreatedAt: record.CreatedAt,
+			Token:     rawToken,
+		})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleTokenByName(w http.ResponseWriter, r *http.Request) {
+	name := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v1/tokens/"), "/")
+	if name == "" {
+		http.Error(w, "token name is required", http.StatusBadRequest)
+		return
+	}
+	if strings.Contains(name, "/") {
+		http.Error(w, "invalid token name", http.StatusBadRequest)
+		return
+	}
+	decoded, err := url.PathUnescape(name)
+	if err == nil {
+		name = strings.TrimSpace(decoded)
+	}
+	if name == "" {
+		http.Error(w, "token name is required", http.StatusBadRequest)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodDelete:
+		err := s.stores.APITokens.Delete(name)
+		if err != nil {
+			switch {
+			case errors.Is(err, store.ErrAPITokenNotFound):
+				http.Error(w, "token not found", http.StatusNotFound)
+			default:
+				http.Error(w, "failed to delete token", http.StatusInternalServerError)
+			}
+			return
+		}
+		s.emitAdminAudit(r, "token.delete", "api-token", name, fmt.Sprintf("deleted API token %q", name))
+		writeJSON(w, http.StatusOK, map[string]string{"status": "token deleted"})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleAuthUsers(w http.ResponseWriter, r *http.Request) {
+	if s.authMode != AuthModeNative {
+		http.Error(w, "user management is only available in native mode", http.StatusBadRequest)
+		return
+	}
+	identity, ok := s.authorizeAdminRequestWithIdentity(w, r)
+	if !ok {
+		return
+	}
+	auditReq := r.WithContext(withAuthIdentity(r.Context(), identity))
+
+	switch r.Method {
+	case http.MethodGet:
+		users, err := s.stores.LocalAdmins.ListUsers()
+		if err != nil {
+			http.Error(w, "auth store error", http.StatusInternalServerError)
+			return
+		}
+		items := make([]authUserResponse, 0, len(users))
+		for _, user := range users {
+			items = append(items, authUserResponse{
+				Username:  user.Username,
+				Role:      user.Role,
+				CreatedAt: user.CreatedAt,
+				UpdatedAt: user.UpdatedAt,
+			})
+		}
+		writeJSON(w, http.StatusOK, authUserListResponse{Items: items})
+	case http.MethodPost:
+		var req createAuthUserRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		req.Username = strings.TrimSpace(req.Username)
+		if req.Username == "" {
+			http.Error(w, "username is required", http.StatusBadRequest)
+			return
+		}
+		password, err := store.GenerateOpaqueCredential(24)
+		if err != nil {
+			http.Error(w, "failed to generate password", http.StatusInternalServerError)
+			return
+		}
+		hash, err := store.GeneratePasswordHash(password)
+		if err != nil {
+			http.Error(w, "failed to hash password", http.StatusInternalServerError)
+			return
+		}
+		user, err := s.stores.LocalAdmins.CreateUser(req.Username, hash, req.Role)
+		if err != nil {
+			switch {
+			case errors.Is(err, store.ErrAuthUserExists):
+				http.Error(w, "user already exists", http.StatusConflict)
+			case errors.Is(err, store.ErrInvalidAuthRole):
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			default:
+				http.Error(w, "failed to create user", http.StatusInternalServerError)
+			}
+			return
+		}
+		s.emitAdminAudit(auditReq, "user.create", "auth-user", user.Username, fmt.Sprintf("created user %q with role %s", user.Username, user.Role))
+		writeJSON(w, http.StatusCreated, authUserCreateResponse{
+			Username:  user.Username,
+			Role:      user.Role,
+			CreatedAt: user.CreatedAt,
+			UpdatedAt: user.UpdatedAt,
+			Password:  password,
+		})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleAuthUserByName(w http.ResponseWriter, r *http.Request) {
+	if s.authMode != AuthModeNative {
+		http.Error(w, "user management is only available in native mode", http.StatusBadRequest)
+		return
+	}
+	identity, ok := s.authorizeAdminRequestWithIdentity(w, r)
+	if !ok {
+		return
+	}
+	auditReq := r.WithContext(withAuthIdentity(r.Context(), identity))
+
+	username := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v1/auth/users/"), "/")
+	if username == "" {
+		http.Error(w, "username is required", http.StatusBadRequest)
+		return
+	}
+	if strings.Contains(username, "/") {
+		http.Error(w, "invalid username", http.StatusBadRequest)
+		return
+	}
+	decoded, err := url.PathUnescape(username)
+	if err == nil {
+		username = strings.TrimSpace(decoded)
+	}
+	if username == "" {
+		http.Error(w, "username is required", http.StatusBadRequest)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodDelete:
+		err := s.stores.LocalAdmins.DeleteUser(username)
+		if err != nil {
+			switch {
+			case errors.Is(err, store.ErrAuthUserNotFound):
+				http.Error(w, "user not found", http.StatusNotFound)
+			case errors.Is(err, store.ErrAuthLastAdmin):
+				http.Error(w, err.Error(), http.StatusConflict)
+			default:
+				http.Error(w, "failed to delete user", http.StatusInternalServerError)
+			}
+			return
+		}
+		if delErr := s.stores.AuthSessions.DeleteByUsername(username); delErr != nil && s.logger != nil {
+			s.logger.Printf("WARNING: failed to invalidate sessions after deleting user %s: %v", username, delErr)
+		}
+		s.emitAdminAudit(auditReq, "user.delete", "auth-user", username, fmt.Sprintf("deleted user %q", username))
+		writeJSON(w, http.StatusOK, map[string]string{"status": "user deleted"})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// emitAdminAudit records an audit event for admin-only auth operations
+// (token and user CRUD).  The caller's identity is extracted from the
+// request context (set by the authorization middleware or session layer).
+func (s *Server) emitAdminAudit(r *http.Request, action, resourceKind, resourceName, message string) {
+	identity, _ := AuthIdentityFromRequest(r)
+	principal := strings.TrimSpace(identity.Name)
+	if principal == "" {
+		principal = "unknown"
+	}
+	s.extensions.Audit.RecordAudit(r.Context(), agentruntime.AuditEvent{
+		Timestamp:    time.Now().UTC().Format(time.RFC3339Nano),
+		Component:    "apiserver",
+		Action:       action,
+		Outcome:      "success",
+		ResourceKind: resourceKind,
+		ResourceName: resourceName,
+		Principal:    principal,
+		Message:      message,
+	})
+}

--- a/api/auth_context.go
+++ b/api/auth_context.go
@@ -10,6 +10,7 @@ type authContextKey struct{}
 // AuthIdentity carries the authenticated caller's identity through the
 // request context for audit logging and downstream authorization.
 type AuthIdentity struct {
+	Name   string // token name (bearer) or username (session)
 	Role   string
 	Method string // "bearer", "session", "none"
 }

--- a/api/auth_handlers.go
+++ b/api/auth_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"strings"
@@ -26,11 +27,13 @@ type authRequest struct {
 type authMeResponse struct {
 	Authenticated bool   `json:"authenticated"`
 	Username      string `json:"username,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Role          string `json:"role,omitempty"`
 	Method        string `json:"method,omitempty"`
 }
 
 type authResetPasswordRequest struct {
-	Username    string `json:"username,omitempty"`
+	Username    string `json:"username"`
 	NewPassword string `json:"new_password"`
 }
 
@@ -48,12 +51,12 @@ func (s *Server) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
 	switch s.authMode {
 	case AuthModeNative:
 		resp.LoginMethods = []string{"password"}
-		hasAdmin, err := s.stores.LocalAdmins.HasAdmin()
+		userCount, err := s.stores.LocalAdmins.CountUsers()
 		if err != nil {
 			http.Error(w, "auth store error", http.StatusInternalServerError)
 			return
 		}
-		resp.SetupRequired = !hasAdmin
+		resp.SetupRequired = userCount == 0
 	case AuthModeSSO:
 		resp.LoginMethods = []string{"sso"}
 	default:
@@ -97,12 +100,12 @@ func (s *Server) handleAuthSetup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	hasAdmin, err := s.stores.LocalAdmins.HasAdmin()
+	userCount, err := s.stores.LocalAdmins.CountUsers()
 	if err != nil {
 		http.Error(w, "auth store error", http.StatusInternalServerError)
 		return
 	}
-	if hasAdmin {
+	if userCount > 0 {
 		http.Error(w, "admin account is already configured", http.StatusConflict)
 		return
 	}
@@ -111,17 +114,28 @@ func (s *Server) handleAuthSetup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to hash password", http.StatusInternalServerError)
 		return
 	}
-	if err := s.stores.LocalAdmins.Upsert(req.Username, hash); err != nil {
+	user, err := s.stores.LocalAdmins.CreateUser(req.Username, hash, "admin")
+	if err != nil {
+		if errors.Is(err, store.ErrAuthUserExists) {
+			http.Error(w, "admin account is already configured", http.StatusConflict)
+			return
+		}
 		http.Error(w, "failed to store admin account", http.StatusInternalServerError)
 		return
 	}
-	session, err := s.stores.AuthSessions.Create(req.Username, s.sessionTTL, time.Now().UTC())
+	session, err := s.stores.AuthSessions.Create(user.Username, s.sessionTTL, time.Now().UTC())
 	if err != nil {
 		http.Error(w, "failed to create session", http.StatusInternalServerError)
 		return
 	}
 	s.setSessionCookie(w, r, session.ID, s.sessionTTL)
-	writeJSON(w, http.StatusCreated, authMeResponse{Authenticated: true, Username: req.Username, Method: "session"})
+	writeJSON(w, http.StatusCreated, authMeResponse{
+		Authenticated: true,
+		Username:      user.Username,
+		Name:          user.Username,
+		Role:          user.Role,
+		Method:        "session",
+	})
 }
 
 func (s *Server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
@@ -147,32 +161,43 @@ func (s *Server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "username is required", http.StatusBadRequest)
 		return
 	}
-	admin, hasAdmin, err := s.stores.LocalAdmins.Get()
+	user, ok, err := s.stores.LocalAdmins.GetByUsername(req.Username)
 	if err != nil {
 		http.Error(w, "auth store error", http.StatusInternalServerError)
 		return
 	}
-	if !hasAdmin {
-		http.Error(w, "admin setup required", http.StatusConflict)
-		return
-	}
-	if !strings.EqualFold(admin.Username, req.Username) {
+	if !ok {
+		userCount, countErr := s.stores.LocalAdmins.CountUsers()
+		if countErr != nil {
+			http.Error(w, "auth store error", http.StatusInternalServerError)
+			return
+		}
+		if userCount == 0 {
+			http.Error(w, "admin setup required", http.StatusConflict)
+			return
+		}
 		http.Error(w, "invalid credentials", http.StatusUnauthorized)
 		return
 	}
-	ok, err := store.VerifyPasswordHash(admin.PasswordHash, req.Password)
+	ok, err = store.VerifyPasswordHash(user.PasswordHash, req.Password)
 	if err != nil || !ok {
 		http.Error(w, "invalid credentials", http.StatusUnauthorized)
 		return
 	}
 	_ = s.stores.AuthSessions.DeleteExpired(time.Now().UTC())
-	session, err := s.stores.AuthSessions.Create(admin.Username, s.sessionTTL, time.Now().UTC())
+	session, err := s.stores.AuthSessions.Create(user.Username, s.sessionTTL, time.Now().UTC())
 	if err != nil {
 		http.Error(w, "failed to create session", http.StatusInternalServerError)
 		return
 	}
 	s.setSessionCookie(w, r, session.ID, s.sessionTTL)
-	writeJSON(w, http.StatusOK, authMeResponse{Authenticated: true, Username: admin.Username, Method: "session"})
+	writeJSON(w, http.StatusOK, authMeResponse{
+		Authenticated: true,
+		Username:      user.Username,
+		Name:          user.Username,
+		Role:          user.Role,
+		Method:        "session",
+	})
 }
 
 func (s *Server) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
@@ -197,29 +222,45 @@ func (s *Server) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if s.authMode != AuthModeNative {
-		writeJSON(w, http.StatusOK, authMeResponse{Authenticated: true, Method: "none"})
+	if s.authMode == AuthModeNative {
+		user, ok, err := s.authenticatedSessionUser(r, true)
+		if err != nil {
+			http.Error(w, "auth store error", http.StatusInternalServerError)
+			return
+		}
+		if ok {
+			writeJSON(w, http.StatusOK, authMeResponse{
+				Authenticated: true,
+				Username:      user.Username,
+				Name:          user.Username,
+				Role:          user.Role,
+				Method:        "session",
+			})
+			return
+		}
+		if bearerToken(r.Header.Get("Authorization")) != "" {
+			allowed, status, _, identity := authorizeWithIdentity(s.authorizer, r, "reader")
+			if status >= 500 {
+				http.Error(w, "authorization lookup failed", http.StatusInternalServerError)
+				return
+			}
+			if allowed {
+				writeJSON(w, http.StatusOK, authMeFromIdentity(identity, true))
+				return
+			}
+		}
+		writeJSON(w, http.StatusOK, authMeResponse{Authenticated: false})
 		return
 	}
 
-	if sessionID := readSessionID(r); sessionID != "" {
-		session, ok, err := s.stores.AuthSessions.Get(sessionID)
-		if err == nil && ok {
-			expiresAt, parseErr := time.Parse(time.RFC3339Nano, session.ExpiresAt)
-			if parseErr == nil && expiresAt.After(time.Now().UTC()) {
-				_ = s.stores.AuthSessions.Touch(sessionID, s.sessionTTL, time.Now().UTC())
-				writeJSON(w, http.StatusOK, authMeResponse{Authenticated: true, Username: session.Username, Method: "session"})
-				return
-			}
-			_ = s.stores.AuthSessions.Delete(sessionID)
-		}
+	allowed, status, _, identity := authorizeWithIdentity(s.authorizer, r, "reader")
+	if status >= 500 {
+		http.Error(w, "authorization lookup failed", http.StatusInternalServerError)
+		return
 	}
-
-	if s.authorizer != nil {
-		if allowed, _, _ := s.authorizer.Authorize(r, "reader"); allowed {
-			writeJSON(w, http.StatusOK, authMeResponse{Authenticated: true, Method: "bearer"})
-			return
-		}
+	if allowed {
+		writeJSON(w, http.StatusOK, authMeFromIdentity(identity, true))
+		return
 	}
 	writeJSON(w, http.StatusOK, authMeResponse{Authenticated: false})
 }
@@ -252,43 +293,18 @@ func (s *Server) handleAuthChangePassword(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	admin, hasAdmin, err := s.stores.LocalAdmins.Get()
+	user, ok, err := s.authenticatedSessionUser(r, true)
 	if err != nil {
 		http.Error(w, "auth store error", http.StatusInternalServerError)
 		return
 	}
-	if !hasAdmin {
-		http.Error(w, "admin setup required", http.StatusConflict)
-		return
-	}
-
-	authenticated := false
-	if sessionID := readSessionID(r); sessionID != "" {
-		session, ok, sessionErr := s.stores.AuthSessions.Get(sessionID)
-		if sessionErr != nil {
-			http.Error(w, "session lookup failed", http.StatusInternalServerError)
-			return
-		}
-		if ok {
-			expiresAt, parseErr := time.Parse(time.RFC3339Nano, session.ExpiresAt)
-			if parseErr == nil && expiresAt.After(time.Now().UTC()) && strings.EqualFold(session.Username, admin.Username) {
-				authenticated = true
-			} else if parseErr != nil || !expiresAt.After(time.Now().UTC()) {
-				_ = s.stores.AuthSessions.Delete(sessionID)
-			}
-		}
-	}
-	if !authenticated && s.authorizer != nil {
-		allowed, _, _ := s.authorizer.Authorize(r, "admin")
-		authenticated = allowed
-	}
-	if !authenticated {
+	if !ok {
 		http.Error(w, "authentication required", http.StatusUnauthorized)
 		return
 	}
 
-	ok, verifyErr := store.VerifyPasswordHash(admin.PasswordHash, req.CurrentPassword)
-	if verifyErr != nil || !ok {
+	passwordOK, verifyErr := store.VerifyPasswordHash(user.PasswordHash, req.CurrentPassword)
+	if verifyErr != nil || !passwordOK {
 		http.Error(w, "invalid current password", http.StatusUnauthorized)
 		return
 	}
@@ -298,11 +314,13 @@ func (s *Server) handleAuthChangePassword(w http.ResponseWriter, r *http.Request
 		http.Error(w, "failed to hash password", http.StatusInternalServerError)
 		return
 	}
-	if upsertErr := s.stores.LocalAdmins.Upsert(admin.Username, hash); upsertErr != nil {
+	if setErr := s.stores.LocalAdmins.SetPassword(user.Username, hash); setErr != nil {
 		http.Error(w, "failed to update password", http.StatusInternalServerError)
 		return
 	}
-	_ = s.stores.AuthSessions.DeleteByUsername(admin.Username)
+	if delErr := s.stores.AuthSessions.DeleteByUsername(user.Username); delErr != nil && s.logger != nil {
+		s.logger.Printf("WARNING: failed to invalidate sessions after password change for %s: %v", user.Username, delErr)
+	}
 	s.clearSessionCookie(w, r)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "password changed"})
 }
@@ -320,15 +338,8 @@ func (s *Server) handleAuthAdminResetPassword(w http.ResponseWriter, r *http.Req
 		http.Error(w, "password reset is only available in native mode", http.StatusBadRequest)
 		return
 	}
-	if s.authorizer != nil {
-		allowed, status, message := s.authorizer.Authorize(r, "admin")
-		if !allowed {
-			if status <= 0 {
-				status = http.StatusForbidden
-			}
-			http.Error(w, strings.TrimSpace(message), status)
-			return
-		}
+	if !s.authorizeAdminRequest(w, r) {
+		return
 	}
 
 	var req authResetPasswordRequest
@@ -337,21 +348,22 @@ func (s *Server) handleAuthAdminResetPassword(w http.ResponseWriter, r *http.Req
 		return
 	}
 	req.Username = strings.TrimSpace(req.Username)
+	if req.Username == "" {
+		http.Error(w, "username is required", http.StatusBadRequest)
+		return
+	}
 	if err := store.ValidatePasswordPolicy(req.NewPassword, 12); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	admin, hasAdmin, err := s.stores.LocalAdmins.Get()
+
+	_, hasUser, err := s.stores.LocalAdmins.GetByUsername(req.Username)
 	if err != nil {
 		http.Error(w, "auth store error", http.StatusInternalServerError)
 		return
 	}
-	if !hasAdmin {
-		http.Error(w, "admin setup required", http.StatusConflict)
-		return
-	}
-	if req.Username != "" && !strings.EqualFold(req.Username, admin.Username) {
-		http.Error(w, "only the existing admin username may be reset", http.StatusBadRequest)
+	if !hasUser {
+		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
 
@@ -360,13 +372,110 @@ func (s *Server) handleAuthAdminResetPassword(w http.ResponseWriter, r *http.Req
 		http.Error(w, "failed to hash password", http.StatusInternalServerError)
 		return
 	}
-	if err := s.stores.LocalAdmins.Upsert(admin.Username, hash); err != nil {
+	if err := s.stores.LocalAdmins.SetPassword(req.Username, hash); err != nil {
+		if errors.Is(err, store.ErrAuthUserNotFound) {
+			http.Error(w, "user not found", http.StatusNotFound)
+			return
+		}
 		http.Error(w, "failed to reset password", http.StatusInternalServerError)
 		return
 	}
-	_ = s.stores.AuthSessions.DeleteByUsername(admin.Username)
-	s.clearSessionCookie(w, r)
+	currentUser, hasCurrentSession, currentSessionErr := s.authenticatedSessionUser(r, false)
+	if currentSessionErr != nil && s.logger != nil {
+		s.logger.Printf("WARNING: failed to resolve current session during password reset for %s: %v", req.Username, currentSessionErr)
+	}
+	if delErr := s.stores.AuthSessions.DeleteByUsername(req.Username); delErr != nil && s.logger != nil {
+		s.logger.Printf("WARNING: failed to invalidate sessions after password reset for %s: %v", req.Username, delErr)
+	}
+	if hasCurrentSession && strings.EqualFold(currentUser.Username, req.Username) {
+		s.clearSessionCookie(w, r)
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "password reset"})
+}
+
+func authMeFromIdentity(identity AuthIdentity, authenticated bool) authMeResponse {
+	name := strings.TrimSpace(identity.Name)
+	method := strings.ToLower(strings.TrimSpace(identity.Method))
+	role := strings.ToLower(strings.TrimSpace(identity.Role))
+	resp := authMeResponse{
+		Authenticated: authenticated,
+		Name:          name,
+		Role:          role,
+		Method:        method,
+	}
+	if method == "session" {
+		resp.Username = name
+	}
+	return resp
+}
+
+func authorizeWithIdentity(authorizer RequestAuthorizer, r *http.Request, requiredRole string) (bool, int, string, AuthIdentity) {
+	if authorizer == nil {
+		return true, 0, "", AuthIdentity{Method: "none"}
+	}
+	if withIdentity, ok := authorizer.(IdentityAuthorizer); ok {
+		return withIdentity.AuthorizeWithIdentity(r, requiredRole)
+	}
+	allowed, statusCode, message := authorizer.Authorize(r, requiredRole)
+	identity := AuthIdentity{}
+	if allowed {
+		identity = AuthIdentity{
+			Role:   strings.TrimSpace(requiredRole),
+			Method: "bearer",
+		}
+	}
+	return allowed, statusCode, message, identity
+}
+
+func (s *Server) authorizeAdminRequest(w http.ResponseWriter, r *http.Request) bool {
+	_, ok := s.authorizeAdminRequestWithIdentity(w, r)
+	return ok
+}
+
+// authorizeAdminRequestWithIdentity performs admin authorization and returns
+// the caller's identity for audit logging.  On failure it writes an HTTP error
+// and returns (zero, false).
+func (s *Server) authorizeAdminRequestWithIdentity(w http.ResponseWriter, r *http.Request) (AuthIdentity, bool) {
+	allowed, status, message, identity := authorizeWithIdentity(s.authorizer, r, "admin")
+	if allowed {
+		return identity, true
+	}
+	if status <= 0 {
+		status = http.StatusForbidden
+	}
+	http.Error(w, strings.TrimSpace(message), status)
+	return AuthIdentity{}, false
+}
+
+func (s *Server) authenticatedSessionUser(r *http.Request, touch bool) (store.LocalAdminAccount, bool, error) {
+	sessionID := readSessionID(r)
+	if sessionID == "" {
+		return store.LocalAdminAccount{}, false, nil
+	}
+	session, ok, err := s.stores.AuthSessions.Get(sessionID)
+	if err != nil {
+		return store.LocalAdminAccount{}, false, err
+	}
+	if !ok {
+		return store.LocalAdminAccount{}, false, nil
+	}
+	expiresAt, parseErr := time.Parse(time.RFC3339Nano, session.ExpiresAt)
+	if parseErr != nil || !expiresAt.After(time.Now().UTC()) {
+		_ = s.stores.AuthSessions.Delete(sessionID)
+		return store.LocalAdminAccount{}, false, nil
+	}
+	user, found, err := s.stores.LocalAdmins.GetByUsername(session.Username)
+	if err != nil {
+		return store.LocalAdminAccount{}, false, err
+	}
+	if !found {
+		_ = s.stores.AuthSessions.Delete(sessionID)
+		return store.LocalAdminAccount{}, false, nil
+	}
+	if touch {
+		_ = s.stores.AuthSessions.Touch(sessionID, s.sessionTTL, time.Now().UTC())
+	}
+	return user, true, nil
 }
 
 func (s *Server) setSessionCookie(w http.ResponseWriter, r *http.Request, sessionID string, ttl time.Duration) {

--- a/api/auth_native_authorizer.go
+++ b/api/auth_native_authorizer.go
@@ -19,6 +19,10 @@ func (noAuthAuthorizer) Authorize(_ *http.Request, _ string) (bool, int, string)
 	return true, 0, ""
 }
 
+func (noAuthAuthorizer) AuthorizeWithIdentity(_ *http.Request, _ string) (bool, int, string, AuthIdentity) {
+	return true, 0, "", AuthIdentity{Method: "none"}
+}
+
 type nativeModeAuthorizer struct {
 	tokenAuthorizer RequestAuthorizer
 	admins          *store.LocalAdminStore
@@ -48,42 +52,66 @@ func newNativeModeAuthorizer(tokenAuthorizer RequestAuthorizer, admins *store.Lo
 }
 
 func (a nativeModeAuthorizer) Authorize(r *http.Request, requiredRole string) (bool, int, string) {
+	allowed, statusCode, message, _ := a.AuthorizeWithIdentity(r, requiredRole)
+	return allowed, statusCode, message
+}
+
+func (a nativeModeAuthorizer) AuthorizeWithIdentity(r *http.Request, requiredRole string) (bool, int, string, AuthIdentity) {
 	if strings.TrimSpace(requiredRole) == "" {
-		return true, 0, ""
+		return true, 0, "", AuthIdentity{Method: "none"}
 	}
 
 	hasAdmin, err := a.admins.HasAdmin()
 	if err != nil {
-		return false, http.StatusInternalServerError, "auth store error"
+		return false, http.StatusInternalServerError, "auth store error", AuthIdentity{}
 	}
 	if !hasAdmin {
-		return false, http.StatusUnauthorized, "admin setup required"
+		return false, http.StatusUnauthorized, "admin setup required", AuthIdentity{}
 	}
 
 	sessionID := readSessionID(r)
 	if sessionID != "" {
 		session, ok, err := a.sessions.Get(sessionID)
 		if err != nil {
-			return false, http.StatusInternalServerError, "session lookup failed"
+			return false, http.StatusInternalServerError, "session lookup failed", AuthIdentity{}
 		}
 		if ok {
 			expiresAt, err := time.Parse(time.RFC3339Nano, session.ExpiresAt)
 			if err != nil || !expiresAt.After(time.Now().UTC()) {
 				_ = a.sessions.Delete(sessionID)
-				return false, http.StatusUnauthorized, "session expired"
+				return false, http.StatusUnauthorized, "session expired", AuthIdentity{}
+			}
+			user, found, err := a.admins.GetByUsername(session.Username)
+			if err != nil {
+				return false, http.StatusInternalServerError, "auth store error", AuthIdentity{}
+			}
+			if !found {
+				_ = a.sessions.Delete(sessionID)
+				return false, http.StatusUnauthorized, "session user not found", AuthIdentity{}
+			}
+			if !roleAllows(user.Role, requiredRole) {
+				return false, http.StatusForbidden, "forbidden", AuthIdentity{}
 			}
 			_ = a.sessions.Touch(sessionID, a.sessionTTL, time.Now().UTC())
-			return true, 0, ""
+			return true, 0, "", AuthIdentity{
+				Name:   user.Username,
+				Role:   strings.ToLower(strings.TrimSpace(user.Role)),
+				Method: "session",
+			}
 		}
 	}
 
 	if a.tokenAuthorizer != nil {
 		if bearerToken(r.Header.Get("Authorization")) == "" {
-			return false, http.StatusUnauthorized, "missing credentials"
+			return false, http.StatusUnauthorized, "missing credentials", AuthIdentity{}
 		}
-		return a.tokenAuthorizer.Authorize(r, requiredRole)
+		if withIdentity, ok := a.tokenAuthorizer.(IdentityAuthorizer); ok {
+			return withIdentity.AuthorizeWithIdentity(r, requiredRole)
+		}
+		allowed, status, message := a.tokenAuthorizer.Authorize(r, requiredRole)
+		return allowed, status, message, AuthIdentity{Method: "bearer", Role: strings.TrimSpace(requiredRole)}
 	}
-	return false, http.StatusUnauthorized, "missing credentials"
+	return false, http.StatusUnauthorized, "missing credentials", AuthIdentity{}
 }
 
 func readSessionID(r *http.Request) string {

--- a/api/auth_native_test.go
+++ b/api/auth_native_test.go
@@ -179,7 +179,7 @@ func TestNativeAuthAdminResetPassword(t *testing.T) {
 
 	_, _ = client.Post(server.URL+"/v1/auth/setup", "application/json", bytes.NewReader([]byte(`{"username":"admin","password":"very-strong-pass"}`)))
 
-	resetBody := []byte(`{"new_password":"another-strong-pass"}`)
+	resetBody := []byte(`{"username":"admin","new_password":"another-strong-pass"}`)
 	resp, err := client.Post(server.URL+"/v1/auth/admin/reset-password", "application/json", bytes.NewReader(resetBody))
 	if err != nil {
 		t.Fatalf("reset request failed: %v", err)
@@ -187,6 +187,15 @@ func TestNativeAuthAdminResetPassword(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 200 reset, got %d body=%s", resp.StatusCode, string(body))
+	}
+	var sawClearedSessionCookie bool
+	for _, cookie := range resp.Cookies() {
+		if (cookie.Name == "orloj_session" || cookie.Name == "__Host-orloj_session") && cookie.MaxAge < 0 {
+			sawClearedSessionCookie = true
+		}
+	}
+	if !sawClearedSessionCookie {
+		t.Fatalf("expected reset response to clear session cookie, cookies=%+v", resp.Cookies())
 	}
 	resp.Body.Close()
 

--- a/api/auth_native_users_test.go
+++ b/api/auth_native_users_test.go
@@ -1,0 +1,326 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"testing"
+
+	"github.com/OrlojHQ/orloj/api"
+	agentruntime "github.com/OrlojHQ/orloj/runtime"
+)
+
+func TestNativeAuthUserCRUDAndRoleEnforcement(t *testing.T) {
+	server := newNativeAuthServer(t)
+	defer server.Close()
+
+	adminJar, _ := cookiejar.New(nil)
+	adminClient := &http.Client{Jar: adminJar}
+	setupResp, err := adminClient.Post(server.URL+"/v1/auth/setup", "application/json", bytes.NewReader([]byte(`{"username":"admin","password":"very-strong-pass"}`)))
+	if err != nil {
+		t.Fatalf("setup request failed: %v", err)
+	}
+	setupResp.Body.Close()
+
+	createUserBody := []byte(`{"username":"reader-user","role":"reader"}`)
+	resp, err := adminClient.Post(server.URL+"/v1/auth/users", "application/json", bytes.NewReader(createUserBody))
+	if err != nil {
+		t.Fatalf("create user request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 201 create user, got %d body=%s", resp.StatusCode, string(body))
+	}
+	var created struct {
+		Username string `json:"username"`
+		Role     string `json:"role"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		resp.Body.Close()
+		t.Fatalf("decode create user response failed: %v", err)
+	}
+	resp.Body.Close()
+	if created.Username != "reader-user" || created.Role != "reader" {
+		t.Fatalf("unexpected create-user response: %+v", created)
+	}
+	if created.Password == "" {
+		t.Fatal("expected generated password in create-user response")
+	}
+
+	resp, err = adminClient.Get(server.URL + "/v1/auth/users")
+	if err != nil {
+		t.Fatalf("list users request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 list users, got %d body=%s", resp.StatusCode, string(body))
+	}
+	var listed struct {
+		Items []struct {
+			Username string `json:"username"`
+			Role     string `json:"role"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
+		resp.Body.Close()
+		t.Fatalf("decode list users response failed: %v", err)
+	}
+	resp.Body.Close()
+	if len(listed.Items) != 2 {
+		t.Fatalf("expected 2 users (admin + reader-user), got %d", len(listed.Items))
+	}
+
+	readerJar, _ := cookiejar.New(nil)
+	readerClient := &http.Client{Jar: readerJar}
+	loginPayload := map[string]string{"username": "reader-user", "password": created.Password}
+	loginBody, _ := json.Marshal(loginPayload)
+	resp, err = readerClient.Post(server.URL+"/v1/auth/login", "application/json", bytes.NewReader(loginBody))
+	if err != nil {
+		t.Fatalf("reader login request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 reader login, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	resp, err = readerClient.Get(server.URL + "/v1/tasks")
+	if err != nil {
+		t.Fatalf("reader get tasks failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 reader get tasks, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	toolBody := []byte(`{"apiVersion":"orloj.dev/v1","kind":"Tool","metadata":{"name":"rtool"},"spec":{"type":"http","endpoint":"https://example"}}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/tools", bytes.NewReader(toolBody))
+	if err != nil {
+		t.Fatalf("build tool create request failed: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = readerClient.Do(req)
+	if err != nil {
+		t.Fatalf("reader create tool request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 403 for reader mutating request, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+}
+
+func TestNativeAuthDeleteLastAdminBlocked(t *testing.T) {
+	server := newNativeAuthServer(t)
+	defer server.Close()
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+	setupResp, err := client.Post(server.URL+"/v1/auth/setup", "application/json", bytes.NewReader([]byte(`{"username":"admin","password":"very-strong-pass"}`)))
+	if err != nil {
+		t.Fatalf("setup request failed: %v", err)
+	}
+	setupResp.Body.Close()
+
+	req, err := http.NewRequest(http.MethodDelete, server.URL+"/v1/auth/users/admin", nil)
+	if err != nil {
+		t.Fatalf("build delete request failed: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("delete last admin request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 409 for last-admin delete, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+}
+
+func TestNativeAuthResetPasswordTargetsUserAndInvalidatesSessions(t *testing.T) {
+	server := newNativeAuthServer(t)
+	defer server.Close()
+
+	adminJar, _ := cookiejar.New(nil)
+	adminClient := &http.Client{Jar: adminJar}
+	setupResp, err := adminClient.Post(server.URL+"/v1/auth/setup", "application/json", bytes.NewReader([]byte(`{"username":"admin","password":"very-strong-pass"}`)))
+	if err != nil {
+		t.Fatalf("setup request failed: %v", err)
+	}
+	setupResp.Body.Close()
+
+	resp, err := adminClient.Post(server.URL+"/v1/auth/users", "application/json", bytes.NewReader([]byte(`{"username":"writer-user","role":"writer"}`)))
+	if err != nil {
+		t.Fatalf("create writer user request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 201 create writer user, got %d body=%s", resp.StatusCode, string(body))
+	}
+	var created struct {
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		resp.Body.Close()
+		t.Fatalf("decode create writer user response failed: %v", err)
+	}
+	resp.Body.Close()
+
+	writerJar, _ := cookiejar.New(nil)
+	writerClient := &http.Client{Jar: writerJar}
+	loginBody, _ := json.Marshal(map[string]string{"username": "writer-user", "password": created.Password})
+	resp, err = writerClient.Post(server.URL+"/v1/auth/login", "application/json", bytes.NewReader(loginBody))
+	if err != nil {
+		t.Fatalf("writer login request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 writer login, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	resp, err = writerClient.Get(server.URL + "/v1/tasks")
+	if err != nil {
+		t.Fatalf("writer get tasks failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 writer tasks before reset, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	resetPayload := []byte(`{"username":"writer-user","new_password":"writer-new-strong-pass"}`)
+	resp, err = adminClient.Post(server.URL+"/v1/auth/admin/reset-password", "application/json", bytes.NewReader(resetPayload))
+	if err != nil {
+		t.Fatalf("admin reset-password request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 reset password, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	resp, err = adminClient.Get(server.URL + "/v1/auth/users")
+	if err != nil {
+		t.Fatalf("admin list-users request after reset failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected admin session to remain valid after resetting another user, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	resp, err = writerClient.Get(server.URL + "/v1/tasks")
+	if err != nil {
+		t.Fatalf("writer tasks request after reset failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 401 after session invalidation, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	oldLoginBody, _ := json.Marshal(map[string]string{"username": "writer-user", "password": created.Password})
+	resp, err = writerClient.Post(server.URL+"/v1/auth/login", "application/json", bytes.NewReader(oldLoginBody))
+	if err != nil {
+		t.Fatalf("writer old password login request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 401 old password after reset, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	newLoginBody, _ := json.Marshal(map[string]string{"username": "writer-user", "password": "writer-new-strong-pass"})
+	resp, err = writerClient.Post(server.URL+"/v1/auth/login", "application/json", bytes.NewReader(newLoginBody))
+	if err != nil {
+		t.Fatalf("writer new password login request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 new password login after reset, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+}
+
+func TestNativeAuthUserCRUDAuditPrincipal(t *testing.T) {
+	audit := &captureAuditSink{}
+	server := newNativeAuthServerWithOptions(t, api.ServerOptions{
+		AuthMode: api.AuthModeNative,
+		Extensions: agentruntime.Extensions{
+			Audit: audit,
+		},
+	}, true)
+	defer server.Close()
+
+	adminJar, _ := cookiejar.New(nil)
+	adminClient := &http.Client{Jar: adminJar}
+
+	setupResp, err := adminClient.Post(server.URL+"/v1/auth/setup", "application/json", bytes.NewReader([]byte(`{"username":"admin","password":"very-strong-pass"}`)))
+	if err != nil {
+		t.Fatalf("setup request failed: %v", err)
+	}
+	setupResp.Body.Close()
+
+	resp, err := adminClient.Post(server.URL+"/v1/auth/users", "application/json", bytes.NewReader([]byte(`{"username":"ops-user","role":"reader"}`)))
+	if err != nil {
+		t.Fatalf("create user request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 201 create user, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	req, err := http.NewRequest(http.MethodDelete, server.URL+"/v1/auth/users/ops-user", nil)
+	if err != nil {
+		t.Fatalf("build delete user request failed: %v", err)
+	}
+	resp, err = adminClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete user request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 delete user, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	events := audit.snapshot()
+	var sawCreate bool
+	var sawDelete bool
+	for _, event := range events {
+		if event.Action == "user.create" && event.Principal == "admin" {
+			sawCreate = true
+		}
+		if event.Action == "user.delete" && event.Principal == "admin" {
+			sawDelete = true
+		}
+	}
+	if !sawCreate {
+		t.Fatalf("expected user.create audit principal=admin, events=%+v", events)
+	}
+	if !sawDelete {
+		t.Fatalf("expected user.delete audit principal=admin, events=%+v", events)
+	}
+}

--- a/api/auth_tokens_api_test.go
+++ b/api/auth_tokens_api_test.go
@@ -1,0 +1,264 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/OrlojHQ/orloj/api"
+	agentruntime "github.com/OrlojHQ/orloj/runtime"
+	"github.com/OrlojHQ/orloj/store"
+)
+
+type captureAuditSink struct {
+	mu     sync.Mutex
+	events []agentruntime.AuditEvent
+}
+
+func (c *captureAuditSink) RecordAudit(_ context.Context, event agentruntime.AuditEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, event)
+}
+
+func (c *captureAuditSink) snapshot() []agentruntime.AuditEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]agentruntime.AuditEvent, len(c.events))
+	copy(out, c.events)
+	return out
+}
+
+func newBearerAuthServer(t *testing.T, ext agentruntime.Extensions) *httptest.Server {
+	t.Helper()
+	logger := log.New(io.Discard, "", 0)
+	runtimeMgr := agentruntime.NewManager(logger)
+	srv := api.NewServerWithOptions(api.Stores{
+		Agents:       store.NewAgentStore(),
+		AgentSystems: store.NewAgentSystemStore(),
+		Tools:        store.NewToolStore(),
+		Memories:     store.NewMemoryStore(),
+		Policies:     store.NewAgentPolicyStore(),
+		Tasks:        store.NewTaskStore(),
+		Workers:      store.NewWorkerStore(),
+		APITokens:    store.NewAPITokenStore(),
+	}, runtimeMgr, logger, api.ServerOptions{Extensions: ext})
+	return httptest.NewServer(srv.Handler())
+}
+
+func TestTokenCRUDStoreOnly(t *testing.T) {
+	t.Setenv("ORLOJ_API_TOKENS", "bootstrap:env-admin-token:admin")
+	t.Setenv("ORLOJ_API_TOKEN", "")
+
+	server := newBearerAuthServer(t, agentruntime.DefaultExtensions())
+	defer server.Close()
+
+	createBody := []byte(`{"name":"ci-writer","role":"writer"}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/tokens", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("build create request failed: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer env-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create token request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 201 create token, got %d body=%s", resp.StatusCode, string(body))
+	}
+	var created map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		resp.Body.Close()
+		t.Fatalf("decode create token response failed: %v", err)
+	}
+	resp.Body.Close()
+	token, _ := created["token"].(string)
+	if strings.TrimSpace(token) == "" {
+		t.Fatal("expected token secret in create response")
+	}
+
+	req, err = http.NewRequest(http.MethodGet, server.URL+"/v1/tokens", nil)
+	if err != nil {
+		t.Fatalf("build list request failed: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer env-admin-token")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list tokens request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 list tokens, got %d body=%s", resp.StatusCode, string(body))
+	}
+	var listed struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
+		resp.Body.Close()
+		t.Fatalf("decode list response failed: %v", err)
+	}
+	resp.Body.Close()
+	if len(listed.Items) != 1 {
+		t.Fatalf("expected exactly 1 store-managed token, got %d", len(listed.Items))
+	}
+	if _, hasTokenField := listed.Items[0]["token"]; hasTokenField {
+		t.Fatal("list response must not include token secret")
+	}
+	if listed.Items[0]["name"] != "ci-writer" {
+		t.Fatalf("expected listed token ci-writer, got %v", listed.Items[0]["name"])
+	}
+
+	req, err = http.NewRequest(http.MethodDelete, server.URL+"/v1/tokens/ci-writer", nil)
+	if err != nil {
+		t.Fatalf("build delete request failed: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer env-admin-token")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete token request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 delete token, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	req, err = http.NewRequest(http.MethodGet, server.URL+"/v1/tokens", nil)
+	if err != nil {
+		t.Fatalf("build list request failed: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer env-admin-token")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list tokens request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 list tokens, got %d body=%s", resp.StatusCode, string(body))
+	}
+	var listedAfterDelete struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listedAfterDelete); err != nil {
+		resp.Body.Close()
+		t.Fatalf("decode list-after-delete response failed: %v", err)
+	}
+	resp.Body.Close()
+	if len(listedAfterDelete.Items) != 0 {
+		t.Fatalf("expected no store-managed tokens after delete, got %d", len(listedAfterDelete.Items))
+	}
+}
+
+func TestAuthMeBearerIdentity(t *testing.T) {
+	t.Setenv("ORLOJ_API_TOKENS", "ci-bot:whoami-token:writer")
+	t.Setenv("ORLOJ_API_TOKEN", "")
+
+	server := newBearerAuthServer(t, agentruntime.DefaultExtensions())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/v1/auth/me", nil)
+	if err != nil {
+		t.Fatalf("build whoami request failed: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer whoami-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("whoami request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200 for whoami, got %d body=%s", resp.StatusCode, string(body))
+	}
+	var me struct {
+		Authenticated bool   `json:"authenticated"`
+		Name          string `json:"name"`
+		Role          string `json:"role"`
+		Method        string `json:"method"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&me); err != nil {
+		resp.Body.Close()
+		t.Fatalf("decode whoami response failed: %v", err)
+	}
+	resp.Body.Close()
+	if !me.Authenticated {
+		t.Fatal("expected authenticated=true")
+	}
+	if me.Name != "ci-bot" || me.Role != "writer" || me.Method != "bearer" {
+		t.Fatalf("unexpected whoami response: %+v", me)
+	}
+}
+
+func TestBearerAuditPrincipalNamedAndLegacy(t *testing.T) {
+	t.Setenv("ORLOJ_API_TOKENS", "named-token:token-named:reader,token-legacy:reader")
+	t.Setenv("ORLOJ_API_TOKEN", "")
+	audit := &captureAuditSink{}
+
+	server := newBearerAuthServer(t, agentruntime.Extensions{Audit: audit})
+	defer server.Close()
+
+	reqNamed, err := http.NewRequest(http.MethodGet, server.URL+"/v1/tasks", nil)
+	if err != nil {
+		t.Fatalf("build named token request failed: %v", err)
+	}
+	reqNamed.Header.Set("Authorization", "Bearer token-named")
+	resp, err := http.DefaultClient.Do(reqNamed)
+	if err != nil {
+		t.Fatalf("named token request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for named token request, got %d", resp.StatusCode)
+	}
+
+	reqLegacy, err := http.NewRequest(http.MethodGet, server.URL+"/v1/tasks", nil)
+	if err != nil {
+		t.Fatalf("build legacy token request failed: %v", err)
+	}
+	reqLegacy.Header.Set("Authorization", "Bearer token-legacy")
+	resp, err = http.DefaultClient.Do(reqLegacy)
+	if err != nil {
+		t.Fatalf("legacy token request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for legacy token request, got %d", resp.StatusCode)
+	}
+
+	events := audit.snapshot()
+	if len(events) == 0 {
+		t.Fatal("expected audit events")
+	}
+	var sawNamed bool
+	var sawLegacy bool
+	for _, event := range events {
+		if event.Action != "api.request" {
+			continue
+		}
+		if event.Principal == "named-token" {
+			sawNamed = true
+		}
+		if event.Principal == "bearer:reader" {
+			sawLegacy = true
+		}
+	}
+	if !sawNamed {
+		t.Fatalf("expected audit principal for named token, events=%+v", events)
+	}
+	if !sawLegacy {
+		t.Fatalf("expected audit principal bearer:reader for legacy token, events=%+v", events)
+	}
+}

--- a/api/authz.go
+++ b/api/authz.go
@@ -3,10 +3,16 @@ package api
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+	"time"
+
+	agentruntime "github.com/OrlojHQ/orloj/runtime"
+	"github.com/OrlojHQ/orloj/store"
 )
 
 // RequestAuthorizer evaluates API authorization for one request+required role.
@@ -14,9 +20,21 @@ type RequestAuthorizer interface {
 	Authorize(r *http.Request, requiredRole string) (allowed bool, statusCode int, message string)
 }
 
+// IdentityAuthorizer is an optional extension implemented by authorizers that
+// can also return the authenticated principal identity.
+type IdentityAuthorizer interface {
+	RequestAuthorizer
+	AuthorizeWithIdentity(r *http.Request, requiredRole string) (allowed bool, statusCode int, message string, identity AuthIdentity)
+}
+
+type tokenPrincipal struct {
+	Name string
+	Role string
+}
+
 type authConfig struct {
-	enabled bool
-	tokens  map[string]string // SHA-256(token) -> role
+	envTokens map[string]tokenPrincipal // SHA-256(token) -> principal
+	store     *store.APITokenStore
 }
 
 // hashToken produces a hex-encoded SHA-256 digest of a raw token. Storing
@@ -31,53 +49,128 @@ type tokenAuthorizer struct {
 	cfg authConfig
 }
 
-func loadAuthConfig() authConfig {
-	cfg := authConfig{
-		enabled: false,
-		tokens:  make(map[string]string),
+func normalizeAPIRole(role, fallback string) (string, bool) {
+	r := strings.ToLower(strings.TrimSpace(role))
+	if r == "" {
+		r = strings.ToLower(strings.TrimSpace(fallback))
 	}
+	switch r {
+	case "admin", "writer", "reader", "controller":
+		return r, true
+	default:
+		return "", false
+	}
+}
 
+func parseTokenEnvConfig() map[string]tokenPrincipal {
+	tokens := make(map[string]tokenPrincipal)
 	rawList := strings.TrimSpace(os.Getenv("ORLOJ_API_TOKENS"))
 	if rawList != "" {
 		pairs := strings.Split(rawList, ",")
 		skipped := 0
 		for _, pair := range pairs {
-			parts := strings.SplitN(strings.TrimSpace(pair), ":", 2)
-			if len(parts) != 2 {
+			raw := strings.TrimSpace(pair)
+			if raw == "" {
 				skipped++
 				continue
 			}
-			token := strings.TrimSpace(parts[0])
-			role := strings.ToLower(strings.TrimSpace(parts[1]))
+			parts := strings.Split(raw, ":")
+			var (
+				name  string
+				token string
+				role  string
+			)
+			switch len(parts) {
+			case 2:
+				token = strings.TrimSpace(parts[0])
+				role = strings.TrimSpace(parts[1])
+			case 3:
+				name = strings.TrimSpace(parts[0])
+				token = strings.TrimSpace(parts[1])
+				role = strings.TrimSpace(parts[2])
+				if name == "" {
+					skipped++
+					continue
+				}
+			default:
+				skipped++
+				continue
+			}
 			if token == "" {
 				skipped++
 				continue
 			}
-			if role == "" {
-				role = "reader"
+			normalizedRole, ok := normalizeAPIRole(role, "reader")
+			if !ok {
+				skipped++
+				continue
 			}
-			cfg.tokens[hashToken(token)] = role
+			tokens[hashToken(token)] = tokenPrincipal{Name: name, Role: normalizedRole}
 		}
 		if skipped > 0 {
-			log.Printf("WARNING: ORLOJ_API_TOKENS: %d malformed token entries skipped (expected token:role pairs)", skipped)
+			log.Printf("WARNING: ORLOJ_API_TOKENS: %d malformed entries skipped (expected token:role or name:token:role)", skipped)
 		}
-		if len(cfg.tokens) == 0 && len(pairs) > 0 {
+		if len(tokens) == 0 && len(pairs) > 0 {
 			log.Fatalf("ORLOJ_API_TOKENS is set but all %d entries are malformed — refusing to start with auth disabled", len(pairs))
 		}
 	}
-
-	if len(cfg.tokens) == 0 {
+	if len(tokens) == 0 {
 		if single := strings.TrimSpace(os.Getenv("ORLOJ_API_TOKEN")); single != "" {
-			cfg.tokens[hashToken(single)] = "admin"
+			tokens[hashToken(single)] = tokenPrincipal{Role: "admin"}
 		}
 	}
+	return tokens
+}
 
-	cfg.enabled = len(cfg.tokens) > 0
-	return cfg
+func loadAuthConfig(tokenStore *store.APITokenStore) authConfig {
+	return authConfig{
+		envTokens: parseTokenEnvConfig(),
+		store:     tokenStore,
+	}
 }
 
 func newTokenAuthorizerFromEnv() RequestAuthorizer {
-	return tokenAuthorizer{cfg: loadAuthConfig()}
+	return newTokenAuthorizerWithStoreFromEnv(nil)
+}
+
+func newTokenAuthorizerWithStoreFromEnv(tokenStore *store.APITokenStore) RequestAuthorizer {
+	return tokenAuthorizer{cfg: loadAuthConfig(tokenStore)}
+}
+
+func (a tokenAuthorizer) authEnabled() (bool, int, string) {
+	if len(a.cfg.envTokens) > 0 {
+		return true, 0, ""
+	}
+	if a.cfg.store == nil {
+		return false, 0, ""
+	}
+	hasAny, err := a.cfg.store.HasAny()
+	if err != nil {
+		return false, http.StatusInternalServerError, "auth store error"
+	}
+	return hasAny, 0, ""
+}
+
+func (a tokenAuthorizer) resolveTokenPrincipal(token string) (tokenPrincipal, bool, int, string) {
+	hashed := hashToken(token)
+	if principal, ok := a.cfg.envTokens[hashed]; ok {
+		return principal, true, 0, ""
+	}
+	if a.cfg.store == nil {
+		return tokenPrincipal{}, false, 0, ""
+	}
+	record, ok, err := a.cfg.store.GetByHash(hashed)
+	if err != nil {
+		return tokenPrincipal{}, false, http.StatusInternalServerError, "auth store error"
+	}
+	if !ok {
+		return tokenPrincipal{}, false, 0, ""
+	}
+	role, valid := normalizeAPIRole(record.Role, "")
+	if !valid {
+		return tokenPrincipal{}, false, http.StatusInternalServerError, "auth store role invalid"
+	}
+	return tokenPrincipal{Name: strings.TrimSpace(record.Name), Role: role}, true, 0, ""
 }
 
 // NewAPIKeyAuthorizer returns an authorizer that validates a single API key
@@ -86,33 +179,71 @@ func newTokenAuthorizerFromEnv() RequestAuthorizer {
 func NewAPIKeyAuthorizer(key string) RequestAuthorizer {
 	key = strings.TrimSpace(key)
 	if key == "" {
-		return tokenAuthorizer{cfg: authConfig{enabled: false}}
+		return tokenAuthorizer{cfg: authConfig{envTokens: map[string]tokenPrincipal{}}}
 	}
 	return tokenAuthorizer{cfg: authConfig{
-		enabled: true,
-		tokens:  map[string]string{hashToken(key): "admin"},
+		envTokens: map[string]tokenPrincipal{hashToken(key): {Role: "admin"}},
 	}}
 }
 
 func (a tokenAuthorizer) Authorize(r *http.Request, requiredRole string) (bool, int, string) {
+	allowed, statusCode, message, _ := a.AuthorizeWithIdentity(r, requiredRole)
+	return allowed, statusCode, message
+}
+
+func (a tokenAuthorizer) AuthorizeWithIdentity(r *http.Request, requiredRole string) (bool, int, string, AuthIdentity) {
 	if strings.TrimSpace(requiredRole) == "" {
-		return true, 0, ""
+		return true, 0, "", AuthIdentity{Method: "none"}
 	}
-	if !a.cfg.enabled {
-		return true, 0, ""
+	enabled, statusCode, message := a.authEnabled()
+	if statusCode > 0 {
+		return false, statusCode, message, AuthIdentity{}
+	}
+	if !enabled {
+		return true, 0, "", AuthIdentity{Method: "none"}
 	}
 	token := bearerToken(r.Header.Get("Authorization"))
 	if token == "" {
-		return false, http.StatusUnauthorized, "missing bearer token"
+		return false, http.StatusUnauthorized, "missing bearer token", AuthIdentity{}
 	}
-	role, ok := a.cfg.tokens[hashToken(token)]
+	principal, ok, pStatus, pMessage := a.resolveTokenPrincipal(token)
+	if pStatus > 0 {
+		return false, pStatus, pMessage, AuthIdentity{}
+	}
 	if !ok {
-		return false, http.StatusUnauthorized, "invalid token"
+		return false, http.StatusUnauthorized, "invalid token", AuthIdentity{}
 	}
-	if !roleAllows(strings.ToLower(strings.TrimSpace(role)), requiredRole) {
-		return false, http.StatusForbidden, "forbidden"
+	if !roleAllows(principal.Role, requiredRole) {
+		return false, http.StatusForbidden, "forbidden", AuthIdentity{}
 	}
-	return true, 0, ""
+	return true, 0, "", AuthIdentity{
+		Name:   principal.Name,
+		Role:   principal.Role,
+		Method: "bearer",
+	}
+}
+
+type statusCaptureResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (w *statusCaptureResponseWriter) WriteHeader(code int) {
+	w.statusCode = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *statusCaptureResponseWriter) Write(b []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.statusCode = http.StatusOK
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *statusCaptureResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }
 
 func (s *Server) withAuth(next http.Handler) http.Handler {
@@ -124,9 +255,20 @@ func (s *Server) withAuth(next http.Handler) http.Handler {
 		}
 		authorizer := s.authorizer
 		if authorizer == nil {
-			authorizer = newTokenAuthorizerFromEnv()
+			authorizer = newTokenAuthorizerWithStoreFromEnv(s.stores.APITokens)
 		}
-		allowed, statusCode, message := authorizer.Authorize(r, required)
+
+		var (
+			allowed    bool
+			statusCode int
+			message    string
+			identity   AuthIdentity
+		)
+		if withIdentity, ok := authorizer.(IdentityAuthorizer); ok {
+			allowed, statusCode, message, identity = withIdentity.AuthorizeWithIdentity(r, required)
+		} else {
+			allowed, statusCode, message = authorizer.Authorize(r, required)
+		}
 		if !allowed {
 			if statusCode <= 0 {
 				statusCode = http.StatusForbidden
@@ -134,12 +276,21 @@ func (s *Server) withAuth(next http.Handler) http.Handler {
 			http.Error(w, strings.TrimSpace(message), statusCode)
 			return
 		}
+		if strings.TrimSpace(identity.Role) == "" {
+			identity.Role = strings.TrimSpace(required)
+		}
+		if strings.TrimSpace(identity.Method) == "" {
+			identity.Method = "bearer"
+		}
+
+		ctx := withAuthIdentity(r.Context(), identity)
+		reqWithIdentity := r.WithContext(ctx)
 		// Extension point: a custom authorizer can enforce per-namespace,
 		// per-resource, or per-user policies here. Nil by default.
 		if s.resourceAuthorizer != nil {
-			ns := requestNamespace(r)
-			resType, resName := resourceInfoFromPath(r.URL.Path)
-			raAllowed, raStatus, raMsg := s.resourceAuthorizer.AuthorizeResource(r, r.Method, resType, ns, resName)
+			ns := requestNamespace(reqWithIdentity)
+			resType, resName := resourceInfoFromPath(reqWithIdentity.URL.Path)
+			raAllowed, raStatus, raMsg := s.resourceAuthorizer.AuthorizeResource(reqWithIdentity, reqWithIdentity.Method, resType, ns, resName)
 			if !raAllowed {
 				if raStatus <= 0 {
 					raStatus = http.StatusForbidden
@@ -148,11 +299,60 @@ func (s *Server) withAuth(next http.Handler) http.Handler {
 				return
 			}
 		}
-		ctx := withAuthIdentity(r.Context(), AuthIdentity{
-			Role:   required,
-			Method: "bearer",
-		})
-		next.ServeHTTP(w, r.WithContext(ctx))
+
+		rw := &statusCaptureResponseWriter{ResponseWriter: w}
+		next.ServeHTTP(rw, reqWithIdentity)
+		if rw.statusCode == 0 {
+			rw.statusCode = http.StatusOK
+		}
+		s.emitBearerRequestAudit(reqWithIdentity, rw.statusCode, identity)
+	})
+}
+
+func (s *Server) emitBearerRequestAudit(r *http.Request, statusCode int, identity AuthIdentity) {
+	if s == nil {
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(identity.Method), "bearer") {
+		return
+	}
+	if !strings.HasPrefix(strings.TrimSpace(r.URL.Path), "/v1/") {
+		return
+	}
+
+	principal := strings.TrimSpace(identity.Name)
+	if principal == "" {
+		role := strings.TrimSpace(identity.Role)
+		if role == "" {
+			role = "unknown"
+		}
+		principal = "bearer:" + role
+	}
+	outcome := "success"
+	if statusCode >= 400 {
+		outcome = "error"
+	}
+	resType, resName := resourceInfoFromPath(r.URL.Path)
+	namespace := ""
+	if !strings.HasPrefix(strings.TrimSpace(r.URL.Path), "/v1/auth") && !strings.HasPrefix(strings.TrimSpace(r.URL.Path), "/v1/tokens") {
+		namespace = requestNamespace(r)
+	}
+	s.extensions.Audit.RecordAudit(r.Context(), agentruntime.AuditEvent{
+		Timestamp:    time.Now().UTC().Format(time.RFC3339Nano),
+		Component:    "apiserver",
+		Action:       "api.request",
+		Outcome:      outcome,
+		Namespace:    namespace,
+		ResourceKind: resType,
+		ResourceName: resName,
+		Principal:    principal,
+		Message:      fmt.Sprintf("%s %s", strings.ToUpper(strings.TrimSpace(r.Method)), strings.TrimSpace(r.URL.Path)),
+		Metadata: map[string]string{
+			"method": strings.ToUpper(strings.TrimSpace(r.Method)),
+			"path":   strings.TrimSpace(r.URL.Path),
+			"status": strconv.Itoa(statusCode),
+			"role":   strings.TrimSpace(identity.Role),
+		},
 	})
 }
 
@@ -187,6 +387,9 @@ func requiredRoleForRequest(r *http.Request, uiBasePath string) string {
 	if path == "/v1/auth" || strings.HasPrefix(path, "/v1/auth/") {
 		return ""
 	}
+	if path == "/v1/tokens" || strings.HasPrefix(path, "/v1/tokens/") {
+		return "admin"
+	}
 	if strings.HasPrefix(path, "/v1/webhook-deliveries/") {
 		return "writer"
 	}
@@ -205,7 +408,19 @@ func requiredRoleForRequest(r *http.Request, uiBasePath string) string {
 	return "writer"
 }
 
+// roleAllows checks whether the actual role satisfies the required role.
+//
+// Role hierarchy (highest to lowest):
+//   - admin:      full access to all endpoints
+//   - writer:     read + write (satisfies both "reader" and "writer" requirements)
+//   - controller: read + status-patch (satisfies "reader" and "controller" requirements)
+//   - reader:     read-only (satisfies only "reader" requirements)
+//
+// Writer and controller are orthogonal write-path capabilities; neither
+// implies the other.  Both include implicit read access.
 func roleAllows(actual, required string) bool {
+	actual = strings.ToLower(strings.TrimSpace(actual))
+	required = strings.ToLower(strings.TrimSpace(required))
 	if actual == "admin" {
 		return true
 	}

--- a/api/authz_parsing_test.go
+++ b/api/authz_parsing_test.go
@@ -1,0 +1,44 @@
+package api
+
+import "testing"
+
+func TestParseTokenEnvConfigSupportsNamedAndLegacyFormats(t *testing.T) {
+	t.Setenv("ORLOJ_API_TOKENS", "ops-bot:token-1:writer,token-2:reader,broken-entry, :token-3:admin,token-4:badrole")
+	t.Setenv("ORLOJ_API_TOKEN", "")
+
+	cfg := parseTokenEnvConfig()
+	if len(cfg) != 2 {
+		t.Fatalf("expected 2 valid token entries, got %d", len(cfg))
+	}
+	principal, ok := cfg[hashToken("token-1")]
+	if !ok {
+		t.Fatal("expected named token to be parsed")
+	}
+	if principal.Name != "ops-bot" || principal.Role != "writer" {
+		t.Fatalf("unexpected principal for named token: %+v", principal)
+	}
+	legacy, ok := cfg[hashToken("token-2")]
+	if !ok {
+		t.Fatal("expected legacy token to be parsed")
+	}
+	if legacy.Name != "" || legacy.Role != "reader" {
+		t.Fatalf("unexpected principal for legacy token: %+v", legacy)
+	}
+}
+
+func TestParseTokenEnvConfigFallsBackToSingleToken(t *testing.T) {
+	t.Setenv("ORLOJ_API_TOKENS", "")
+	t.Setenv("ORLOJ_API_TOKEN", "single-admin-token")
+
+	cfg := parseTokenEnvConfig()
+	if len(cfg) != 1 {
+		t.Fatalf("expected 1 fallback token, got %d", len(cfg))
+	}
+	principal, ok := cfg[hashToken("single-admin-token")]
+	if !ok {
+		t.Fatal("expected single token to be present")
+	}
+	if principal.Role != "admin" {
+		t.Fatalf("expected fallback role admin, got %q", principal.Role)
+	}
+}

--- a/api/authz_test.go
+++ b/api/authz_test.go
@@ -126,6 +126,31 @@ func TestAuthzEnforcement(t *testing.T) {
 	}
 	resp.Body.Close()
 
+	// Token management endpoints are admin-only.
+	req, _ = http.NewRequest(http.MethodGet, httpServer.URL+"/v1/tokens", nil)
+	req.Header.Set("Authorization", "Bearer writer-token")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("writer tokens get failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected writer GET /v1/tokens 403, got %d body=%s", resp.StatusCode, string(b))
+	}
+	resp.Body.Close()
+
+	req, _ = http.NewRequest(http.MethodGet, httpServer.URL+"/v1/tokens", nil)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("admin tokens get failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected admin GET /v1/tokens 200, got %d body=%s", resp.StatusCode, string(b))
+	}
+	resp.Body.Close()
+
 	req, _ = http.NewRequest(http.MethodGet, httpServer.URL+"/v1/tools/t1", nil)
 	req.Header.Set("Authorization", "Bearer reader-token")
 	resp, err = http.DefaultClient.Do(req)

--- a/api/server.go
+++ b/api/server.go
@@ -41,6 +41,7 @@ type Stores struct {
 	Workers       *store.WorkerStore
 	McpServers    *store.McpServerStore
 	LocalAdmins   *store.LocalAdminStore
+	APITokens     *store.APITokenStore
 	AuthSessions  *store.AuthSessionStore
 }
 
@@ -104,6 +105,9 @@ func NewServerWithOptions(stores Stores, runtime *agentruntime.Manager, logger *
 	if stores.LocalAdmins == nil {
 		stores.LocalAdmins = store.NewLocalAdminStore()
 	}
+	if stores.APITokens == nil {
+		stores.APITokens = store.NewAPITokenStore()
+	}
 	if stores.AuthSessions == nil {
 		stores.AuthSessions = store.NewAuthSessionStore()
 	}
@@ -119,7 +123,7 @@ func NewServerWithOptions(stores Stores, runtime *agentruntime.Manager, logger *
 	if authMode == AuthModeOff && authModeExplicit {
 		authorizer = noAuthAuthorizer{}
 	} else if authorizer == nil {
-		authorizer = newTokenAuthorizerFromEnv()
+		authorizer = newTokenAuthorizerWithStoreFromEnv(stores.APITokens)
 	}
 	if authMode == AuthModeNative {
 		authorizer = newNativeModeAuthorizer(authorizer, stores.LocalAdmins, stores.AuthSessions, sessionTTL)
@@ -243,7 +247,11 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/v1/auth/logout", s.handleAuthLogout)
 	s.mux.HandleFunc("/v1/auth/me", s.handleAuthMe)
 	s.mux.HandleFunc("/v1/auth/change-password", s.handleAuthChangePassword)
+	s.mux.HandleFunc("/v1/auth/users", s.handleAuthUsers)
+	s.mux.HandleFunc("/v1/auth/users/", s.handleAuthUserByName)
 	s.mux.HandleFunc("/v1/auth/admin/reset-password", s.handleAuthAdminResetPassword)
+	s.mux.HandleFunc("/v1/tokens", s.handleTokens)
+	s.mux.HandleFunc("/v1/tokens/", s.handleTokenByName)
 	if s.uiBasePath != "/" {
 		trimmed := strings.TrimSuffix(s.uiBasePath, "/")
 		s.mux.HandleFunc(trimmed, func(w http.ResponseWriter, r *http.Request) {

--- a/cli/orlojctl.go
+++ b/cli/orlojctl.go
@@ -122,6 +122,8 @@ func Run(args []string) error {
 		return runCompletion(args[1:])
 	case "admin":
 		return runAdmin(args[1:])
+	case "auth":
+		return runAuth(args[1:])
 	case "config":
 		return runConfig(args[1:])
 	case "rollback":
@@ -379,28 +381,149 @@ func (f *stringSliceFlag) Set(v string) error {
 
 func runCreate(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: orlojctl create secret <name> --from-literal key=value [--from-literal key2=value2 ...]")
+		return errors.New("usage: orlojctl create secret <name> --from-literal key=value [--from-literal key2=value2 ...] | orlojctl create token <name> --role <role>")
 	}
 	switch strings.ToLower(strings.TrimSpace(args[0])) {
 	case "secret":
 		return runCreateSecret(args[1:])
+	case "token":
+		return runCreateToken(args[1:])
 	default:
-		return fmt.Errorf("unsupported create resource %q (supported: secret)", args[0])
+		return fmt.Errorf("unsupported create resource %q (supported: secret, token)", args[0])
 	}
 }
 
 func runAdmin(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: orlojctl admin reset-password [--server URL] [--username name] --new-password value")
+		return errors.New("usage: orlojctl admin create-user <username> --role <role> | list-users | delete-user <username> | reset-password --username <name> --new-password <value>")
 	}
 	switch strings.ToLower(strings.TrimSpace(args[0])) {
+	case "create-user":
+		fs := flag.NewFlagSet("admin create-user", flag.ContinueOnError)
+		server := fs.String("server", defaultServerResolved(resolvedCliConfig), "Orloj server URL")
+		role := fs.String("role", "reader", "user role: admin|writer|reader|controller")
+		parseArgs := args[1:]
+		username := ""
+		if len(parseArgs) > 0 && !strings.HasPrefix(strings.TrimSpace(parseArgs[0]), "-") {
+			username = strings.TrimSpace(parseArgs[0])
+			parseArgs = parseArgs[1:]
+		}
+		if err := fs.Parse(parseArgs); err != nil {
+			return err
+		}
+		switch fs.NArg() {
+		case 0:
+		case 1:
+			if username == "" {
+				username = strings.TrimSpace(fs.Arg(0))
+			}
+		default:
+			return errors.New("usage: orlojctl admin create-user <username> --role <role>")
+		}
+		if username != "" && fs.NArg() == 1 {
+			return errors.New("usage: orlojctl admin create-user <username> --role <role>")
+		}
+		if username == "" {
+			return errors.New("username is required")
+		}
+		payload, _ := json.Marshal(map[string]string{
+			"username": username,
+			"role":     strings.TrimSpace(*role),
+		})
+		resp, err := http.Post(strings.TrimRight(*server, "/")+"/v1/auth/users", "application/json", bytes.NewReader(payload))
+		if err != nil {
+			return fmt.Errorf("create user request failed: %w", err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= 300 {
+			return fmt.Errorf("create user failed: %s", bytes.TrimSpace(body))
+		}
+		var created struct {
+			Username string `json:"username"`
+			Role     string `json:"role"`
+			Password string `json:"password"`
+		}
+		if err := json.Unmarshal(body, &created); err != nil {
+			return fmt.Errorf("decode create-user response failed: %w", err)
+		}
+		fmt.Printf("created user/%s role=%s\n", created.Username, created.Role)
+		fmt.Printf("password: %s\n", strings.TrimSpace(created.Password))
+		return nil
+	case "list-users":
+		fs := flag.NewFlagSet("admin list-users", flag.ContinueOnError)
+		server := fs.String("server", defaultServerResolved(resolvedCliConfig), "Orloj server URL")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if fs.NArg() != 0 {
+			return errors.New("usage: orlojctl admin list-users")
+		}
+		resp, err := http.Get(strings.TrimRight(*server, "/") + "/v1/auth/users")
+		if err != nil {
+			return fmt.Errorf("list users request failed: %w", err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= 300 {
+			return fmt.Errorf("list users failed: %s", bytes.TrimSpace(body))
+		}
+		var list struct {
+			Items []struct {
+				Username  string `json:"username"`
+				Role      string `json:"role"`
+				CreatedAt string `json:"created_at"`
+				UpdatedAt string `json:"updated_at"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(body, &list); err != nil {
+			return fmt.Errorf("decode list-users response failed: %w", err)
+		}
+		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "USERNAME\tROLE\tCREATED_AT\tUPDATED_AT")
+		for _, item := range list.Items {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", item.Username, item.Role, item.CreatedAt, item.UpdatedAt)
+		}
+		_ = tw.Flush()
+		return nil
+	case "delete-user":
+		fs := flag.NewFlagSet("admin delete-user", flag.ContinueOnError)
+		server := fs.String("server", defaultServerResolved(resolvedCliConfig), "Orloj server URL")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if fs.NArg() != 1 {
+			return errors.New("usage: orlojctl admin delete-user <username>")
+		}
+		username := strings.TrimSpace(fs.Arg(0))
+		if username == "" {
+			return errors.New("username is required")
+		}
+		req, err := http.NewRequest(http.MethodDelete, strings.TrimRight(*server, "/")+"/v1/auth/users/"+url.PathEscape(username), nil)
+		if err != nil {
+			return fmt.Errorf("delete user request build failed: %w", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("delete user request failed: %w", err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= 300 {
+			return fmt.Errorf("delete user failed: %s", bytes.TrimSpace(body))
+		}
+		fmt.Printf("deleted user/%s\n", username)
+		return nil
 	case "reset-password":
 		fs := flag.NewFlagSet("admin reset-password", flag.ContinueOnError)
 		server := fs.String("server", defaultServerResolved(resolvedCliConfig), "Orloj server URL")
-		username := fs.String("username", "", "admin username (optional)")
+		username := fs.String("username", "", "target username")
 		newPassword := fs.String("new-password", "", "new admin password")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
+		}
+		if strings.TrimSpace(*username) == "" {
+			return errors.New("--username is required")
 		}
 		if strings.TrimSpace(*newPassword) == "" {
 			return errors.New("--new-password is required")
@@ -418,11 +541,127 @@ func runAdmin(args []string) error {
 			body, _ := io.ReadAll(resp.Body)
 			return fmt.Errorf("password reset failed: %s", bytes.TrimSpace(body))
 		}
-		fmt.Println("admin password reset")
+		fmt.Printf("password reset for %s\n", strings.TrimSpace(*username))
 		return nil
 	default:
-		return fmt.Errorf("unsupported admin subcommand %q (supported: reset-password)", args[0])
+		return fmt.Errorf("unsupported admin subcommand %q (supported: create-user, list-users, delete-user, reset-password)", args[0])
 	}
+}
+
+func runAuth(args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: orlojctl auth whoami [--server URL]")
+	}
+	switch strings.ToLower(strings.TrimSpace(args[0])) {
+	case "whoami":
+		fs := flag.NewFlagSet("auth whoami", flag.ContinueOnError)
+		server := fs.String("server", defaultServerResolved(resolvedCliConfig), "Orloj server URL")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if fs.NArg() != 0 {
+			return errors.New("usage: orlojctl auth whoami [--server URL]")
+		}
+		resp, err := http.Get(strings.TrimRight(*server, "/") + "/v1/auth/me")
+		if err != nil {
+			return fmt.Errorf("whoami request failed: %w", err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= 300 {
+			return fmt.Errorf("whoami failed: %s", bytes.TrimSpace(body))
+		}
+		var me struct {
+			Authenticated bool   `json:"authenticated"`
+			Username      string `json:"username"`
+			Name          string `json:"name"`
+			Role          string `json:"role"`
+			Method        string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &me); err != nil {
+			return fmt.Errorf("decode whoami response failed: %w", err)
+		}
+		if !me.Authenticated {
+			return errors.New("not authenticated")
+		}
+		name := strings.TrimSpace(me.Name)
+		if name == "" {
+			name = strings.TrimSpace(me.Username)
+		}
+		if name == "" {
+			name = "anonymous"
+		}
+		role := strings.TrimSpace(me.Role)
+		if role == "" {
+			role = "none"
+		}
+		method := strings.TrimSpace(me.Method)
+		if method == "" {
+			method = "unknown"
+		}
+		fmt.Printf("method=%s name=%s role=%s\n", method, name, role)
+		return nil
+	default:
+		return fmt.Errorf("unsupported auth subcommand %q (supported: whoami)", args[0])
+	}
+}
+
+func runCreateToken(args []string) error {
+	fs := flag.NewFlagSet("create token", flag.ContinueOnError)
+	server := fs.String("server", defaultServerResolved(resolvedCliConfig), "Orloj server URL")
+	role := fs.String("role", "", "token role: admin|writer|reader|controller")
+	parseArgs := args
+	name := ""
+	if len(parseArgs) > 0 && !strings.HasPrefix(strings.TrimSpace(parseArgs[0]), "-") {
+		name = strings.TrimSpace(parseArgs[0])
+		parseArgs = parseArgs[1:]
+	}
+	if err := fs.Parse(parseArgs); err != nil {
+		return err
+	}
+	switch fs.NArg() {
+	case 0:
+	case 1:
+		if name == "" {
+			name = strings.TrimSpace(fs.Arg(0))
+		}
+	default:
+		return errors.New("usage: orlojctl create token <name> --role <role>")
+	}
+	if name != "" && fs.NArg() == 1 {
+		return errors.New("usage: orlojctl create token <name> --role <role>")
+	}
+	if name == "" {
+		return errors.New("token name is required")
+	}
+	if strings.TrimSpace(*role) == "" {
+		return errors.New("--role is required")
+	}
+	payload, _ := json.Marshal(map[string]string{
+		"name": name,
+		"role": strings.TrimSpace(*role),
+	})
+	resp, err := http.Post(strings.TrimRight(*server, "/")+"/v1/tokens", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("create token failed: %s", bytes.TrimSpace(body))
+	}
+	var created struct {
+		Name      string `json:"name"`
+		Role      string `json:"role"`
+		Token     string `json:"token"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := json.Unmarshal(body, &created); err != nil {
+		return fmt.Errorf("decode create-token response failed: %w", err)
+	}
+	fmt.Printf("created token/%s role=%s\n", created.Name, created.Role)
+	fmt.Printf("token: %s\n", strings.TrimSpace(created.Token))
+	return nil
 }
 
 func runCreateSecret(args []string) error {
@@ -707,6 +946,9 @@ func runGet(args []string) error {
 		if name == "" {
 			return errors.New("resource name cannot be empty")
 		}
+	}
+	if resource == "tokens" && name != "" {
+		return errors.New("usage: orlojctl get tokens")
 	}
 	if *watch {
 		if resource != "tasks" {
@@ -999,6 +1241,23 @@ func runGet(args []string) error {
 			)
 		}
 		_ = tw.Flush()
+	case "tokens":
+		var list struct {
+			Items []struct {
+				Name      string `json:"name"`
+				Role      string `json:"role"`
+				CreatedAt string `json:"created_at"`
+			} `json:"items"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
+		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "NAME\tROLE\tCREATED_AT")
+		for _, item := range list.Items {
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", item.Name, item.Role, item.CreatedAt)
+		}
+		_ = tw.Flush()
 	}
 
 	return nil
@@ -1036,6 +1295,8 @@ func normalizeResource(resource string) string {
 		return "workers"
 	case "mcp-servers", "mcpservers", "mcpserver":
 		return "mcp-servers"
+	case "tokens", "token":
+		return "tokens"
 	default:
 		return ""
 	}
@@ -1073,6 +1334,8 @@ func listEndpointForResource(resource string) (string, error) {
 		return "/v1/workers", nil
 	case "mcp-servers":
 		return "/v1/mcp-servers", nil
+	case "tokens":
+		return "/v1/tokens", nil
 	default:
 		return "", fmt.Errorf("unsupported resource %q", resource)
 	}
@@ -1797,12 +2060,15 @@ Usage:
   orlojctl apply -f <file-or-directory> [--run] [--dry-run] [--namespace <ns>]
   orlojctl validate -f <file|dir>
   orlojctl create secret <name> --from-literal key=value [--from-literal key2=value2 ...]
+  orlojctl create token <name> --role <role>
   orlojctl approve tool-approval <name> [--decided-by <id>] [--reason <text>]
   orlojctl deny tool-approval <name> [--decided-by <id>] [--reason <text>]
   orlojctl get [-w] <resource> [name] [-o table|json|yaml] [--namespace <ns>]
+  orlojctl get tokens
   orlojctl get memory-entries <memory-name> [--query <q>] [--prefix <p>] [--limit <n>] [-o table|json|yaml]
   orlojctl memory-entries <memory-name> [--query <q>] [--prefix <p>] [--limit <n>] [-o table|json|yaml]
   orlojctl delete <resource> <name>
+  orlojctl delete token <name>
   orlojctl describe <resource> <name>
   orlojctl edit <resource> <name>
   orlojctl diff -f <file-or-directory> [--namespace <ns>]
@@ -1821,7 +2087,11 @@ Usage:
   orlojctl health [-o table|json|yaml]
   orlojctl status [-o table|json|yaml]
   orlojctl completion bash|zsh|fish
-  orlojctl admin reset-password [--server <url>] [--username <name>] --new-password <value>
+  orlojctl auth whoami [--server <url>]
+  orlojctl admin create-user <username> --role <role>
+  orlojctl admin list-users
+  orlojctl admin delete-user <username>
+  orlojctl admin reset-password [--server <url>] --username <name> --new-password <value>
   orlojctl config path|get|use <name>|set-profile <name> [--server URL] [--token value] [--token-env NAME]
 
 Global options:

--- a/cli/orlojctl_auth_cli_test.go
+++ b/cli/orlojctl_auth_cli_test.go
@@ -1,0 +1,188 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRunCreateTokenCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   map[string]string
+	)
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		_ = json.Unmarshal(raw, &gotBody)
+		return mockResponse(r, http.StatusCreated, `{"name":"ci","role":"writer","token":"secret-token"}`), nil
+	})
+
+	var (
+		out string
+		err error
+	)
+	withRoundTripper(t, rt, func() {
+		out, err = captureStdout(t, func() error {
+			return Run([]string{"create", "token", "ci", "--role", "writer", "--server", "http://orloj.test"})
+		})
+	})
+	if err != nil {
+		t.Fatalf("create token command failed: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("expected POST, got %s", gotMethod)
+	}
+	if gotPath != "/v1/tokens" {
+		t.Fatalf("expected /v1/tokens path, got %q", gotPath)
+	}
+	if gotBody["name"] != "ci" || gotBody["role"] != "writer" {
+		t.Fatalf("unexpected create token payload: %+v", gotBody)
+	}
+	if !strings.Contains(out, "created token/ci role=writer") || !strings.Contains(out, "token: secret-token") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}
+
+func TestRunGetTokensCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/tokens" {
+			t.Fatalf("expected /v1/tokens path, got %q", r.URL.Path)
+		}
+		return mockResponse(r, http.StatusOK, `{"items":[{"name":"ci","role":"writer","created_at":"2026-03-30T00:00:00Z"}]}`), nil
+	})
+
+	var (
+		out string
+		err error
+	)
+	withRoundTripper(t, rt, func() {
+		out, err = captureStdout(t, func() error {
+			return Run([]string{"get", "tokens", "--server", "http://orloj.test"})
+		})
+	})
+	if err != nil {
+		t.Fatalf("get tokens command failed: %v", err)
+	}
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "ROLE") || !strings.Contains(out, "ci") {
+		t.Fatalf("unexpected get tokens output: %q", out)
+	}
+}
+
+func TestRunDeleteTokenCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var (
+		gotMethod string
+		gotPath   string
+	)
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		return mockResponse(r, http.StatusOK, `{"status":"token deleted"}`), nil
+	})
+
+	var (
+		out string
+		err error
+	)
+	withRoundTripper(t, rt, func() {
+		out, err = captureStdout(t, func() error {
+			return Run([]string{"delete", "token", "ci", "--server", "http://orloj.test"})
+		})
+	})
+	if err != nil {
+		t.Fatalf("delete token command failed: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Fatalf("expected DELETE, got %s", gotMethod)
+	}
+	if gotPath != "/v1/tokens/ci" {
+		t.Fatalf("unexpected delete path %q", gotPath)
+	}
+	if !strings.Contains(out, "deleted tokens/ci") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}
+
+func TestRunAuthWhoamiCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/auth/me" {
+			t.Fatalf("expected /v1/auth/me path, got %q", r.URL.Path)
+		}
+		return mockResponse(r, http.StatusOK, `{"authenticated":true,"method":"bearer","name":"ci-bot","role":"writer"}`), nil
+	})
+
+	var (
+		out string
+		err error
+	)
+	withRoundTripper(t, rt, func() {
+		out, err = captureStdout(t, func() error {
+			return Run([]string{"auth", "whoami", "--server", "http://orloj.test"})
+		})
+	})
+	if err != nil {
+		t.Fatalf("auth whoami command failed: %v", err)
+	}
+	if !strings.Contains(out, "method=bearer name=ci-bot role=writer") {
+		t.Fatalf("unexpected whoami output: %q", out)
+	}
+}
+
+func TestRunAdminCreateUserCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   map[string]string
+	)
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		_ = json.Unmarshal(raw, &gotBody)
+		return mockResponse(r, http.StatusCreated, `{"username":"alice","role":"writer","password":"one-time-pass"}`), nil
+	})
+
+	var (
+		out string
+		err error
+	)
+	withRoundTripper(t, rt, func() {
+		out, err = captureStdout(t, func() error {
+			return Run([]string{"admin", "create-user", "alice", "--role", "writer", "--server", "http://orloj.test"})
+		})
+	})
+	if err != nil {
+		t.Fatalf("admin create-user command failed: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/auth/users" {
+		t.Fatalf("unexpected request method/path: %s %s", gotMethod, gotPath)
+	}
+	if gotBody["username"] != "alice" || gotBody["role"] != "writer" {
+		t.Fatalf("unexpected payload: %+v", gotBody)
+	}
+	if !strings.Contains(out, "created user/alice role=writer") || !strings.Contains(out, "password: one-time-pass") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}

--- a/cli/orlojctl_extended.go
+++ b/cli/orlojctl_extended.go
@@ -1365,11 +1365,23 @@ func orlojctlBashCompletion() string {
   local cur prev
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
-  local commands="apply validate create approve deny get memory-entries delete describe edit diff wait cancel retry top run init logs trace graph events messages metrics health status completion admin config version"
-  local resources="agents agent-systems model-endpoints tools secrets memories agent-policies agent-roles tool-permissions tool-approvals tasks task-schedules task-webhooks workers mcp-servers"
+  local commands="apply validate create approve deny get memory-entries delete describe edit diff wait cancel retry top run init logs trace graph events messages metrics health status completion auth admin config version"
+  local resources="agents agent-systems model-endpoints tools secrets memories agent-policies agent-roles tool-permissions tool-approvals tasks task-schedules task-webhooks workers mcp-servers tokens"
   case "${prev}" in
+    create)
+      COMPREPLY=( $(compgen -W "secret token" -- "${cur}") )
+      return
+      ;;
     get|describe|delete|edit)
       COMPREPLY=( $(compgen -W "${resources} memory-entries" -- "${cur}") )
+      return
+      ;;
+    auth)
+      COMPREPLY=( $(compgen -W "whoami" -- "${cur}") )
+      return
+      ;;
+    admin)
+      COMPREPLY=( $(compgen -W "create-user list-users delete-user reset-password" -- "${cur}") )
       return
       ;;
     approve|deny)
@@ -1396,14 +1408,23 @@ func orlojctlZshCompletion() string {
 _orlojctl() {
   local -a commands resources
   commands=(
-    apply validate create approve deny get memory-entries delete describe edit diff wait cancel retry top run init logs trace graph events messages metrics health status completion admin config version
+    apply validate create approve deny get memory-entries delete describe edit diff wait cancel retry top run init logs trace graph events messages metrics health status completion auth admin config version
   )
   resources=(
-    agents agent-systems model-endpoints tools secrets memories agent-policies agent-roles tool-permissions tool-approvals tasks task-schedules task-webhooks workers mcp-servers
+    agents agent-systems model-endpoints tools secrets memories agent-policies agent-roles tool-permissions tool-approvals tasks task-schedules task-webhooks workers mcp-servers tokens
   )
   case $words[2] in
+    create)
+      _arguments "1:resource:(secret token)"
+      ;;
     get|describe|delete|edit)
       _arguments "1:resource:(${resources} memory-entries)"
+      ;;
+    auth)
+      _arguments "1:subcommand:(whoami)"
+      ;;
+    admin)
+      _arguments "1:subcommand:(create-user list-users delete-user reset-password)"
       ;;
     approve|deny)
       _arguments "1:resource:(tool-approval)"
@@ -1424,9 +1445,12 @@ _orlojctl "$@"
 }
 
 func orlojctlFishCompletion() string {
-	return `complete -c orlojctl -f -a "apply validate create approve deny get memory-entries delete describe edit diff wait cancel retry top run init logs trace graph events messages metrics health status completion admin config version"
-complete -c orlojctl -n "__fish_seen_subcommand_from get describe delete edit" -a "agents agent-systems model-endpoints tools secrets memories agent-policies agent-roles tool-permissions tool-approvals tasks task-schedules task-webhooks workers mcp-servers memory-entries"
+	return `complete -c orlojctl -f -a "apply validate create approve deny get memory-entries delete describe edit diff wait cancel retry top run init logs trace graph events messages metrics health status completion auth admin config version"
+complete -c orlojctl -n "__fish_seen_subcommand_from create" -a "secret token"
+complete -c orlojctl -n "__fish_seen_subcommand_from get describe delete edit" -a "agents agent-systems model-endpoints tools secrets memories agent-policies agent-roles tool-permissions tool-approvals tasks task-schedules task-webhooks workers mcp-servers tokens memory-entries"
 complete -c orlojctl -n "__fish_seen_subcommand_from approve deny" -a "tool-approval"
+complete -c orlojctl -n "__fish_seen_subcommand_from auth" -a "whoami"
+complete -c orlojctl -n "__fish_seen_subcommand_from admin" -a "create-user list-users delete-user reset-password"
 complete -c orlojctl -n "__fish_seen_subcommand_from top" -a "workers tasks"
 complete -c orlojctl -n "__fish_seen_subcommand_from completion" -a "bash zsh fish"
 `

--- a/cmd/orlojd/main.go
+++ b/cmd/orlojd/main.go
@@ -99,6 +99,10 @@ func main() {
 	slogger := telemetry.NewLogger("orlojd")
 	logger := telemetry.NewBridgeLogger(slogger)
 
+	if authMode == api.AuthModeNative && strings.TrimSpace(os.Getenv("ORLOJ_SETUP_TOKEN")) == "" {
+		logger.Printf("WARNING: auth mode is native but ORLOJ_SETUP_TOKEN is not set; the first POST to /v1/auth/setup will create the admin account without a setup secret")
+	}
+
 	otelShutdown, otelErr := telemetry.Init(context.Background(), telemetry.Config{
 		ServiceName: "orlojd",
 	})
@@ -229,6 +233,7 @@ func main() {
 		Workers:       stores.Workers,
 		McpServers:    stores.McpServers,
 		LocalAdmins:   stores.LocalAdmins,
+		APITokens:     stores.APITokens,
 		AuthSessions:  stores.AuthSessions,
 	}, runtime, logger, api.ServerOptions{
 		Authorizer: requestAuthorizer,
@@ -356,7 +361,6 @@ func main() {
 	wg.Wait()
 }
 
-
 func runLocalAdminPasswordReset(stores *startup.StoreSet, username, password string) error {
 	if stores == nil || stores.LocalAdmins == nil || stores.AuthSessions == nil {
 		return fmt.Errorf("auth stores are not initialized")
@@ -382,8 +386,25 @@ func runLocalAdminPasswordReset(stores *startup.StoreSet, username, password str
 	if err != nil {
 		return err
 	}
-	if err := stores.LocalAdmins.Upsert(username, hash); err != nil {
+	existing, found, err := stores.LocalAdmins.GetByUsername(username)
+	if err != nil {
 		return err
+	}
+	if found {
+		if err := stores.LocalAdmins.SetPassword(existing.Username, hash); err != nil {
+			return err
+		}
+	} else {
+		userCount, err := stores.LocalAdmins.CountUsers()
+		if err != nil {
+			return err
+		}
+		if userCount > 0 {
+			return fmt.Errorf("user %q not found", username)
+		}
+		if _, err := stores.LocalAdmins.UpsertUser(username, hash, "admin"); err != nil {
+			return err
+		}
 	}
 	if hasAdmin {
 		_ = stores.AuthSessions.DeleteByUsername(current.Username)

--- a/docs/pages/deploy/remote-cli-access.md
+++ b/docs/pages/deploy/remote-cli-access.md
@@ -25,7 +25,7 @@ openssl rand -hex 32
 
 Store the value in your secrets manager or deployment environment—**not** in git.
 
-On the server, set **`orlojd --api-key=...`** or **`ORLOJ_API_TOKEN=...`** (or **`ORLOJ_API_TOKENS`** for multiple `token:role` pairs). See [Control plane API tokens](../operations/security.md#control-plane-api-tokens) for details.
+On the server, set **`orlojd --api-key=...`** or **`ORLOJ_API_TOKEN=...`** (or **`ORLOJ_API_TOKENS`** for multiple `name:token:role` entries; legacy `token:role` remains supported). See [Control plane API tokens](../operations/security.md#control-plane-api-tokens) for details.
 
 ## Server-side wiring
 

--- a/docs/pages/operations/configuration.md
+++ b/docs/pages/operations/configuration.md
@@ -54,7 +54,7 @@ Example:
 | `ORLOJ_AGENT_MESSAGE_CONSUME` | `orlojworker` | `--agent-message-consume` | Enables worker-side runtime inbox consumers. |
 | `ORLOJ_AGENT_MESSAGE_CONSUMER_NAMESPACE` | `orlojworker` | `--agent-message-consumer-namespace` | Optional namespace filter for runtime inbox consumers. |
 | `ORLOJ_API_TOKEN` | `orlojd`, `orlojctl`, `orloj-alertcheck` | `--api-key` (server), `--api-token` (client/checker) | Bearer token fallback for API auth. |
-| `ORLOJ_API_TOKENS` | `orlojd` | none | Multi-token auth map (`token:role` comma-separated list). |
+| `ORLOJ_API_TOKENS` | `orlojd` | none | Multi-token auth map (`name:token:role` entries; legacy `token:role` supported). |
 | `ORLOJ_UI_PATH` | `orlojd` | `--ui-path` | Base URL path for the web console (default `/`). |
 | `ORLOJ_AUTH_MODE` | `orlojd` | `--auth-mode` | API auth mode (`off`, `native`, `sso`; `sso` unavailable in this distribution). |
 | `ORLOJ_AUTH_SESSION_TTL` | `orlojd` | `--auth-session-ttl` | Session TTL for native auth mode. |

--- a/docs/pages/operations/security.md
+++ b/docs/pages/operations/security.md
@@ -48,10 +48,18 @@ Pick **one** of these (same token string you generated):
 For **multiple** distinct tokens with different roles (reader vs admin-style access), use:
 
 ```bash
-export ORLOJ_API_TOKENS='reader-token-here:reader,automation-token-here:admin'
+export ORLOJ_API_TOKENS='reader-bot:reader-token-here:reader,automation-bot:automation-token-here:admin'
 ```
 
-Format is comma-separated `token:role` pairs. When `ORLOJ_API_TOKENS` is set, it populates the token map and a single `ORLOJ_API_TOKEN` is only used if that list is empty (see `loadAuthConfig` in `api/authz.go`).
+Format is comma-separated `name:token:role` entries. Legacy `token:role` entries are still accepted for backward compatibility. When `ORLOJ_API_TOKENS` is set, it populates the token map and a single `ORLOJ_API_TOKEN` is only used if that list is empty (see `loadAuthConfig` in `api/authz.go`).
+
+For runtime-managed tokens (no server restart required), use:
+
+```bash
+orlojctl create token <name> --role <role>
+orlojctl get tokens
+orlojctl delete token <name>
+```
 
 ### 3. Configure clients (`orlojctl` and automation)
 
@@ -83,7 +91,7 @@ The comparison uses constant-time comparison to prevent timing side-channels. Wi
 
 ### 6. Authentication rate limiting
 
-Authentication endpoints (`/v1/auth/login`, `/v1/auth/setup`, `/v1/auth/change-password`, `/v1/auth/admin-reset-password`) are rate-limited per client IP address. The default policy allows 10 requests per minute sustained with a burst of 20 to accommodate legitimate multi-step flows. Requests that exceed the limit receive HTTP 429.
+Authentication endpoints (`/v1/auth/login`, `/v1/auth/setup`, `/v1/auth/change-password`, `/v1/auth/admin/reset-password`) are rate-limited per client IP address. The default policy allows 10 requests per minute sustained with a burst of 20 to accommodate legitimate multi-step flows. Requests that exceed the limit receive HTTP 429.
 
 ## Tool Types
 

--- a/docs/pages/reference/api.md
+++ b/docs/pages/reference/api.md
@@ -41,9 +41,21 @@ Namespace defaults to `default` and can be overridden with `?namespace=<ns>`.
 - `POST /v1/auth/logout`
   - clears local session cookie
 - `GET /v1/auth/me`
-  - returns current auth state for UI bootstrap
+  - returns current auth state and identity (`method`, `name`, `role`) for UI/CLI bootstrap
+- `POST /v1/auth/users`
+  - admin-only native-auth endpoint; creates a local user and returns a generated password once
+- `GET /v1/auth/users`
+  - admin-only native-auth endpoint; lists local users
+- `DELETE /v1/auth/users/{username}`
+  - admin-only native-auth endpoint; deletes a local user (last-admin delete is blocked)
 - `POST /v1/auth/admin/reset-password`
-  - admin-authenticated local password rotation endpoint
+  - admin-authenticated local password reset endpoint for a specific `username`
+- `POST /v1/tokens`
+  - admin-only endpoint; creates a named API token and returns the token once
+- `GET /v1/tokens`
+  - admin-only endpoint; lists store-managed tokens (`name`, `role`, `created_at`)
+- `DELETE /v1/tokens/{name}`
+  - admin-only endpoint; revokes a store-managed token
 
 ## Status and Logs
 

--- a/docs/pages/reference/cli.md
+++ b/docs/pages/reference/cli.md
@@ -18,12 +18,15 @@ Usage patterns:
 orlojctl apply -f <file-or-directory> [--run] [--dry-run] [--namespace <ns>]
 orlojctl validate -f <file|dir>
 orlojctl create secret <name> --from-literal key=value [...]
+orlojctl create token <name> --role <role>
 orlojctl approve tool-approval <name> [--decided-by <id>] [--reason <text>]
 orlojctl deny tool-approval <name> [--decided-by <id>] [--reason <text>]
 orlojctl get [-w] <resource> [name] [-o table|json|yaml]
+orlojctl get tokens
 orlojctl get memory-entries <memory-name> [--query <q>] [--prefix <p>] [--limit <n>]
 orlojctl memory-entries <memory-name> [--query <q>] [--prefix <p>] [--limit <n>]
 orlojctl delete <resource> <name>
+orlojctl delete token <name>
 orlojctl describe <resource> <name>
 orlojctl edit <resource> <name>
 orlojctl diff -f <file-or-directory> [--namespace <ns>]
@@ -42,7 +45,11 @@ orlojctl metrics task/<task-name> [-o table|json|yaml]
 orlojctl health [-o table|json|yaml]
 orlojctl status [-o table|json|yaml]
 orlojctl completion bash|zsh|fish
-orlojctl admin reset-password --new-password <value> [--username <name>]
+orlojctl auth whoami [--server URL]
+orlojctl admin create-user <username> --role <role>
+orlojctl admin list-users
+orlojctl admin delete-user <username>
+orlojctl admin reset-password --username <name> --new-password <value>
 orlojctl config path|get|use <name>|set-profile <name> [--server URL] [--token value] [--token-env NAME]
 ```
 
@@ -116,6 +123,13 @@ orlojctl validate -f ./manifests/
 | `-n` | `default` | Shorthand for `--namespace`. |
 | `--server` | resolved server | API server URL. |
 
+### `orlojctl create token`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--role` | none | Token role (`admin`, `writer`, `reader`, `controller`). Required. |
+| `--server` | resolved server | API server URL. |
+
 ### `orlojctl approve` / `orlojctl deny`
 
 Approves or denies a pending `ToolApproval`:
@@ -158,6 +172,7 @@ Supported resources:
 - `task-webhooks`
 - `workers`
 - `mcp-servers`
+- `tokens`
 
 Notes:
 
@@ -388,12 +403,39 @@ Usage:
 |---|---|---|
 | `--server` | resolved server | API server URL. |
 
+### `orlojctl auth whoami`
+
+Returns the currently authenticated identity from `/v1/auth/me`.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--server` | resolved server | API server URL. |
+
+### `orlojctl admin create-user`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--role` | `reader` | User role (`admin`, `writer`, `reader`, `controller`). |
+| `--server` | resolved server | API server URL. |
+
+### `orlojctl admin list-users`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--server` | resolved server | API server URL. |
+
+### `orlojctl admin delete-user`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--server` | resolved server | API server URL. |
+
 ### `orlojctl admin reset-password`
 
 | Flag | Default | Description |
 |---|---|---|
 | `--server` | resolved server | API server URL. |
-| `--username` | empty | Optional admin username. |
+| `--username` | none | Target username (required). |
 | `--new-password` | none | New password (required). |
 
 ### `orlojctl config set-profile`

--- a/openapi/build_openapi.py
+++ b/openapi/build_openapi.py
@@ -886,7 +886,7 @@ def build() -> dict:
     paths["/v1/auth/change-password"] = {
         "post": {
             "tags": ["auth"],
-            "security": [],
+            "security": SEC_READER,
             "requestBody": {
                 "required": True,
                 "content": json_body(
@@ -923,6 +923,142 @@ def build() -> dict:
                 "400": {"description": "Bad request", "content": text_plain_error()},
                 "403": {"description": "Forbidden", "content": text_plain_error()},
                 "429": {"description": "Rate limited", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/auth/users"] = {
+        "get": {
+            "tags": ["auth"],
+            "security": SEC_ADMIN,
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/AuthUserListResponse"
+                    ),
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "401": {"description": "Unauthorized", "content": text_plain_error()},
+                "403": {"description": "Forbidden", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        },
+        "post": {
+            "tags": ["auth"],
+            "security": SEC_ADMIN,
+            "requestBody": {
+                "required": True,
+                "content": json_body(
+                    "./schemas/common.yaml#/components/schemas/AuthUserCreateRequest"
+                ),
+            },
+            "responses": {
+                "201": {
+                    "description": "Created",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/AuthUserCreateResponse"
+                    ),
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "401": {"description": "Unauthorized", "content": text_plain_error()},
+                "403": {"description": "Forbidden", "content": text_plain_error()},
+                "409": {"description": "Conflict", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        },
+    }
+    paths["/v1/auth/users/{username}"] = {
+        "delete": {
+            "tags": ["auth"],
+            "security": SEC_ADMIN,
+            "parameters": [
+                {
+                    "name": "username",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/OkStatusMessage"
+                    ),
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "401": {"description": "Unauthorized", "content": text_plain_error()},
+                "403": {"description": "Forbidden", "content": text_plain_error()},
+                "404": {"description": "Not found", "content": text_plain_error()},
+                "409": {"description": "Conflict", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        }
+    }
+    paths["/v1/tokens"] = {
+        "get": {
+            "tags": ["auth"],
+            "security": SEC_ADMIN,
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/TokenListResponse"
+                    ),
+                },
+                "401": {"description": "Unauthorized", "content": text_plain_error()},
+                "403": {"description": "Forbidden", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        },
+        "post": {
+            "tags": ["auth"],
+            "security": SEC_ADMIN,
+            "requestBody": {
+                "required": True,
+                "content": json_body(
+                    "./schemas/common.yaml#/components/schemas/TokenCreateRequest"
+                ),
+            },
+            "responses": {
+                "201": {
+                    "description": "Created",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/TokenCreateResponse"
+                    ),
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "401": {"description": "Unauthorized", "content": text_plain_error()},
+                "403": {"description": "Forbidden", "content": text_plain_error()},
+                "409": {"description": "Conflict", "content": text_plain_error()},
+                "default": {"description": "Error", "content": text_plain_error()},
+            },
+        },
+    }
+    paths["/v1/tokens/{name}"] = {
+        "delete": {
+            "tags": ["auth"],
+            "security": SEC_ADMIN,
+            "parameters": [
+                {
+                    "name": "name",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": json_body(
+                        "./schemas/common.yaml#/components/schemas/OkStatusMessage"
+                    ),
+                },
+                "400": {"description": "Bad request", "content": text_plain_error()},
+                "401": {"description": "Unauthorized", "content": text_plain_error()},
+                "403": {"description": "Forbidden", "content": text_plain_error()},
+                "404": {"description": "Not found", "content": text_plain_error()},
                 "default": {"description": "Error", "content": text_plain_error()},
             },
         }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -5322,7 +5322,9 @@ paths:
     post:
       tags:
       - auth
-      security: []
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
       requestBody:
         required: true
         content:
@@ -5400,6 +5402,280 @@ paths:
                 "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
         '429':
           description: Rate limited
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/auth/users":
+    get:
+      tags:
+      - auth
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/AuthUserListResponse"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '403':
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - auth
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/AuthUserCreateRequest"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/AuthUserCreateResponse"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '403':
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/auth/users/{username}":
+    delete:
+      tags:
+      - auth
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/OkStatusMessage"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '403':
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tokens":
+    get:
+      tags:
+      - auth
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/TokenListResponse"
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '403':
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+    post:
+      tags:
+      - auth
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/common.yaml#/components/schemas/TokenCreateRequest"
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/TokenCreateResponse"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '403':
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '409':
+          description: Conflict
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/tokens/{name}":
+    delete:
+      tags:
+      - auth
+      security:
+      - bearerAuth: []
+      - sessionCookie: []
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/OkStatusMessage"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '403':
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        '404':
+          description: Not found
           content:
             text/plain:
               schema:

--- a/openapi/schemas/common.yaml
+++ b/openapi/schemas/common.yaml
@@ -58,6 +58,8 @@ components:
       properties:
         authenticated: { type: boolean }
         username: { type: string }
+        name: { type: string }
+        role: { type: string }
         method: { type: string }
     AuthCredentialsRequest:
       type: object
@@ -72,9 +74,62 @@ components:
         new_password: { type: string }
     AuthResetPasswordRequest:
       type: object
+      required: [username, new_password]
       properties:
         username: { type: string }
         new_password: { type: string }
+    TokenCreateRequest:
+      type: object
+      required: [name, role]
+      properties:
+        name: { type: string }
+        role: { type: string }
+    TokenMetadata:
+      type: object
+      properties:
+        name: { type: string }
+        role: { type: string }
+        created_at: { type: string }
+    TokenCreateResponse:
+      type: object
+      properties:
+        name: { type: string }
+        role: { type: string }
+        created_at: { type: string }
+        token: { type: string }
+    TokenListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/TokenMetadata" }
+    AuthUserCreateRequest:
+      type: object
+      required: [username]
+      properties:
+        username: { type: string }
+        role: { type: string }
+    AuthUserResponse:
+      type: object
+      properties:
+        username: { type: string }
+        role: { type: string }
+        created_at: { type: string }
+        updated_at: { type: string }
+    AuthUserCreateResponse:
+      type: object
+      properties:
+        username: { type: string }
+        role: { type: string }
+        created_at: { type: string }
+        updated_at: { type: string }
+        password: { type: string }
+    AuthUserListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/AuthUserResponse" }
     OkStatusMessage:
       type: object
       properties:

--- a/startup/stores.go
+++ b/startup/stores.go
@@ -30,6 +30,7 @@ type StoreSet struct {
 	Workers       *store.WorkerStore
 	McpServers    *store.McpServerStore
 	LocalAdmins   *store.LocalAdminStore
+	APITokens     *store.APITokenStore
 	AuthSessions  *store.AuthSessionStore
 	DB            *sql.DB
 }
@@ -71,6 +72,7 @@ func OpenStores(cfg StoreConfig, logger *log.Logger) (*StoreSet, error) {
 		Workers:       store.NewWorkerStore(),
 		McpServers:    store.NewMcpServerStore(),
 		LocalAdmins:   store.NewLocalAdminStore(),
+		APITokens:     store.NewAPITokenStore(),
 		AuthSessions:  store.NewAuthSessionStore(),
 	}
 	if cfg.IncludeScheduleStores {
@@ -141,6 +143,7 @@ func OpenStores(cfg StoreConfig, logger *log.Logger) (*StoreSet, error) {
 		s.Workers = store.NewWorkerStoreWithDB(db)
 		s.McpServers = store.NewMcpServerStoreWithDB(db)
 		s.LocalAdmins = store.NewLocalAdminStoreWithDB(db)
+		s.APITokens = store.NewAPITokenStoreWithDB(db)
 		s.AuthSessions = store.NewAuthSessionStoreWithDB(db)
 		if cfg.IncludeScheduleStores {
 			s.TaskSchedules = store.NewTaskScheduleStoreWithDB(db)

--- a/store/auth_store.go
+++ b/store/auth_store.go
@@ -6,7 +6,9 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -14,44 +16,132 @@ import (
 
 const (
 	tableAuthLocalAdmin = "auth_local_admin"
+	tableAuthLocalUsers = "auth_local_users"
 	tableAuthSessions   = "auth_sessions"
+	tableAuthAPITokens  = "auth_api_tokens"
 )
+
+var (
+	ErrAuthUserExists     = errors.New("auth user already exists")
+	ErrAuthUserNotFound   = errors.New("auth user not found")
+	ErrAuthLastAdmin      = errors.New("cannot delete last admin user")
+	ErrAPITokenExists     = errors.New("api token already exists")
+	ErrAPITokenNotFound   = errors.New("api token not found")
+	ErrInvalidAuthRole    = errors.New("invalid auth role")
+	allowedAuthRoleValues = map[string]struct{}{
+		"admin":      {},
+		"writer":     {},
+		"reader":     {},
+		"controller": {},
+	}
+)
+
+func normalizeAuthRoleWithDefault(role, defaultRole string) (string, error) {
+	r := strings.ToLower(strings.TrimSpace(role))
+	if r == "" {
+		r = strings.ToLower(strings.TrimSpace(defaultRole))
+	}
+	if _, ok := allowedAuthRoleValues[r]; !ok {
+		return "", fmt.Errorf("%w: %q", ErrInvalidAuthRole, strings.TrimSpace(role))
+	}
+	return r, nil
+}
+
+func normalizeAuthRole(role string) (string, error) {
+	return normalizeAuthRoleWithDefault(role, "")
+}
+
+func normalizeLocalUsername(username string) string {
+	return strings.ToLower(strings.TrimSpace(username))
+}
 
 type LocalAdminAccount struct {
 	Username     string
+	Role         string
 	PasswordHash string
+	CreatedAt    string
 	UpdatedAt    string
 }
 
 type LocalAdminStore struct {
-	mu      sync.RWMutex
-	account *LocalAdminAccount
-	db      *sql.DB
+	mu    sync.RWMutex
+	users map[string]LocalAdminAccount
+	db    *sql.DB
 }
 
 func NewLocalAdminStore() *LocalAdminStore {
-	return &LocalAdminStore{}
+	return &LocalAdminStore{users: make(map[string]LocalAdminAccount)}
 }
 
 func NewLocalAdminStoreWithDB(db *sql.DB) *LocalAdminStore {
-	return &LocalAdminStore{db: db}
+	return &LocalAdminStore{users: make(map[string]LocalAdminAccount), db: db}
 }
 
 func (s *LocalAdminStore) HasAdmin() (bool, error) {
-	_, ok, err := s.Get()
-	return ok, err
+	count, err := s.CountByRole("admin")
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
+func (s *LocalAdminStore) CountUsers() (int, error) {
+	if s.db != nil {
+		var count int
+		err := s.db.QueryRow(`SELECT COUNT(*) FROM auth_local_users`).Scan(&count)
+		if err != nil {
+			return 0, err
+		}
+		return count, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.users), nil
+}
+
+func (s *LocalAdminStore) CountByRole(role string) (int, error) {
+	role, err := normalizeAuthRole(role)
+	if err != nil {
+		return 0, err
+	}
+	if s.db != nil {
+		var count int
+		err := s.db.QueryRow(`SELECT COUNT(*) FROM auth_local_users WHERE role = $1`, role).Scan(&count)
+		if err != nil {
+			return 0, err
+		}
+		return count, nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	count := 0
+	for _, user := range s.users {
+		if strings.EqualFold(user.Role, role) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// Get returns one admin account for backward compatibility with legacy callers.
 func (s *LocalAdminStore) Get() (LocalAdminAccount, bool, error) {
 	if s.db != nil {
 		var (
-			account   LocalAdminAccount
-			updatedAt time.Time
+			account            LocalAdminAccount
+			createdAt, updated time.Time
 		)
-		err := s.db.QueryRow(`SELECT username, password_hash, updated_at FROM auth_local_admin WHERE id = 1`).Scan(
+		err := s.db.QueryRow(`
+			SELECT username, role, password_hash, created_at, updated_at
+			FROM auth_local_users
+			WHERE role = 'admin'
+			ORDER BY username ASC
+			LIMIT 1`).Scan(
 			&account.Username,
+			&account.Role,
 			&account.PasswordHash,
-			&updatedAt,
+			&createdAt,
+			&updated,
 		)
 		if err == sql.ErrNoRows {
 			return LocalAdminAccount{}, false, nil
@@ -59,20 +149,224 @@ func (s *LocalAdminStore) Get() (LocalAdminAccount, bool, error) {
 		if err != nil {
 			return LocalAdminAccount{}, false, err
 		}
-		account.UpdatedAt = updatedAt.UTC().Format(time.RFC3339Nano)
+		account.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
+		account.UpdatedAt = updated.UTC().Format(time.RFC3339Nano)
 		return account, true, nil
 	}
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.account == nil {
+	admins := make([]LocalAdminAccount, 0)
+	for _, user := range s.users {
+		if strings.EqualFold(user.Role, "admin") {
+			admins = append(admins, user)
+		}
+	}
+	if len(admins) == 0 {
 		return LocalAdminAccount{}, false, nil
 	}
-	return *s.account, true, nil
+	sort.Slice(admins, func(i, j int) bool { return admins[i].Username < admins[j].Username })
+	return admins[0], true, nil
 }
 
+func (s *LocalAdminStore) GetByUsername(username string) (LocalAdminAccount, bool, error) {
+	username = normalizeLocalUsername(username)
+	if username == "" {
+		return LocalAdminAccount{}, false, nil
+	}
+	if s.db != nil {
+		var (
+			account            LocalAdminAccount
+			createdAt, updated time.Time
+		)
+		err := s.db.QueryRow(`
+			SELECT username, role, password_hash, created_at, updated_at
+			FROM auth_local_users
+			WHERE username = $1`,
+			username,
+		).Scan(&account.Username, &account.Role, &account.PasswordHash, &createdAt, &updated)
+		if err == sql.ErrNoRows {
+			return LocalAdminAccount{}, false, nil
+		}
+		if err != nil {
+			return LocalAdminAccount{}, false, err
+		}
+		account.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
+		account.UpdatedAt = updated.UTC().Format(time.RFC3339Nano)
+		return account, true, nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	account, ok := s.users[username]
+	if !ok {
+		return LocalAdminAccount{}, false, nil
+	}
+	return account, true, nil
+}
+
+func (s *LocalAdminStore) ListUsers() ([]LocalAdminAccount, error) {
+	if s.db != nil {
+		rows, err := s.db.Query(`
+			SELECT username, role, password_hash, created_at, updated_at
+			FROM auth_local_users
+			ORDER BY username ASC`)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		out := make([]LocalAdminAccount, 0)
+		for rows.Next() {
+			var (
+				account            LocalAdminAccount
+				createdAt, updated time.Time
+			)
+			if err := rows.Scan(&account.Username, &account.Role, &account.PasswordHash, &createdAt, &updated); err != nil {
+				return nil, err
+			}
+			account.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
+			account.UpdatedAt = updated.UTC().Format(time.RFC3339Nano)
+			out = append(out, account)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]LocalAdminAccount, 0, len(s.users))
+	for _, user := range s.users {
+		out = append(out, user)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Username < out[j].Username })
+	return out, nil
+}
+
+// Upsert keeps backward compatibility for legacy single-admin callers by
+// forcing role=admin.
 func (s *LocalAdminStore) Upsert(username, passwordHash string) error {
-	username = strings.TrimSpace(username)
+	_, err := s.UpsertUser(username, passwordHash, "admin")
+	return err
+}
+
+func (s *LocalAdminStore) UpsertUser(username, passwordHash, role string) (LocalAdminAccount, error) {
+	username = normalizeLocalUsername(username)
+	passwordHash = strings.TrimSpace(passwordHash)
+	if username == "" {
+		return LocalAdminAccount{}, fmt.Errorf("username is required")
+	}
+	if passwordHash == "" {
+		return LocalAdminAccount{}, fmt.Errorf("password hash is required")
+	}
+	r, err := normalizeAuthRoleWithDefault(role, "admin")
+	if err != nil {
+		return LocalAdminAccount{}, err
+	}
+
+	now := time.Now().UTC()
+	if s.db != nil {
+		_, err := s.db.Exec(
+			`INSERT INTO auth_local_users(username, role, password_hash, created_at, updated_at)
+			 VALUES($1, $2, $3, NOW(), NOW())
+			 ON CONFLICT(username) DO UPDATE SET
+				 role = EXCLUDED.role,
+				 password_hash = EXCLUDED.password_hash,
+				 updated_at = NOW()`,
+			username,
+			r,
+			passwordHash,
+		)
+		if err != nil {
+			return LocalAdminAccount{}, err
+		}
+		user, ok, err := s.GetByUsername(username)
+		if err != nil {
+			return LocalAdminAccount{}, err
+		}
+		if !ok {
+			return LocalAdminAccount{}, fmt.Errorf("upserted user %q not found", username)
+		}
+		return user, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, ok := s.users[username]
+	createdAt := now
+	if ok {
+		if parsed, parseErr := time.Parse(time.RFC3339Nano, existing.CreatedAt); parseErr == nil {
+			createdAt = parsed
+		}
+	}
+	account := LocalAdminAccount{
+		Username:     username,
+		Role:         r,
+		PasswordHash: passwordHash,
+		CreatedAt:    createdAt.UTC().Format(time.RFC3339Nano),
+		UpdatedAt:    now.Format(time.RFC3339Nano),
+	}
+	s.users[username] = account
+	return account, nil
+}
+
+func (s *LocalAdminStore) CreateUser(username, passwordHash, role string) (LocalAdminAccount, error) {
+	username = normalizeLocalUsername(username)
+	passwordHash = strings.TrimSpace(passwordHash)
+	if username == "" {
+		return LocalAdminAccount{}, fmt.Errorf("username is required")
+	}
+	if passwordHash == "" {
+		return LocalAdminAccount{}, fmt.Errorf("password hash is required")
+	}
+	r, err := normalizeAuthRoleWithDefault(role, "reader")
+	if err != nil {
+		return LocalAdminAccount{}, err
+	}
+	if s.db != nil {
+		_, err := s.db.Exec(
+			`INSERT INTO auth_local_users(username, role, password_hash, created_at, updated_at)
+			 VALUES($1, $2, $3, NOW(), NOW())`,
+			username,
+			r,
+			passwordHash,
+		)
+		if err != nil {
+			if strings.Contains(strings.ToLower(err.Error()), "duplicate") || strings.Contains(strings.ToLower(err.Error()), "unique") {
+				return LocalAdminAccount{}, ErrAuthUserExists
+			}
+			return LocalAdminAccount{}, err
+		}
+		user, ok, err := s.GetByUsername(username)
+		if err != nil {
+			return LocalAdminAccount{}, err
+		}
+		if !ok {
+			return LocalAdminAccount{}, fmt.Errorf("created user %q not found", username)
+		}
+		return user, nil
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.users[username]; exists {
+		return LocalAdminAccount{}, ErrAuthUserExists
+	}
+	account := LocalAdminAccount{
+		Username:     username,
+		Role:         r,
+		PasswordHash: passwordHash,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	s.users[username] = account
+	return account, nil
+}
+
+func (s *LocalAdminStore) SetPassword(username, passwordHash string) error {
+	username = normalizeLocalUsername(username)
 	passwordHash = strings.TrimSpace(passwordHash)
 	if username == "" {
 		return fmt.Errorf("username is required")
@@ -80,28 +374,90 @@ func (s *LocalAdminStore) Upsert(username, passwordHash string) error {
 	if passwordHash == "" {
 		return fmt.Errorf("password hash is required")
 	}
-	now := time.Now().UTC().Format(time.RFC3339Nano)
 	if s.db != nil {
-		_, err := s.db.Exec(
-			`INSERT INTO auth_local_admin(id, username, password_hash, updated_at)
-			 VALUES(1, $1, $2, NOW())
-			 ON CONFLICT(id) DO UPDATE SET
-				 username = EXCLUDED.username,
-				 password_hash = EXCLUDED.password_hash,
-				 updated_at = NOW()`,
+		result, err := s.db.Exec(
+			`UPDATE auth_local_users SET password_hash = $2, updated_at = NOW() WHERE username = $1`,
 			username,
 			passwordHash,
 		)
-		return err
+		if err != nil {
+			return err
+		}
+		affected, err := result.RowsAffected()
+		if err == nil && affected == 0 {
+			return ErrAuthUserNotFound
+		}
+		return nil
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.account = &LocalAdminAccount{
-		Username:     username,
-		PasswordHash: passwordHash,
-		UpdatedAt:    now,
+	user, ok := s.users[username]
+	if !ok {
+		return ErrAuthUserNotFound
 	}
+	user.PasswordHash = passwordHash
+	user.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	s.users[username] = user
+	return nil
+}
+
+func (s *LocalAdminStore) DeleteUser(username string) error {
+	username = normalizeLocalUsername(username)
+	if username == "" {
+		return fmt.Errorf("username is required")
+	}
+	if s.db != nil {
+		tx, err := s.db.Begin()
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+
+		var role string
+		err = tx.QueryRow(`SELECT role FROM auth_local_users WHERE username = $1 FOR UPDATE`, username).Scan(&role)
+		if err == sql.ErrNoRows {
+			return ErrAuthUserNotFound
+		}
+		if err != nil {
+			return err
+		}
+		if strings.EqualFold(strings.TrimSpace(role), "admin") {
+			var adminCount int
+			if err := tx.QueryRow(`SELECT COUNT(*) FROM auth_local_users WHERE role = 'admin'`).Scan(&adminCount); err != nil {
+				return err
+			}
+			if adminCount <= 1 {
+				return ErrAuthLastAdmin
+			}
+		}
+		if _, err := tx.Exec(`DELETE FROM auth_local_users WHERE username = $1`, username); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	user, ok := s.users[username]
+	if !ok {
+		return ErrAuthUserNotFound
+	}
+	if strings.EqualFold(user.Role, "admin") {
+		adminCount := 0
+		for _, item := range s.users {
+			if strings.EqualFold(item.Role, "admin") {
+				adminCount++
+			}
+		}
+		if adminCount <= 1 {
+			return ErrAuthLastAdmin
+		}
+	}
+	delete(s.users, username)
 	return nil
 }
 
@@ -128,7 +484,7 @@ func NewAuthSessionStoreWithDB(db *sql.DB) *AuthSessionStore {
 }
 
 func (s *AuthSessionStore) Create(username string, ttl time.Duration, now time.Time) (AuthSession, error) {
-	username = strings.TrimSpace(username)
+	username = normalizeLocalUsername(username)
 	if username == "" {
 		return AuthSession{}, fmt.Errorf("username is required")
 	}
@@ -270,7 +626,7 @@ func (s *AuthSessionStore) Delete(token string) error {
 }
 
 func (s *AuthSessionStore) DeleteByUsername(username string) error {
-	username = strings.TrimSpace(username)
+	username = normalizeLocalUsername(username)
 	if username == "" {
 		return nil
 	}
@@ -305,6 +661,245 @@ func (s *AuthSessionStore) DeleteExpired(now time.Time) error {
 	return nil
 }
 
+type APITokenRecord struct {
+	Name      string
+	Role      string
+	TokenHash string
+	CreatedAt string
+	UpdatedAt string
+}
+
+type APITokenStore struct {
+	mu     sync.RWMutex
+	tokens map[string]APITokenRecord
+	db     *sql.DB
+}
+
+func NewAPITokenStore() *APITokenStore {
+	return &APITokenStore{tokens: make(map[string]APITokenRecord)}
+}
+
+func NewAPITokenStoreWithDB(db *sql.DB) *APITokenStore {
+	return &APITokenStore{tokens: make(map[string]APITokenRecord), db: db}
+}
+
+func normalizeTokenName(name string) string {
+	return strings.TrimSpace(name)
+}
+
+func (s *APITokenStore) Create(name, tokenHash, role string, now time.Time) (APITokenRecord, error) {
+	name = normalizeTokenName(name)
+	tokenHash = strings.TrimSpace(tokenHash)
+	if name == "" {
+		return APITokenRecord{}, fmt.Errorf("name is required")
+	}
+	if tokenHash == "" {
+		return APITokenRecord{}, fmt.Errorf("token hash is required")
+	}
+	r, err := normalizeAuthRoleWithDefault(role, "reader")
+	if err != nil {
+		return APITokenRecord{}, err
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if s.db != nil {
+		_, err := s.db.Exec(
+			`INSERT INTO auth_api_tokens(name, token_hash, role, created_at, updated_at)
+			 VALUES($1, $2, $3, NOW(), NOW())`,
+			name,
+			tokenHash,
+			r,
+		)
+		if err != nil {
+			msg := strings.ToLower(err.Error())
+			if strings.Contains(msg, "duplicate") || strings.Contains(msg, "unique") {
+				return APITokenRecord{}, ErrAPITokenExists
+			}
+			return APITokenRecord{}, err
+		}
+		record, ok, err := s.Get(name)
+		if err != nil {
+			return APITokenRecord{}, err
+		}
+		if !ok {
+			return APITokenRecord{}, fmt.Errorf("created token %q not found", name)
+		}
+		return record, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.tokens[name]; exists {
+		return APITokenRecord{}, ErrAPITokenExists
+	}
+	for _, existing := range s.tokens {
+		if existing.TokenHash == tokenHash {
+			return APITokenRecord{}, ErrAPITokenExists
+		}
+	}
+	record := APITokenRecord{
+		Name:      name,
+		Role:      r,
+		TokenHash: tokenHash,
+		CreatedAt: now.UTC().Format(time.RFC3339Nano),
+		UpdatedAt: now.UTC().Format(time.RFC3339Nano),
+	}
+	s.tokens[name] = record
+	return record, nil
+}
+
+func (s *APITokenStore) Get(name string) (APITokenRecord, bool, error) {
+	name = normalizeTokenName(name)
+	if name == "" {
+		return APITokenRecord{}, false, nil
+	}
+	if s.db != nil {
+		var (
+			record             APITokenRecord
+			createdAt, updated time.Time
+		)
+		err := s.db.QueryRow(
+			`SELECT name, token_hash, role, created_at, updated_at
+			 FROM auth_api_tokens
+			 WHERE name = $1`,
+			name,
+		).Scan(&record.Name, &record.TokenHash, &record.Role, &createdAt, &updated)
+		if err == sql.ErrNoRows {
+			return APITokenRecord{}, false, nil
+		}
+		if err != nil {
+			return APITokenRecord{}, false, err
+		}
+		record.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
+		record.UpdatedAt = updated.UTC().Format(time.RFC3339Nano)
+		return record, true, nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	record, ok := s.tokens[name]
+	if !ok {
+		return APITokenRecord{}, false, nil
+	}
+	return record, true, nil
+}
+
+func (s *APITokenStore) GetByHash(tokenHash string) (APITokenRecord, bool, error) {
+	tokenHash = strings.TrimSpace(tokenHash)
+	if tokenHash == "" {
+		return APITokenRecord{}, false, nil
+	}
+	if s.db != nil {
+		var (
+			record             APITokenRecord
+			createdAt, updated time.Time
+		)
+		err := s.db.QueryRow(
+			`SELECT name, token_hash, role, created_at, updated_at
+			 FROM auth_api_tokens
+			 WHERE token_hash = $1`,
+			tokenHash,
+		).Scan(&record.Name, &record.TokenHash, &record.Role, &createdAt, &updated)
+		if err == sql.ErrNoRows {
+			return APITokenRecord{}, false, nil
+		}
+		if err != nil {
+			return APITokenRecord{}, false, err
+		}
+		record.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
+		record.UpdatedAt = updated.UTC().Format(time.RFC3339Nano)
+		return record, true, nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, record := range s.tokens {
+		if strings.EqualFold(record.TokenHash, tokenHash) {
+			return record, true, nil
+		}
+	}
+	return APITokenRecord{}, false, nil
+}
+
+func (s *APITokenStore) List() ([]APITokenRecord, error) {
+	if s.db != nil {
+		rows, err := s.db.Query(`
+			SELECT name, token_hash, role, created_at, updated_at
+			FROM auth_api_tokens
+			ORDER BY name ASC`)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		out := make([]APITokenRecord, 0)
+		for rows.Next() {
+			var (
+				record             APITokenRecord
+				createdAt, updated time.Time
+			)
+			if err := rows.Scan(&record.Name, &record.TokenHash, &record.Role, &createdAt, &updated); err != nil {
+				return nil, err
+			}
+			record.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
+			record.UpdatedAt = updated.UTC().Format(time.RFC3339Nano)
+			out = append(out, record)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]APITokenRecord, 0, len(s.tokens))
+	for _, record := range s.tokens {
+		out = append(out, record)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (s *APITokenStore) HasAny() (bool, error) {
+	if s.db != nil {
+		var count int
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM auth_api_tokens`).Scan(&count); err != nil {
+			return false, err
+		}
+		return count > 0, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.tokens) > 0, nil
+}
+
+func (s *APITokenStore) Delete(name string) error {
+	name = normalizeTokenName(name)
+	if name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if s.db != nil {
+		result, err := s.db.Exec(`DELETE FROM auth_api_tokens WHERE name = $1`, name)
+		if err != nil {
+			return err
+		}
+		affected, err := result.RowsAffected()
+		if err == nil && affected == 0 {
+			return ErrAPITokenNotFound
+		}
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.tokens[name]; !ok {
+		return ErrAPITokenNotFound
+	}
+	delete(s.tokens, name)
+	return nil
+}
+
 func randomToken(size int) (string, error) {
 	if size <= 0 {
 		size = 32
@@ -314,6 +909,12 @@ func randomToken(size int) (string, error) {
 		return "", fmt.Errorf("generate session token: %w", err)
 	}
 	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// GenerateOpaqueCredential returns a random base64url credential suitable for
+// bearer tokens or one-time bootstrap passwords.
+func GenerateOpaqueCredential(size int) (string, error) {
+	return randomToken(size)
 }
 
 func hashSessionToken(token string) string {

--- a/store/migrations/009_auth_users_and_tokens.up.sql
+++ b/store/migrations/009_auth_users_and_tokens.up.sql
@@ -1,0 +1,36 @@
+-- 009: multi-user native auth and store-managed API tokens.
+
+CREATE TABLE IF NOT EXISTS auth_local_users (
+    username TEXT PRIMARY KEY,
+    role TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT auth_local_users_role CHECK (role IN ('admin', 'writer', 'reader', 'controller'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_local_users_role ON auth_local_users(role);
+
+INSERT INTO auth_local_users(username, role, password_hash, created_at, updated_at)
+SELECT
+    username,
+    'admin'::TEXT,
+    password_hash,
+    updated_at,
+    updated_at
+FROM auth_local_admin
+ON CONFLICT (username) DO UPDATE SET
+    role = EXCLUDED.role,
+    password_hash = EXCLUDED.password_hash,
+    updated_at = EXCLUDED.updated_at;
+
+CREATE TABLE IF NOT EXISTS auth_api_tokens (
+    name TEXT PRIMARY KEY,
+    token_hash TEXT NOT NULL UNIQUE,
+    role TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT auth_api_tokens_role CHECK (role IN ('admin', 'writer', 'reader', 'controller'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_api_tokens_role ON auth_api_tokens(role);


### PR DESCRIPTION
- Add native auth: local users (bcrypt), sessions, /v1/auth/setup bootstrap, ORLOJ_SETUP_TOKEN guard, role checks from the real session user.
- Persist auth_local_users and auth_api_tokens (migration 009) with env backfill; extend store and startup wiring.
- Admin API: token CRUD (/v1/tokens), user CRUD (/v1/auth/users), named bearer format name:token:role; propagate AuthIdentity for audits and admin audit events.
- Handlers: /v1/auth/me identity, targeted admin reset-password with session invalidation and self-reset cookie clear; log session cleanup failures.
- Auth middleware: forward Flush for SSE/watch under bearer auth; path/role parsing tests as needed.
- orlojctl: token and admin user commands, auth whoami, reset-password.
- OpenAPI + docs: auth/token endpoints, security and operations references.

