### PR TITLE
fix(runtime): use agent output for sequential handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sequential agent handoffs**: Downstream agents in sequential task execution now receive the upstream agent's actual output (`result.Output`) before falling back to the last event message, instead of being handed generic values such as `worker completed`.
 - **Postgres task claiming**: Worker claim SQL used placeholder indices `$2`/`$3` while the driver bound arguments as `$1`/`$2`, causing `could not determine data type of parameter $1` (SQLSTATE 42P18) during embedded worker reconcile when both region and assigned-worker hints were set.
 
 ## [0.5.0] - 2026-04-01

--- a/controllers/task_agent_message_test.go
+++ b/controllers/task_agent_message_test.go
@@ -149,7 +149,17 @@ func TestTaskControllerPublishesAgentHandoffMessages(t *testing.T) {
 	if published[0].Namespace != "default" {
 		t.Fatalf("expected published namespace default, got %q", published[0].Namespace)
 	}
+	if message.Content != "model=gpt-4o step=1" {
+		t.Fatalf("expected handoff content from result output, got %q", message.Content)
+	}
+	if published[0].Payload != "model=gpt-4o step=1" {
+		t.Fatalf("expected published payload from result output, got %q", published[0].Payload)
+	}
+	if got := task.Status.Output["agent.1.message_content"]; got != "model=gpt-4o step=1" {
+		t.Fatalf("expected task output message content from result output, got %q", got)
+	}
 }
+
 
 func TestTaskControllerFailsTaskWhenMessagePublishFails(t *testing.T) {
 	controller, stores := newTaskControllerHarness()

--- a/controllers/task_controller.go
+++ b/controllers/task_controller.go
@@ -1315,7 +1315,10 @@ func (c *TaskController) executeTask(ctx context.Context, task *resources.Task, 
 
 		if idx+1 < len(order) {
 			nextAgent := order[idx+1]
-			content := strings.TrimSpace(result.LastEvent)
+			content := strings.TrimSpace(result.Output)
+			if content == "" {
+				content = strings.TrimSpace(result.LastEvent)
+			}
 			if content == "" {
 				content = fmt.Sprintf("steps=%d tool_calls=%d tokens=%d usage_source=%s", result.Steps, result.ToolCalls, result.TokensUsed, strings.TrimSpace(result.TokenSource))
 			}


### PR DESCRIPTION
## Summary

Sequential task execution was using `result.LastEvent` as the handoff content for downstream agents. In practice, this could pass generic values such as `worker completed` instead of the upstream agent's actual output, which broke multi-agent sequential pipelines.

This PR updates the sequential handoff path to prefer `result.Output`, and only fall back to `result.LastEvent` when the output is empty.

It also adds a regression test covering the handoff behavior and a changelog entry under `[Unreleased]`.

## Validation

Commands run:

bash
go test ./controllers ./store -count=1

Outcome:
- `./controllers` ✅ passed
- `./store` ✅ passed

I also attempted the broader runtime/API test command:

bash
go test ./api ./controllers ./store -count=1

but in this checkout `./api` fails due to missing embedded frontend assets, unrelated to this change:

text
frontend/embed.go:12:12: pattern dist: no matching files found

## Checklist

- [x] I ran relevant tests for the packages I changed.
- [ ] I updated docs/examples if behavior changed.
- [x] I added a changelog entry under `[Unreleased]` when user-visible behavior changed.
- [x] I kept this PR focused and avoided unrelated refactors.
- [x] I included DCO sign-off (`git commit -s`).

## Risk and Rollback

**Risk**
- Low risk. The change only affects the content selected for sequential inter-agent handoff messages.
- The fallback behavior is preserved when `result.Output` is empty.

**Rollback**
- Revert this PR to restore the previous behavior.
- As a temporary workaround, users can rely on shared memory / explicit memory tools instead of inbox handoff content if needed.