### PR TITLE
bug(sql): fix parameter binding in sql_backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Postgres task claiming**: Worker claim SQL used placeholder indices `$2`/`$3` while the driver bound arguments as `$1`/`$2`, causing `could not determine data type of parameter $1` (SQLSTATE 42P18) during embedded worker reconcile when both region and assigned-worker hints were set.
+
 ## [0.5.0] - 2026-04-01
 
 ### Added

--- a/store/sql_backend.go
+++ b/store/sql_backend.go
@@ -696,23 +696,20 @@ func claimNextDueTaskSQL(ctx context.Context, db *sql.DB, workerID string, lease
 	// cannot execute, which would starve workers with specialized requirements.
 	extraWhere := ""
 	args := []any{}
-	argIdx := 1
 
 	if hints.Region != "" {
-		argIdx++
 		extraWhere += fmt.Sprintf(` AND (
 			payload->'spec'->'requirements'->>'region' IS NULL
 			OR payload->'spec'->'requirements'->>'region' = ''
 			OR LOWER(payload->'spec'->'requirements'->>'region') = LOWER($%d)
-		)`, argIdx)
+		)`, len(args)+1)
 		args = append(args, hints.Region)
 	}
 	if hints.AssignedWorker != "" {
-		argIdx++
 		extraWhere += fmt.Sprintf(` AND (
 			assigned_worker = ''
 			OR LOWER(assigned_worker) = LOWER($%d)
-		)`, argIdx)
+		)`, len(args)+1)
 		args = append(args, hints.AssignedWorker)
 	}
 
@@ -827,7 +824,7 @@ func renewTaskLeaseSQL(ctx context.Context, db *sql.DB, name, workerID string, l
 		 WHERE name = $1
 		   AND status_phase = 'running'
 		   AND LOWER(TRIM(claimed_by)) = LOWER(TRIM($5))`,
-		name, &leaseUntilTS, leaseUntilStr, heartbeatStr, workerID,
+		name, leaseUntilTS, leaseUntilStr, heartbeatStr, workerID,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
- Fix placeholder numbering in claimNextDueTaskSQL by deriving index from len(args)+1 instead of a separate counter that started at the wrong offset (caused SQLSTATE 42P18 when both worker hints were set)
- Remove erroneous pointer pass (&leaseUntilTS) in renewTaskLeaseSQL
