### PR TITLE
bug(auth): UI and /v1/auth/config support for ORLOJ_SETUP_TOKEN setup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@ go run ./cmd/orlojctl validate -f examples/
 - [ ] I added a changelog entry under `[Unreleased]` when user-visible behavior changed.
 - [ ] I kept this PR focused and avoided unrelated refactors.
 - [ ] I included DCO sign-off (`git commit -s`).
+- [ ] I confirmed my commit author email is linked to my GitHub account (or GitHub `noreply`) so contributor attribution works.
 
 ## Risk and Rollback
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`GET /v1/auth/config`**: `setup_token_required` indicates when `ORLOJ_SETUP_TOKEN` is set so clients can require `setup_token` on initial setup; the web console setup page shows a setup-token field when applicable. `orlojctl status` includes `setup_token_required` in table/JSON output.
+
 ### Fixed
 
 - **Sequential agent handoffs**: Downstream agents in sequential task execution now receive the upstream agent's actual output (`result.Output`) before falling back to the last event message, instead of being handed generic values such as `worker completed`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,14 +59,14 @@ go run ./cmd/orlojctl get task bp-pipeline-task
 
 Run the smallest relevant checks first, then run broader checks before review:
 
-| Change type | Recommended command |
-| --- | --- |
-| Single package change | `go test ./path/to/package -count=1` |
-| API/runtime touched | `go test ./api ./controllers ./store -count=1` |
-| Frontend touched | `cd frontend && bun run build` |
-| Docs touched | `cd docs && bun run build` |
-| Examples/manifests touched | `go run ./cmd/orlojctl validate -f examples/` |
-| Pre-PR full pass | `go test ./... -count=1 -timeout 120s` |
+| Change type                | Recommended command                            |
+| -------------------------- | ---------------------------------------------- |
+| Single package change      | `go test ./path/to/package -count=1`           |
+| API/runtime touched        | `go test ./api ./controllers ./store -count=1` |
+| Frontend touched           | `cd frontend && bun run build`                 |
+| Docs touched               | `cd docs && bun run build`                     |
+| Examples/manifests touched | `go run ./cmd/orlojctl validate -f examples/`  |
+| Pre-PR full pass           | `go test ./... -count=1 -timeout 120s`         |
 
 ## Pull Request Expectations
 
@@ -91,7 +91,7 @@ The root README includes visual media for **Orloj in Action** backed by assets i
 - **[openapi/openapi.yaml](openapi/openapi.yaml)** is **generated**. Do not edit it by hand for `paths`, `info`, or `tags`—changes are overwritten when someone runs the generator.
 - **Regenerate** from the repo root: `python3 openapi/build_openapi.py` (uses Ruby to emit YAML). CI lints with `npx @redocly/cli lint openapi/openapi.yaml`.
 - **Where to edit:**
-  - **[openapi/schemas/*.yaml](openapi/schemas/)** — `components` schemas (fields, types, `description` on properties). Referenced by `$ref` from the root spec.
+  - **[openapi/schemas/\*.yaml](openapi/schemas/)** — `components` schemas (fields, types, `description` on properties). Referenced by `$ref` from the root spec.
   - **[openapi/build_openapi.py](openapi/build_openapi.py)** — `info.description` (keep it high-level), **`tags`** (including tag `description` for groups like secrets), and all **path operations** (`get` / `put` / …). Use operation-level text for resource-specific notes; use tag descriptions for behavior shared by all operations under that tag.
 
 ## Review and Response SLA
@@ -125,6 +125,20 @@ You can add this automatically with:
 ```bash
 git commit -s
 ```
+
+## Commit Identity and Contributor Credit
+
+To ensure your commits are attributed to your GitHub account:
+
+1. Use an email that is added and verified in GitHub **Settings -> Emails**, or use your GitHub `noreply` email.
+2. Check your local commit email before committing:
+   ```bash
+   git config --get user.email
+   ```
+3. (Optional) Set your global GitHub noreply email:
+   ```bash
+   git config --global user.email "YOUR_ID+YOUR_USERNAME@users.noreply.github.com"
+   ```
 
 ## License
 

--- a/api/auth_handlers.go
+++ b/api/auth_handlers.go
@@ -13,9 +13,10 @@ import (
 )
 
 type authConfigResponse struct {
-	Mode          string   `json:"mode"`
-	SetupRequired bool     `json:"setup_required"`
-	LoginMethods  []string `json:"login_methods"`
+	Mode               string   `json:"mode"`
+	SetupRequired      bool     `json:"setup_required"`
+	SetupTokenRequired bool     `json:"setup_token_required"`
+	LoginMethods       []string `json:"login_methods"`
 }
 
 type authRequest struct {
@@ -51,6 +52,7 @@ func (s *Server) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
 	switch s.authMode {
 	case AuthModeNative:
 		resp.LoginMethods = []string{"password"}
+		resp.SetupTokenRequired = strings.TrimSpace(os.Getenv("ORLOJ_SETUP_TOKEN")) != ""
 		userCount, err := s.stores.LocalAdmins.CountUsers()
 		if err != nil {
 			http.Error(w, "auth store error", http.StatusInternalServerError)

--- a/api/auth_native_test.go
+++ b/api/auth_native_test.go
@@ -67,6 +67,9 @@ func TestNativeAuthSetupLoginAndProtectedRoutes(t *testing.T) {
 	if cfg["setup_required"] != true {
 		t.Fatalf("expected setup_required=true, got %v", cfg["setup_required"])
 	}
+	if cfg["setup_token_required"] != false {
+		t.Fatalf("expected setup_token_required=false when ORLOJ_SETUP_TOKEN unset, got %v", cfg["setup_token_required"])
+	}
 
 	resp, err = client.Get(server.URL + "/v1/tasks")
 	if err != nil {
@@ -387,6 +390,47 @@ func TestNativeAuthSessionExpiryEnforced(t *testing.T) {
 	if resp.StatusCode != http.StatusUnauthorized {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 401 after session expiry, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+}
+
+func TestNativeAuthConfigSetupTokenRequired(t *testing.T) {
+	t.Setenv("ORLOJ_SETUP_TOKEN", "bootstrap-secret")
+	server := newNativeAuthServer(t)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/v1/auth/config")
+	if err != nil {
+		t.Fatalf("config request failed: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode config failed: %v", err)
+	}
+	resp.Body.Close()
+	if cfg["setup_token_required"] != true {
+		t.Fatalf("expected setup_token_required=true when ORLOJ_SETUP_TOKEN set, got %v", cfg["setup_token_required"])
+	}
+
+	noToken := []byte(`{"username":"admin","password":"very-strong-pass-12"}`)
+	resp, err = http.Post(server.URL+"/v1/auth/setup", "application/json", bytes.NewReader(noToken))
+	if err != nil {
+		t.Fatalf("setup without token failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 403 without setup_token, got %d body=%s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	withToken := []byte(`{"username":"admin","password":"very-strong-pass-12","setup_token":"bootstrap-secret"}`)
+	resp, err = http.Post(server.URL+"/v1/auth/setup", "application/json", bytes.NewReader(withToken))
+	if err != nil {
+		t.Fatalf("setup with token failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201 with valid setup_token, got %d body=%s", resp.StatusCode, string(body))
 	}
 	resp.Body.Close()
 }

--- a/cli/orlojctl_extended.go
+++ b/cli/orlojctl_extended.go
@@ -643,8 +643,9 @@ func runStatus(args []string) error {
 		Namespaces []string `json:"namespaces"`
 	}
 	var auth struct {
-		Mode          string `json:"mode"`
-		SetupRequired bool   `json:"setup_required"`
+		Mode               string `json:"mode"`
+		SetupRequired      bool   `json:"setup_required"`
+		SetupTokenRequired bool   `json:"setup_token_required"`
 	}
 	_ = json.Unmarshal(healthRaw, &health)
 	_ = json.Unmarshal(capRaw, &caps)
@@ -661,7 +662,8 @@ func runStatus(args []string) error {
 		"server":              base,
 		"health":              health.Status,
 		"auth_mode":           auth.Mode,
-		"auth_setup_required": auth.SetupRequired,
+		"auth_setup_required":       auth.SetupRequired,
+		"auth_setup_token_required": auth.SetupTokenRequired,
 		"capabilities_count":  len(caps.Capabilities),
 		"capabilities_at":     caps.GeneratedAt,
 		"workers_count":       len(workers.Items),
@@ -673,7 +675,7 @@ func runStatus(args []string) error {
 	}
 	fmt.Printf("server=%s\n", base)
 	fmt.Printf("health=%s\n", health.Status)
-	fmt.Printf("auth_mode=%s setup_required=%t\n", auth.Mode, auth.SetupRequired)
+	fmt.Printf("auth_mode=%s setup_required=%t setup_token_required=%t\n", auth.Mode, auth.SetupRequired, auth.SetupTokenRequired)
 	fmt.Printf("capabilities=%d generated_at=%s\n", len(caps.Capabilities), caps.GeneratedAt)
 	fmt.Printf("workers=%d\n", len(workers.Items))
 	fmt.Printf("namespaces=%d\n", len(namespaces.Namespaces))

--- a/docs/pages/reference/api.md
+++ b/docs/pages/reference/api.md
@@ -34,7 +34,7 @@ Namespace defaults to `default` and can be overridden with `?namespace=<ns>`.
 ## Authentication Endpoints
 
 - `GET /v1/auth/config`
-  - returns auth mode and login/setup requirements
+  - returns auth mode and login/setup requirements; when mode is `native`, `setup_token_required` is true if the server was started with `ORLOJ_SETUP_TOKEN` (the UI shows a setup-token field; `POST /v1/auth/setup` must include `setup_token`)
 - `POST /v1/auth/setup`
   - one-time native admin bootstrap when auth mode is `native`
 - `POST /v1/auth/login`

--- a/docs/pages/reference/cli.md
+++ b/docs/pages/reference/cli.md
@@ -388,6 +388,8 @@ Checks `/healthz`.
 
 Composite status view using `/healthz`, `/v1/auth/config`, `/v1/capabilities`, `/v1/workers`, and `/v1/namespaces`.
 
+Table output includes `auth_mode`, `setup_required`, and `setup_token_required` (from auth config; the last is true when `ORLOJ_SETUP_TOKEN` is set on the server). JSON/YAML snapshots include `auth_setup_token_required`.
+
 | Flag | Default | Description |
 |---|---|---|
 | `--server` | resolved server | API server URL. |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -217,7 +217,12 @@ export function App() {
         if (!cancelled) {
           setAuth({
             loading: false,
-            config: { mode: "off", setup_required: false, login_methods: [] },
+            config: {
+              mode: "off",
+              setup_required: false,
+              setup_token_required: false,
+              login_methods: [],
+            },
             authenticated: true,
             me: null,
           });
@@ -239,9 +244,17 @@ export function App() {
                 <h1 className="page__title">Loading</h1>
               </div>
             </div>
-          ) : isNativeAuthMode(auth.config?.mode) && auth.config.setup_required ? (
+          ) : isNativeAuthMode(auth.config?.mode) && auth.config?.setup_required ? (
             <Routes>
-              <Route path="/setup" element={<Setup onSuccess={refreshAuth} />} />
+              <Route
+                path="/setup"
+                element={
+                  <Setup
+                    onSuccess={refreshAuth}
+                    setupTokenRequired={auth.config?.setup_token_required === true}
+                  />
+                }
+              />
               <Route path="*" element={<Navigate to="/setup" replace />} />
             </Routes>
           ) : isNativeAuthMode(auth.config?.mode) && !auth.authenticated ? (

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -288,6 +288,8 @@ export async function healthCheck(): Promise<boolean> {
 export interface AuthConfigResponse {
   mode: "off" | "native" | "sso" | string;
   setup_required: boolean;
+  /** True when the server has `ORLOJ_SETUP_TOKEN` set; setup must include `setup_token`. */
+  setup_token_required?: boolean;
   login_methods: string[];
 }
 
@@ -327,13 +329,22 @@ export async function getAuthMe(): Promise<AuthMeResponse> {
   return (await resp.json()) as AuthMeResponse;
 }
 
-export async function setupLocalAuth(username: string, password: string): Promise<AuthMeResponse> {
+export async function setupLocalAuth(
+  username: string,
+  password: string,
+  setupToken?: string,
+): Promise<AuthMeResponse> {
   const { apiBase } = getConnection();
   const base = apiBase.replace(/\/$/, "");
+  const body: Record<string, string> = { username, password };
+  const trimmed = setupToken?.trim();
+  if (trimmed) {
+    body.setup_token = trimmed;
+  }
   const resp = await fetchOrThrow(`${base}/v1/auth/setup`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
-    body: JSON.stringify({ username, password }),
+    body: JSON.stringify(body),
   });
   if (!resp.ok) {
     const body = await resp.text();

--- a/frontend/src/pages/Setup.tsx
+++ b/frontend/src/pages/Setup.tsx
@@ -5,13 +5,16 @@ import { AuthShell } from "../components/AuthShell";
 
 interface SetupProps {
   onSuccess: () => void;
+  /** From `GET /v1/auth/config` when `ORLOJ_SETUP_TOKEN` is configured on the server. */
+  setupTokenRequired?: boolean;
 }
 
-export function Setup({ onSuccess }: SetupProps) {
+export function Setup({ onSuccess, setupTokenRequired = false }: SetupProps) {
   const navigate = useNavigate();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [setupToken, setSetupToken] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
 
@@ -21,10 +24,14 @@ export function Setup({ onSuccess }: SetupProps) {
       setError("Passwords do not match");
       return;
     }
+    if (setupTokenRequired && !setupToken.trim()) {
+      setError("Setup token is required");
+      return;
+    }
     setSubmitting(true);
     setError("");
     try {
-      await setupLocalAuth(username, password);
+      await setupLocalAuth(username, password, setupTokenRequired ? setupToken : undefined);
       onSuccess();
       navigate("/", { replace: true });
     } catch (err) {
@@ -41,6 +48,21 @@ export function Setup({ onSuccess }: SetupProps) {
       subtitle="Set up initial credentials to secure this installation."
     >
       <form onSubmit={onSubmit} className="auth-form">
+        {setupTokenRequired && (
+          <label className="auth-form__field">
+            <span className="auth-form__label">Setup token</span>
+            <input
+              type="password"
+              value={setupToken}
+              onChange={(e) => setSetupToken(e.target.value)}
+              autoComplete="off"
+              required
+            />
+            <span className="auth-form__hint">
+              Value of <code>ORLOJ_SETUP_TOKEN</code> on the server.
+            </span>
+          </label>
+        )}
         <label className="auth-form__field">
           <span className="auth-form__label">Username</span>
           <input

--- a/openapi/schemas/common.yaml
+++ b/openapi/schemas/common.yaml
@@ -52,6 +52,9 @@ components:
       properties:
         mode: { type: string }
         setup_required: { type: boolean }
+        setup_token_required:
+          type: boolean
+          description: When true, native initial setup requires `setup_token` in `POST /v1/auth/setup` (matches `ORLOJ_SETUP_TOKEN` on the server).
         login_methods: { type: array, items: { type: string } }
     AuthMeResponse:
       type: object

--- a/testing/docker-compose.embedded.yml
+++ b/testing/docker-compose.embedded.yml
@@ -1,0 +1,63 @@
+# Orloj stack: Postgres + orlojd with embedded worker (memory bus, no NATS).
+
+services:
+  postgres:
+    image: postgres:18
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-orloj}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-orloj}
+    # Postgres 18+ expects the mount at the parent dir (versioned PGDATA below it).
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-orloj} -d ${POSTGRES_DB:-orloj}",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+    restart: unless-stopped
+
+  orlojd:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      target: orlojd
+    image: orloj-orlojd:local
+    environment:
+      ORLOJ_POSTGRES_DSN: ${ORLOJ_POSTGRES_DSN}
+      ORLOJ_AUTH_MODE: ${ORLOJ_AUTH_MODE}
+      ORLOJ_API_TOKEN: ${ORLOJ_API_TOKEN}
+      ORLOJ_SETUP_TOKEN: ${ORLOJ_SETUP_TOKEN:-}
+      ORLOJ_SECRET_ENCRYPTION_KEY: ${ORLOJ_SECRET_ENCRYPTION_KEY:-}
+      ORLOJ_EMBEDDED_WORKER_MAX_CONCURRENT_TASKS: ${ORLOJ_EMBEDDED_WORKER_MAX_CONCURRENT_TASKS}
+      ORLOJ_TASK_WORKER_REGION: ${ORLOJ_TASK_WORKER_REGION:-default}
+    command:
+      - --addr=:8080
+      - --storage-backend=postgres
+      - --task-execution-mode=message-driven
+      - --agent-message-bus-backend=memory
+      - --tool-isolation-backend=container
+      - --tool-container-network=bridge
+      - --embedded-worker
+    ports:
+      - "${ORLOJ_HTTP_PORT:-8080}:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -q -O - http://127.0.0.1:8080/healthz >/dev/null 2>&1",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+    restart: unless-stopped
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
- Add setup_token_required to GET /v1/auth/config when ORLOJ_SETUP_TOKEN is set
- Web console setup form shows setup token field and sends setup_token
- Extend orlojctl status; update OpenAPI, API/CLI docs, and CHANGELOG
- Add API tests for setup token config and setup POST behavior
