### PR TITLE
fix: concurrency races, goroutine leaks, store isolation, and SQL claim filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Rate limiter goroutine leak**: `authRateLimiter` no longer spawns a background goroutine per instance; cleanup runs inline during `allow()`, throttled to every 5 minutes
+- **Watch streams killed by request timeout**: SSE watch endpoints (`/watch` suffix) now bypass the global read timeout middleware
+- **Watch polling with event bus present**: `watchResourceStream` now subscribes to the event bus reactively instead of polling snapshots every 1s when a bus is available
+- **Task controller claim scoping bug**: fixed incorrect indentation/brace alignment in `ReconcileOnce` that caused slot release and early-return paths to execute at the wrong scope
+- **Slice aliasing in worker claim hints**: `workerClaimHints()` now copies `SupportedModels` to prevent mutations from corrupting the worker spec
+- **Work queue blocking on full channel**: replaced fixed-size channel with a growable slice + notify channel so `Enqueue` never blocks
+- **Event bus subscriber double-close panic**: `Subscribe` goroutine now uses a single deferred cleanup, preventing races on concurrent context cancellation
+- **Agent message bus close/send panic**: `Close()` now signals via a broadcast `done` channel instead of closing individual subscriber channels, eliminating send-on-closed-channel races
+- **Bounded tool helpers leaking goroutines**: removed redundant wrapper goroutines in `callToolRuntimeBounded`, `runContainerCommandBounded`, and `executeWASMToolBounded`; the underlying runtimes already honor context cancellation
+- **Embedding provider data race**: `OpenAIEmbeddingProvider.dimensions` is now an `atomic.Int64`
+- **MCP HTTP transport session ID race**: added `RWMutex` for session reads/writes and a serialization mutex for session establishment
+- **MCP image inspect swallowing errors**: `ensureImagePulled` now distinguishes "image not found" from actual Docker daemon errors instead of treating all failures as "not present"
+- **Webhook poll errors silently dropped**: non-context HTTP errors from poll requests now return a proper `ToolError` instead of `nil`
+- **Task store returning shared references**: all `TaskStore` read/write paths now deep-copy tasks to prevent callers from corrupting store state
+- **Worker heartbeat shutdown using cancelled context**: the final "NotReady" write now uses a fresh 5s context instead of the already-cancelled parent
+- **SQL claim missing GPU/model filters**: `claimNextDueTaskSQL` now filters on `RequiresGPU` and `SupportedModels` hints, preventing workers from claiming incompatible tasks
+
 ## [0.9.0] - 2026-04-14
 
 ### Changed

--- a/api/auth_ratelimit.go
+++ b/api/auth_ratelimit.go
@@ -22,6 +22,7 @@ type authRateLimiter struct {
 	trustedProxies []*net.IPNet
 	warnOnce       sync.Once
 	logger         *log.Logger
+	lastCleanup    time.Time
 }
 
 type rateLimiterEntry struct {
@@ -33,11 +34,11 @@ func newAuthRateLimiter(trustedProxies []*net.IPNet, logger *log.Logger) *authRa
 	rl := &authRateLimiter{
 		limiters:       make(map[string]*rateLimiterEntry),
 		rate:           rate.Limit(10.0 / 60.0), // 10 requests per minute sustained
-		burst:          20,                       // allow short bursts for legitimate multi-step flows
+		burst:          20,                      // allow short bursts for legitimate multi-step flows
 		trustedProxies: trustedProxies,
 		logger:         logger,
+		lastCleanup:    time.Now(),
 	}
-	go rl.cleanupLoop()
 	return rl
 }
 
@@ -56,6 +57,7 @@ func (rl *authRateLimiter) allow(r *http.Request) bool {
 	}
 
 	rl.mu.Lock()
+	rl.cleanupLocked(time.Now())
 	entry, ok := rl.limiters[ip]
 	if !ok {
 		entry = &rateLimiterEntry{
@@ -69,19 +71,20 @@ func (rl *authRateLimiter) allow(r *http.Request) bool {
 	return entry.limiter.Allow()
 }
 
-func (rl *authRateLimiter) cleanupLoop() {
-	ticker := time.NewTicker(5 * time.Minute)
-	defer ticker.Stop()
-	for range ticker.C {
-		rl.mu.Lock()
-		cutoff := time.Now().Add(-10 * time.Minute)
-		for ip, entry := range rl.limiters {
-			if entry.lastSeen.Before(cutoff) {
-				delete(rl.limiters, ip)
-			}
-		}
-		rl.mu.Unlock()
+func (rl *authRateLimiter) cleanupLocked(now time.Time) {
+	if rl == nil {
+		return
 	}
+	if !rl.lastCleanup.IsZero() && now.Sub(rl.lastCleanup) < 5*time.Minute {
+		return
+	}
+	cutoff := now.Add(-10 * time.Minute)
+	for ip, entry := range rl.limiters {
+		if entry.lastSeen.Before(cutoff) {
+			delete(rl.limiters, ip)
+		}
+	}
+	rl.lastCleanup = now
 }
 
 // extractClientIP determines the real client IP for rate-limiting purposes.

--- a/api/auth_ratelimit_leak_test.go
+++ b/api/auth_ratelimit_leak_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAuthRateLimiterDoesNotStartBackgroundGoroutines(t *testing.T) {
+	if os.Getenv("ORLOJ_AUTH_RATELIMIT_LEAK_CHILD") == "1" {
+		baseline := runtime.NumGoroutine()
+		for i := 0; i < 8; i++ {
+			_ = newAuthRateLimiter(nil, nil)
+		}
+		time.Sleep(50 * time.Millisecond)
+		fmt.Printf("%d\n", runtime.NumGoroutine()-baseline)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAuthRateLimiterDoesNotStartBackgroundGoroutines$")
+	cmd.Env = append(os.Environ(), "ORLOJ_AUTH_RATELIMIT_LEAK_CHILD=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("limiter subprocess failed: %v\n%s", err, output)
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) == 0 {
+		t.Fatalf("expected goroutine delta output, got %q", output)
+	}
+	delta, err := strconv.Atoi(fields[0])
+	if err != nil {
+		t.Fatalf("parse goroutine delta failed: %v\n%s", err, output)
+	}
+	if delta > 0 {
+		t.Fatalf("expected no background goroutine growth, got delta %d", delta)
+	}
+}

--- a/api/request_timeout_test.go
+++ b/api/request_timeout_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWithRequestTimeoutSkipsStreamingWatchRequests(t *testing.T) {
+	var sawDeadline bool
+	handler := withRequestTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawDeadline = r.Context().Deadline()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/events/watch", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if sawDeadline {
+		t.Fatal("expected streaming watch request to bypass the global timeout")
+	}
+}
+
+func TestWithRequestTimeoutStillAppliesDeadlineToRegularReads(t *testing.T) {
+	var sawDeadline bool
+	handler := withRequestTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawDeadline = r.Context().Deadline()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agents", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !sawDeadline {
+		t.Fatal("expected regular GET requests to retain the read timeout")
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -227,7 +227,7 @@ func normalizeUIBasePath(raw string) string {
 	return p
 }
 
-const (
+var (
 	apiReadTimeout  = 30 * time.Second
 	apiWriteTimeout = 60 * time.Second
 )
@@ -236,14 +236,37 @@ const (
 // (GET, HEAD) get a shorter deadline than mutating methods.
 func withRequestTimeout(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		timeout := apiWriteTimeout
-		if r.Method == http.MethodGet || r.Method == http.MethodHead {
-			timeout = apiReadTimeout
+		timeout, ok := requestTimeoutFor(r)
+		if !ok {
+			next.ServeHTTP(w, r)
+			return
 		}
 		ctx, cancel := context.WithTimeout(r.Context(), timeout)
 		defer cancel()
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func requestTimeoutFor(r *http.Request) (time.Duration, bool) {
+	if isStreamingWatchRequest(r) {
+		return 0, false
+	}
+	timeout := apiWriteTimeout
+	if r != nil && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
+		timeout = apiReadTimeout
+	}
+	return timeout, true
+}
+
+func isStreamingWatchRequest(r *http.Request) bool {
+	if r == nil || r.URL == nil {
+		return false
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return false
+	}
+	path := strings.TrimSpace(r.URL.Path)
+	return path == "/v1/events/watch" || strings.HasSuffix(path, "/watch")
 }
 
 func (s *Server) routes() {

--- a/api/watch.go
+++ b/api/watch.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/OrlojHQ/orloj/resources"
 	"github.com/OrlojHQ/orloj/eventbus"
+	"github.com/OrlojHQ/orloj/resources"
 )
 
 type watchEvent struct {
@@ -26,7 +26,7 @@ type watchRecord struct {
 }
 
 func (s *Server) watchAgents(w http.ResponseWriter, r *http.Request) {
-	s.watchResourceStream(w, r, func() []watchRecord {
+	s.watchResourceStream(w, r, "Agent", func() []watchRecord {
 		items, err := s.stores.Agents.List(r.Context())
 		if err != nil {
 			writeStoreFetchError(w, err)
@@ -47,7 +47,7 @@ func (s *Server) watchAgents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) watchTasks(w http.ResponseWriter, r *http.Request) {
-	s.watchResourceStream(w, r, func() []watchRecord {
+	s.watchResourceStream(w, r, "Task", func() []watchRecord {
 		items, err := s.stores.Tasks.List(r.Context())
 		if err != nil {
 			writeStoreFetchError(w, err)
@@ -67,7 +67,7 @@ func (s *Server) watchTasks(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) watchTaskSchedules(w http.ResponseWriter, r *http.Request) {
-	s.watchResourceStream(w, r, func() []watchRecord {
+	s.watchResourceStream(w, r, "TaskSchedule", func() []watchRecord {
 		items, err := s.stores.TaskSchedules.List(r.Context())
 		if err != nil {
 			writeStoreFetchError(w, err)
@@ -87,7 +87,7 @@ func (s *Server) watchTaskSchedules(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) watchTaskWebhooks(w http.ResponseWriter, r *http.Request) {
-	s.watchResourceStream(w, r, func() []watchRecord {
+	s.watchResourceStream(w, r, "TaskWebhook", func() []watchRecord {
 		items, err := s.stores.TaskWebhooks.List(r.Context())
 		if err != nil {
 			writeStoreFetchError(w, err)
@@ -156,7 +156,7 @@ func (s *Server) watchEvents(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) watchResourceStream(w http.ResponseWriter, r *http.Request, snapshot func() []watchRecord) {
+func (s *Server) watchResourceStream(w http.ResponseWriter, r *http.Request, kind string, snapshot func() []watchRecord) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
@@ -174,81 +174,79 @@ func (s *Server) watchResourceStream(w http.ResponseWriter, r *http.Request, sna
 	seen := make(map[string]int64)
 	heartbeat := time.NewTicker(15 * time.Second)
 	defer heartbeat.Stop()
-	poll := time.NewTicker(1 * time.Second)
-	defer poll.Stop()
-
-	sendSnapshot := func() error {
-		records := snapshot()
-		sort.Slice(records, func(i, j int) bool {
-			left := records[i].Namespace + "/" + records[i].Name
-			right := records[j].Namespace + "/" + records[j].Name
-			return left < right
-		})
-
-		nextSeen := make(map[string]int64, len(records))
-		for _, rec := range records {
-			rec.Namespace = resources.NormalizeNamespace(rec.Namespace)
-			if hasNamespaceFilter && !strings.EqualFold(rec.Namespace, namespaceFilterValue) {
-				continue
-			}
-			if nameFilter != "" && !strings.EqualFold(nameFilter, rec.Name) {
-				continue
-			}
-			recordKey := rec.Namespace + "/" + rec.Name
-			nextSeen[recordKey] = rec.ResourceVersion
-			previousRV, existed := seen[recordKey]
-			if rec.ResourceVersion <= sinceRV {
-				continue
-			}
-			if existed && previousRV == rec.ResourceVersion {
-				continue
-			}
-			eventType := "added"
-			if existed {
-				eventType = "updated"
-			}
-			if err := writeSSE(w, "resource", watchEvent{Type: eventType, Resource: rec.Resource}); err != nil {
-				return err
-			}
-		}
-
-		for key, previousRV := range seen {
-			if _, ok := nextSeen[key]; ok {
-				continue
-			}
-			namespace := ""
-			name := key
-			if parts := strings.SplitN(key, "/", 2); len(parts) == 2 {
-				namespace = parts[0]
-				name = parts[1]
-			}
-			if hasNamespaceFilter && !strings.EqualFold(namespace, namespaceFilterValue) {
-				continue
-			}
-			if nameFilter != "" && !strings.EqualFold(nameFilter, name) {
-				continue
-			}
-			meta := resources.ObjectMeta{Name: name, Namespace: namespace, ResourceVersion: strconv.FormatInt(previousRV, 10)}
-			if err := writeSSE(w, "resource", watchEvent{Type: "deleted", Resource: map[string]any{"metadata": meta}}); err != nil {
-				return err
-			}
-		}
-
-		seen = nextSeen
-		return nil
+	startEventID := uint64(0)
+	if s != nil && s.bus != nil {
+		startEventID = s.bus.LatestID()
 	}
 
-	if err := sendSnapshot(); err != nil {
+	if err := sendWatchSnapshot(w, snapshot(), seen, sinceRV, nameFilter, namespaceFilterValue, hasNamespaceFilter); err != nil {
 		return
 	}
 	flusher.Flush()
+
+	if s == nil || s.bus == nil {
+		s.watchResourceStreamPolling(w, r, snapshot, seen, sinceRV, nameFilter, namespaceFilterValue, hasNamespaceFilter, flusher, heartbeat)
+		return
+	}
+
+	filter := eventbus.Filter{
+		SinceID:   startEventID,
+		Source:    "apiserver",
+		Kind:      strings.TrimSpace(kind),
+		Name:      nameFilter,
+		Namespace: namespaceFilterValue,
+	}
+	if !hasNamespaceFilter {
+		filter.Namespace = ""
+	}
+	stream := s.bus.Subscribe(r.Context(), filter)
 
 	for {
 		select {
 		case <-r.Context().Done():
 			return
-		case <-poll.C:
-			if err := sendSnapshot(); err != nil {
+		case evt := <-stream:
+			record, ok := watchRecordFromResource(evt.Data)
+			if !ok {
+				if strings.EqualFold(strings.TrimSpace(evt.Action), "deleted") {
+					record = watchRecord{
+						Name:      strings.TrimSpace(evt.Name),
+						Namespace: resources.NormalizeNamespace(strings.TrimSpace(evt.Namespace)),
+						Resource: map[string]any{
+							"metadata": resources.ObjectMeta{
+								Name:      strings.TrimSpace(evt.Name),
+								Namespace: resources.NormalizeNamespace(strings.TrimSpace(evt.Namespace)),
+							},
+						},
+					}
+				} else {
+					continue
+				}
+			}
+			if hasNamespaceFilter && !strings.EqualFold(record.Namespace, namespaceFilterValue) {
+				continue
+			}
+			if nameFilter != "" && !strings.EqualFold(record.Name, nameFilter) {
+				continue
+			}
+			eventType := watchEventTypeForAction(evt.Action)
+			if eventType != "deleted" {
+				recordKey := record.Namespace + "/" + record.Name
+				if record.ResourceVersion <= sinceRV {
+					continue
+				}
+				if previousRV, existed := seen[recordKey]; existed && record.ResourceVersion != 0 && previousRV == record.ResourceVersion {
+					continue
+				}
+				seen[recordKey] = record.ResourceVersion
+			} else {
+				recordKey := record.Namespace + "/" + record.Name
+				if _, existed := seen[recordKey]; !existed {
+					continue
+				}
+				delete(seen, recordKey)
+			}
+			if err := writeSSE(w, "resource", watchEvent{Type: eventType, Resource: record.Resource}); err != nil {
 				return
 			}
 			flusher.Flush()
@@ -258,6 +256,196 @@ func (s *Server) watchResourceStream(w http.ResponseWriter, r *http.Request, sna
 			}
 			flusher.Flush()
 		}
+	}
+}
+
+func (s *Server) watchResourceStreamPolling(
+	w http.ResponseWriter,
+	r *http.Request,
+	snapshot func() []watchRecord,
+	seen map[string]int64,
+	sinceRV int64,
+	nameFilter string,
+	namespaceFilterValue string,
+	hasNamespaceFilter bool,
+	flusher http.Flusher,
+	heartbeat *time.Ticker,
+) {
+	poll := time.NewTicker(1 * time.Second)
+	defer poll.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-poll.C:
+			if err := sendWatchSnapshot(w, snapshot(), seen, sinceRV, nameFilter, namespaceFilterValue, hasNamespaceFilter); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": keep-alive\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func sendWatchSnapshot(
+	w http.ResponseWriter,
+	records []watchRecord,
+	seen map[string]int64,
+	sinceRV int64,
+	nameFilter string,
+	namespaceFilterValue string,
+	hasNamespaceFilter bool,
+) error {
+	sort.Slice(records, func(i, j int) bool {
+		left := records[i].Namespace + "/" + records[i].Name
+		right := records[j].Namespace + "/" + records[j].Name
+		return left < right
+	})
+
+	nextSeen := make(map[string]int64, len(records))
+	for _, rec := range records {
+		rec.Namespace = resources.NormalizeNamespace(rec.Namespace)
+		if hasNamespaceFilter && !strings.EqualFold(rec.Namespace, namespaceFilterValue) {
+			continue
+		}
+		if nameFilter != "" && !strings.EqualFold(nameFilter, rec.Name) {
+			continue
+		}
+		recordKey := rec.Namespace + "/" + rec.Name
+		nextSeen[recordKey] = rec.ResourceVersion
+		previousRV, existed := seen[recordKey]
+		if rec.ResourceVersion <= sinceRV {
+			continue
+		}
+		if existed && previousRV == rec.ResourceVersion {
+			continue
+		}
+		eventType := "added"
+		if existed {
+			eventType = "updated"
+		}
+		if err := writeSSE(w, "resource", watchEvent{Type: eventType, Resource: rec.Resource}); err != nil {
+			return err
+		}
+	}
+
+	for key, previousRV := range seen {
+		if _, ok := nextSeen[key]; ok {
+			continue
+		}
+		namespace := ""
+		name := key
+		if parts := strings.SplitN(key, "/", 2); len(parts) == 2 {
+			namespace = parts[0]
+			name = parts[1]
+		}
+		if hasNamespaceFilter && !strings.EqualFold(namespace, namespaceFilterValue) {
+			continue
+		}
+		if nameFilter != "" && !strings.EqualFold(nameFilter, name) {
+			continue
+		}
+		meta := resources.ObjectMeta{Name: name, Namespace: namespace, ResourceVersion: strconv.FormatInt(previousRV, 10)}
+		if err := writeSSE(w, "resource", watchEvent{Type: "deleted", Resource: map[string]any{"metadata": meta}}); err != nil {
+			return err
+		}
+	}
+
+	for key := range seen {
+		delete(seen, key)
+	}
+	for key, value := range nextSeen {
+		seen[key] = value
+	}
+	return nil
+}
+
+func watchRecordFromResource(resource any) (watchRecord, bool) {
+	switch obj := resource.(type) {
+	case resources.Agent:
+		return watchRecord{
+			Name:            strings.TrimSpace(obj.Metadata.Name),
+			Namespace:       resources.NormalizeNamespace(obj.Metadata.Namespace),
+			ResourceVersion: parseResourceVersion(obj.Metadata.ResourceVersion),
+			Resource:        obj,
+		}, true
+	case resources.Task:
+		return watchRecord{
+			Name:            strings.TrimSpace(obj.Metadata.Name),
+			Namespace:       resources.NormalizeNamespace(obj.Metadata.Namespace),
+			ResourceVersion: parseResourceVersion(obj.Metadata.ResourceVersion),
+			Resource:        obj,
+		}, true
+	case resources.TaskSchedule:
+		return watchRecord{
+			Name:            strings.TrimSpace(obj.Metadata.Name),
+			Namespace:       resources.NormalizeNamespace(obj.Metadata.Namespace),
+			ResourceVersion: parseResourceVersion(obj.Metadata.ResourceVersion),
+			Resource:        obj,
+		}, true
+	case resources.TaskWebhook:
+		return watchRecord{
+			Name:            strings.TrimSpace(obj.Metadata.Name),
+			Namespace:       resources.NormalizeNamespace(obj.Metadata.Namespace),
+			ResourceVersion: parseResourceVersion(obj.Metadata.ResourceVersion),
+			Resource:        obj,
+		}, true
+	case map[string]any:
+		meta, ok := watchObjectMetaFromMap(obj["metadata"])
+		if !ok {
+			return watchRecord{}, false
+		}
+		return watchRecord{
+			Name:            strings.TrimSpace(meta.Name),
+			Namespace:       resources.NormalizeNamespace(meta.Namespace),
+			ResourceVersion: parseResourceVersion(meta.ResourceVersion),
+			Resource:        obj,
+		}, true
+	default:
+		return watchRecord{}, false
+	}
+}
+
+func watchObjectMetaFromMap(raw any) (resources.ObjectMeta, bool) {
+	switch meta := raw.(type) {
+	case resources.ObjectMeta:
+		return meta, true
+	case map[string]string:
+		return resources.ObjectMeta{
+			Name:            strings.TrimSpace(meta["name"]),
+			Namespace:       resources.NormalizeNamespace(meta["namespace"]),
+			ResourceVersion: strings.TrimSpace(meta["resourceVersion"]),
+		}, true
+	case map[string]any:
+		out := resources.ObjectMeta{}
+		if name, ok := meta["name"].(string); ok {
+			out.Name = strings.TrimSpace(name)
+		}
+		if namespace, ok := meta["namespace"].(string); ok {
+			out.Namespace = resources.NormalizeNamespace(namespace)
+		}
+		if rv, ok := meta["resourceVersion"].(string); ok {
+			out.ResourceVersion = strings.TrimSpace(rv)
+		}
+		return out, strings.TrimSpace(out.Name) != ""
+	default:
+		return resources.ObjectMeta{}, false
+	}
+}
+
+func watchEventTypeForAction(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "created":
+		return "added"
+	case "deleted":
+		return "deleted"
+	default:
+		return "updated"
 	}
 }
 

--- a/api/watch_repro_test.go
+++ b/api/watch_repro_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/OrlojHQ/orloj/eventbus"
+)
+
+func TestWatchResourceStreamDoesNotPollWhenEventBusIsAvailable(t *testing.T) {
+	var snapshots atomic.Int32
+	server := &Server{bus: eventbus.NewMemoryBus(32)}
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("GET", "/v1/tasks/watch", nil).WithContext(ctx)
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		server.watchResourceStream(recorder, req, "Task", func() []watchRecord {
+			snapshots.Add(1)
+			return []watchRecord{{
+				Name:            "task-a",
+				Namespace:       "default",
+				ResourceVersion: 1,
+				Resource:        map[string]any{"metadata": map[string]any{"name": "task-a"}},
+			}}
+		})
+	}()
+
+	time.Sleep(2200 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for watch stream shutdown")
+	}
+
+	if got := snapshots.Load(); got != 1 {
+		t.Fatalf("expected only the initial snapshot when idle, got %d snapshots", got)
+	}
+}

--- a/controllers/task_controller.go
+++ b/controllers/task_controller.go
@@ -195,19 +195,19 @@ func (c *TaskController) ReconcileOnce(ctx context.Context) error {
 		}
 		task, claimed, err := c.taskStore.ClaimNextDue(ctx, c.workerID, c.leaseDuration, c.workerClaimHints(), c.taskMatchesWorker)
 		if err != nil {
-		if slotAcquired {
-			_ = c.workerStore.ReleaseSlot(ctx, c.workerID)
+			if slotAcquired {
+				_ = c.workerStore.ReleaseSlot(ctx, c.workerID)
+			}
+			return err
 		}
-		return err
-	}
-	if !claimed {
-		if slotAcquired {
-			_ = c.workerStore.ReleaseSlot(ctx, c.workerID)
+		if !claimed {
+			if slotAcquired {
+				_ = c.workerStore.ReleaseSlot(ctx, c.workerID)
+			}
+			return nil
 		}
-		return nil
-	}
 
-	taskKey := taskScopedName(task)
+		taskKey := taskScopedName(task)
 		stopHeartbeat := c.startHeartbeat(ctx, taskKey)
 		c.appendTaskLog(taskKey, fmt.Sprintf("task claimed by worker=%s lease=%s", c.workerID, c.leaseDuration))
 		c.appendTaskHistory(&task, "claim", fmt.Sprintf("task claimed by worker=%s lease=%s", c.workerID, c.leaseDuration))
@@ -1673,7 +1673,7 @@ func (c *TaskController) workerClaimHints() store.WorkerClaimHints {
 	return store.WorkerClaimHints{
 		AssignedWorker:  c.workerID,
 		Region:          strings.TrimSpace(worker.Spec.Region),
-		SupportedModels: worker.Spec.Capabilities.SupportedModels,
+		SupportedModels: append([]string(nil), worker.Spec.Capabilities.SupportedModels...),
 	}
 }
 
@@ -2124,4 +2124,3 @@ func dedupeStringsController(values []string) []string {
 	}
 	return out
 }
-

--- a/controllers/worker_controller.go
+++ b/controllers/worker_controller.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/OrlojHQ/orloj/resources"
 	"github.com/OrlojHQ/orloj/eventbus"
+	"github.com/OrlojHQ/orloj/resources"
 	"github.com/OrlojHQ/orloj/store"
 )
 
@@ -70,15 +70,14 @@ func (c *WorkerController) ReconcileOnce() error {
 	c.enqueueAll(ctx, queue)
 
 	for {
-		select {
-		case key := <-queue.ch:
-			if err := c.reconcileByName(ctx, key); err != nil {
-				return err
-			}
-			queue.Done(key)
-		default:
+		key, ok := queue.TryPop()
+		if !ok {
 			return nil
 		}
+		if err := c.reconcileByName(ctx, key); err != nil {
+			return err
+		}
+		queue.Done(key)
 	}
 }
 

--- a/controllers/workqueue.go
+++ b/controllers/workqueue.go
@@ -7,9 +7,10 @@ import (
 )
 
 type keyQueue struct {
-	ch      chan string
 	mu      sync.Mutex
 	pending map[string]struct{}
+	items   []string
+	notify  chan struct{}
 }
 
 func newKeyQueue(size int) *keyQueue {
@@ -17,8 +18,9 @@ func newKeyQueue(size int) *keyQueue {
 		size = 1024
 	}
 	return &keyQueue{
-		ch:      make(chan string, size),
 		pending: make(map[string]struct{}),
+		items:   make([]string, 0, size),
+		notify:  make(chan struct{}, 1),
 	}
 }
 
@@ -33,17 +35,37 @@ func (q *keyQueue) Enqueue(key string) {
 		return
 	}
 	q.pending[key] = struct{}{}
+	q.items = append(q.items, key)
 	q.mu.Unlock()
-	q.ch <- key
+	select {
+	case q.notify <- struct{}{}:
+	default:
+	}
 }
 
 func (q *keyQueue) Pop(ctx context.Context) (string, bool) {
-	select {
-	case <-ctx.Done():
-		return "", false
-	case key := <-q.ch:
-		return key, true
+	for {
+		if key, ok := q.TryPop(); ok {
+			return key, true
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", false
+		case <-q.notify:
+		}
 	}
+}
+
+func (q *keyQueue) TryPop() (string, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.items) == 0 {
+		return "", false
+	}
+	key := q.items[0]
+	q.items = q.items[1:]
+	return key, true
 }
 
 func (q *keyQueue) Done(key string) {

--- a/controllers/workqueue_test.go
+++ b/controllers/workqueue_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -65,7 +66,25 @@ func TestKeyQueuePopRespectsCancelledContext(t *testing.T) {
 
 func TestKeyQueueNewKeyQueueDefaultSize(t *testing.T) {
 	q := newKeyQueue(0)
-	if q == nil || cap(q.ch) != 1024 {
-		t.Fatalf("expected default buffer 1024, got cap=%d", cap(q.ch))
+	if q == nil || cap(q.items) != 1024 {
+		t.Fatalf("expected default capacity 1024, got cap=%d", cap(q.items))
+	}
+}
+
+func TestKeyQueueEnqueueDoesNotBlockWhenQueueGrowsPastInitialCapacity(t *testing.T) {
+	q := newKeyQueue(1)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for i := 0; i < 2048; i++ {
+			q.Enqueue(fmt.Sprintf("task-%d", i))
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected enqueue loop to remain non-blocking")
 	}
 }

--- a/eventbus/memory_bus.go
+++ b/eventbus/memory_bus.go
@@ -124,18 +124,15 @@ func (b *MemoryBus) Subscribe(ctx context.Context, filter Filter) <-chan Event {
 	b.mu.Unlock()
 
 	go func() {
+		defer b.removeSubscriber(subID)
 		for _, evt := range snapshot {
 			select {
 			case <-ctx.Done():
-				b.removeSubscriber(subID)
-				close(ch)
 				return
 			case ch <- evt:
 			}
 		}
 		<-ctx.Done()
-		b.removeSubscriber(subID)
-		close(ch)
 	}()
 
 	return ch

--- a/eventbus/memory_bus_test.go
+++ b/eventbus/memory_bus_test.go
@@ -2,6 +2,7 @@ package eventbus
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 )
@@ -46,5 +47,68 @@ func TestMemoryBusSubscribeWithSinceID(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for replayed event")
+	}
+}
+
+func TestMemoryBusPublishWhileSubscribersCancel(t *testing.T) {
+	bus := NewMemoryBus(64)
+	panicCh := make(chan any, 1)
+	stop := make(chan struct{})
+
+	var publishers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		publishers.Add(1)
+		go func(idx int) {
+			defer publishers.Done()
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					select {
+					case panicCh <- recovered:
+					default:
+					}
+				}
+			}()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					bus.Publish(Event{
+						Source: "apiserver",
+						Type:   "resource.updated",
+						Kind:   "Task",
+						Name:   "task-a",
+						Action: "publisher",
+					})
+				}
+			}
+		}(i)
+	}
+
+	var subscribers sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		subscribers.Add(1)
+		go func(idx int) {
+			defer subscribers.Done()
+			ctx, cancel := context.WithCancel(context.Background())
+			ch := bus.Subscribe(ctx, Filter{Kind: "Task"})
+			time.Sleep(time.Duration((idx%5)+1) * time.Millisecond)
+			select {
+			case <-ch:
+			default:
+			}
+			cancel()
+		}(i)
+	}
+
+	subscribers.Wait()
+	time.Sleep(25 * time.Millisecond)
+	close(stop)
+	publishers.Wait()
+
+	select {
+	case recovered := <-panicCh:
+		t.Fatalf("publish panicked during subscriber cancellation: %v", recovered)
+	default:
 	}
 }

--- a/resources/task_deepcopy.go
+++ b/resources/task_deepcopy.go
@@ -1,0 +1,87 @@
+package resources
+
+func (t Task) DeepCopy() Task {
+	copy := t
+	copy.Metadata = copyObjectMeta(t.Metadata)
+	copy.Spec = copyTaskSpec(t.Spec)
+	copy.Status = copyTaskStatus(t.Status)
+	return copy
+}
+
+func copyObjectMeta(meta ObjectMeta) ObjectMeta {
+	copy := meta
+	copy.Labels = copyStringMap(meta.Labels)
+	copy.Annotations = copyStringMap(meta.Annotations)
+	return copy
+}
+
+func copyTaskSpec(spec TaskSpec) TaskSpec {
+	copy := spec
+	copy.Input = copyStringMap(spec.Input)
+	if spec.MessageRetry.NonRetryable != nil {
+		copy.MessageRetry.NonRetryable = append([]string(nil), spec.MessageRetry.NonRetryable...)
+	}
+	return copy
+}
+
+func copyTaskStatus(status TaskStatus) TaskStatus {
+	copy := status
+	copy.Output = copyStringMap(status.Output)
+	copy.Trace = copyTaskTrace(status.Trace)
+	copy.History = append([]TaskHistoryEvent(nil), status.History...)
+	copy.Messages = append([]TaskMessage(nil), status.Messages...)
+	copy.MessageIdempotency = append([]TaskMessageIdempotency(nil), status.MessageIdempotency...)
+	copy.JoinStates = copyTaskJoinStates(status.JoinStates)
+	copy.DelegationStates = copyTaskDelegationStates(status.DelegationStates)
+	return copy
+}
+
+func copyTaskTrace(events []TaskTraceEvent) []TaskTraceEvent {
+	if events == nil {
+		return nil
+	}
+	copy := make([]TaskTraceEvent, len(events))
+	for i, event := range events {
+		copy[i] = event
+		if event.Retryable != nil {
+			retryable := *event.Retryable
+			copy[i].Retryable = &retryable
+		}
+	}
+	return copy
+}
+
+func copyTaskJoinStates(states []TaskJoinState) []TaskJoinState {
+	if states == nil {
+		return nil
+	}
+	copy := make([]TaskJoinState, len(states))
+	for i, state := range states {
+		copy[i] = state
+		copy[i].Sources = append([]TaskJoinSource(nil), state.Sources...)
+	}
+	return copy
+}
+
+func copyTaskDelegationStates(states []TaskDelegationState) []TaskDelegationState {
+	if states == nil {
+		return nil
+	}
+	copy := make([]TaskDelegationState, len(states))
+	for i, state := range states {
+		copy[i] = state
+		copy[i].Sources = append([]TaskJoinSource(nil), state.Sources...)
+	}
+	return copy
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/runtime/agent_message_bus_memory.go
+++ b/runtime/agent_message_bus_memory.go
@@ -57,6 +57,8 @@ type MemoryAgentMessageBus struct {
 	history       []AgentMessage
 	dedupe        map[string]time.Time
 	subs          map[uint64]*memorySubscriber
+	done          chan struct{}
+	closeOnce     sync.Once
 }
 
 func NewMemoryAgentMessageBus(subjectPrefix string, historyMax int, dedupeWindow time.Duration) *MemoryAgentMessageBus {
@@ -73,6 +75,7 @@ func NewMemoryAgentMessageBus(subjectPrefix string, historyMax int, dedupeWindow
 		history:       make([]AgentMessage, 0, historyMax),
 		dedupe:        make(map[string]time.Time),
 		subs:          make(map[uint64]*memorySubscriber),
+		done:          make(chan struct{}),
 	}
 }
 
@@ -81,9 +84,16 @@ func (b *MemoryAgentMessageBus) Publish(_ context.Context, message AgentMessage)
 	if err != nil {
 		return AgentMessage{}, err
 	}
+	if b.isClosed() {
+		return normalized, nil
+	}
 	subject := messageSubject(b.subjectPrefix, normalized.Namespace, normalized.ToAgent)
 
 	b.mu.Lock()
+	if b.isClosed() {
+		b.mu.Unlock()
+		return normalized, nil
+	}
 	b.pruneDedupeLocked()
 	if seenAt, exists := b.dedupe[normalized.MessageID]; exists {
 		if time.Since(seenAt) <= b.dedupeWindow {
@@ -126,6 +136,10 @@ func (b *MemoryAgentMessageBus) Consume(ctx context.Context, sub AgentMessageSub
 	}
 
 	b.mu.Lock()
+	if b.isClosed() {
+		b.mu.Unlock()
+		return nil
+	}
 	b.nextSubID++
 	consumer.id = b.nextSubID
 	b.subs[consumer.id] = consumer
@@ -146,10 +160,9 @@ func (b *MemoryAgentMessageBus) Consume(ctx context.Context, sub AgentMessageSub
 		select {
 		case <-ctx.Done():
 			return nil
-		case message, ok := <-consumer.ch:
-			if !ok {
-				return nil
-			}
+		case <-b.done:
+			return nil
+		case message := <-consumer.ch:
 			msg := message
 			delivery := &memoryDelivery{
 				message: msg,
@@ -175,24 +188,21 @@ func (b *MemoryAgentMessageBus) Consume(ctx context.Context, sub AgentMessageSub
 }
 
 func (b *MemoryAgentMessageBus) Close() error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	for id, sub := range b.subs {
-		delete(b.subs, id)
-		close(sub.ch)
-	}
+	b.closeOnce.Do(func() {
+		close(b.done)
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		for id := range b.subs {
+			delete(b.subs, id)
+		}
+	})
 	return nil
 }
 
 func (b *MemoryAgentMessageBus) removeSubscriber(id uint64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	sub, ok := b.subs[id]
-	if !ok {
-		return
-	}
 	delete(b.subs, id)
-	close(sub.ch)
 }
 
 func (b *MemoryAgentMessageBus) pruneDedupeLocked() {
@@ -205,6 +215,9 @@ func (b *MemoryAgentMessageBus) pruneDedupeLocked() {
 }
 
 func (b *MemoryAgentMessageBus) requeueToSubscriber(id uint64, message AgentMessage, delay time.Duration) {
+	if b.isClosed() {
+		return
+	}
 	if delay <= 0 {
 		b.pushToSubscriber(id, message)
 		return
@@ -212,12 +225,19 @@ func (b *MemoryAgentMessageBus) requeueToSubscriber(id uint64, message AgentMess
 	timer := time.NewTimer(delay)
 	go func() {
 		defer timer.Stop()
-		<-timer.C
-		b.pushToSubscriber(id, message)
+		select {
+		case <-b.done:
+			return
+		case <-timer.C:
+			b.pushToSubscriber(id, message)
+		}
 	}()
 }
 
 func (b *MemoryAgentMessageBus) pushToSubscriber(id uint64, message AgentMessage) {
+	if b.isClosed() {
+		return
+	}
 	b.mu.Lock()
 	sub, ok := b.subs[id]
 	b.mu.Unlock()
@@ -225,26 +245,43 @@ func (b *MemoryAgentMessageBus) pushToSubscriber(id uint64, message AgentMessage
 		return
 	}
 	select {
+	case <-b.done:
+		return
 	case sub.ch <- message:
 	default:
 	}
 }
 
 func (b *MemoryAgentMessageBus) enqueueNonBlocking(ch chan AgentMessage, message AgentMessage) {
-	if ch == nil {
+	if ch == nil || b.isClosed() {
 		return
 	}
 	select {
+	case <-b.done:
+		return
 	case ch <- message:
 	default:
 		// Keep publish/replay non-blocking.
 		select {
+		case <-b.done:
+			return
 		case <-ch:
 		default:
 		}
 		select {
+		case <-b.done:
+			return
 		case ch <- message:
 		default:
 		}
+	}
+}
+
+func (b *MemoryAgentMessageBus) isClosed() bool {
+	select {
+	case <-b.done:
+		return true
+	default:
+		return false
 	}
 }

--- a/runtime/agent_message_bus_memory_test.go
+++ b/runtime/agent_message_bus_memory_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -273,5 +274,153 @@ func TestMemoryAgentMessageBusRetryAfterDelay(t *testing.T) {
 	elapsed := secondAttemptAt.Sub(firstAttemptAt)
 	if elapsed < 100*time.Millisecond {
 		t.Fatalf("expected delayed retry >=100ms, got %s", elapsed)
+	}
+}
+
+func TestMemoryAgentMessageBusPublishWhileConsumersCancel(t *testing.T) {
+	bus := NewMemoryAgentMessageBus("orloj.agentmsg", 64, time.Minute)
+	defer func() { _ = bus.Close() }()
+
+	panicCh := make(chan any, 1)
+	stop := make(chan struct{})
+
+	var publishers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		publishers.Add(1)
+		go func(idx int) {
+			defer publishers.Done()
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					select {
+					case panicCh <- recovered:
+					default:
+					}
+				}
+			}()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if _, err := bus.Publish(context.Background(), AgentMessage{
+						TaskID:    "default/task-cancel",
+						FromAgent: "planner-agent",
+						ToAgent:   "research-agent",
+						Payload:   "keep publishing",
+					}); err != nil {
+						select {
+						case panicCh <- err:
+						default:
+						}
+						return
+					}
+				}
+			}
+		}(i)
+	}
+
+	errCh := make(chan error, 200)
+	var consumers sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		consumers.Add(1)
+		go func(idx int) {
+			defer consumers.Done()
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() {
+				done <- bus.Consume(ctx, AgentMessageSubscription{
+					Namespace: "default",
+					Agent:     "research-agent",
+				}, func(ctx context.Context, delivery AgentMessageDelivery) error {
+					return delivery.Ack(ctx)
+				})
+			}()
+
+			time.Sleep(time.Duration((idx%5)+1) * time.Millisecond)
+			cancel()
+
+			select {
+			case err := <-done:
+				if err != nil {
+					errCh <- err
+				}
+			case <-time.After(2 * time.Second):
+				errCh <- errors.New("timed out waiting for consumer shutdown")
+			}
+		}(i)
+	}
+
+	consumers.Wait()
+	time.Sleep(25 * time.Millisecond)
+	close(stop)
+	publishers.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("consumer returned error: %v", err)
+		}
+	}
+	select {
+	case recovered := <-panicCh:
+		t.Fatalf("publish panicked during consumer cancellation: %v", recovered)
+	default:
+	}
+}
+
+func TestMemoryAgentMessageBusCloseStopsDelayedRequeue(t *testing.T) {
+	bus := NewMemoryAgentMessageBus("orloj.agentmsg", 64, time.Minute)
+
+	var attempts atomic.Int32
+	firstAttempt := make(chan struct{}, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- bus.Consume(context.Background(), AgentMessageSubscription{
+			Namespace: "default",
+			Agent:     "research-agent",
+		}, func(ctx context.Context, delivery AgentMessageDelivery) error {
+			if attempts.Add(1) == 1 {
+				firstAttempt <- struct{}{}
+				return RetryAfter(150*time.Millisecond, errors.New("retry later"))
+			}
+			return delivery.Ack(ctx)
+		})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	if _, err := bus.Publish(context.Background(), AgentMessage{
+		MessageID: "msg-close-delay-1",
+		TaskID:    "default/task-close-delay",
+		FromAgent: "planner-agent",
+		ToAgent:   "research-agent",
+		Type:      "task_handoff",
+		Payload:   "delay then close",
+	}); err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+
+	select {
+	case <-firstAttempt:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first delivery attempt")
+	}
+
+	if err := bus.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("consume returned error after close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for consume shutdown after close")
+	}
+
+	time.Sleep(250 * time.Millisecond)
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("expected delayed requeue to stop after close, got %d attempts", got)
 	}
 }

--- a/runtime/bounded_repro_test.go
+++ b/runtime/bounded_repro_test.go
@@ -1,0 +1,82 @@
+package agentruntime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBoundedHelpersDoNotLeakWhenRuntimeHonorsContext(t *testing.T) {
+	testCases := []string{
+		"governed",
+		"container",
+		"wasm",
+	}
+	for _, mode := range testCases {
+		t.Run(mode, func(t *testing.T) {
+			if os.Getenv("ORLOJ_BOUNDED_LEAK_CHILD") == mode {
+				baseline := runtime.NumGoroutine()
+				for i := 0; i < 4; i++ {
+					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+					switch mode {
+					case "governed":
+						_, _ = callToolRuntimeBounded(ctx, ctxAwareBlockingToolRuntime{}, "tool", "input")
+					case "container":
+						_, _, _ = runContainerCommandBounded(ctx, ctxAwareBlockingContainerRunner{}, "docker", []string{"run"}, "", nil)
+					case "wasm":
+						_, _ = executeWASMToolBounded(ctx, ctxAwareBlockingWASMExecutor{}, WASMToolExecuteRequest{Tool: "tool"})
+					}
+					cancel()
+				}
+				time.Sleep(50 * time.Millisecond)
+				fmt.Printf("%d\n", runtime.NumGoroutine()-baseline)
+				return
+			}
+
+			cmd := exec.Command(os.Args[0], "-test.run=^TestBoundedHelpersDoNotLeakWhenRuntimeHonorsContext$/^"+mode+"$")
+			cmd.Env = append(os.Environ(), "ORLOJ_BOUNDED_LEAK_CHILD="+mode)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("bounded helper subprocess failed: %v\n%s", err, output)
+			}
+			fields := strings.Fields(string(output))
+			if len(fields) == 0 {
+				t.Fatalf("expected goroutine delta output, got %q", output)
+			}
+			delta, err := strconv.Atoi(fields[0])
+			if err != nil {
+				t.Fatalf("parse goroutine delta failed: %v\n%s", err, output)
+			}
+			if delta > 0 {
+				t.Fatalf("expected no leaked goroutines for %s helper, got delta %d", mode, delta)
+			}
+		})
+	}
+}
+
+type ctxAwareBlockingToolRuntime struct{}
+
+func (ctxAwareBlockingToolRuntime) Call(ctx context.Context, _ string, _ string) (string, error) {
+	<-ctx.Done()
+	return "", ctx.Err()
+}
+
+type ctxAwareBlockingContainerRunner struct{}
+
+func (ctxAwareBlockingContainerRunner) Run(ctx context.Context, _ string, _ []string, _ string, _ map[string]string) (string, string, error) {
+	<-ctx.Done()
+	return "", "", ctx.Err()
+}
+
+type ctxAwareBlockingWASMExecutor struct{}
+
+func (ctxAwareBlockingWASMExecutor) Execute(ctx context.Context, _ WASMToolExecuteRequest) (WASMToolExecuteResponse, error) {
+	<-ctx.Done()
+	return WASMToolExecuteResponse{}, ctx.Err()
+}

--- a/runtime/embedding.go
+++ b/runtime/embedding.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -25,7 +26,7 @@ type OpenAIEmbeddingProvider struct {
 	baseURL    string
 	apiKey     string
 	model      string
-	dimensions int
+	dimensions atomic.Int64
 	client     *http.Client
 }
 
@@ -46,7 +47,10 @@ func NewOpenAIEmbeddingProvider(baseURL, apiKey, model string) *OpenAIEmbeddingP
 }
 
 func (p *OpenAIEmbeddingProvider) Dimensions() int {
-	return p.dimensions
+	if p == nil {
+		return 0
+	}
+	return int(p.dimensions.Load())
 }
 
 type openAIEmbeddingRequest struct {
@@ -125,8 +129,8 @@ func (p *OpenAIEmbeddingProvider) Embed(ctx context.Context, texts []string) ([]
 		result[d.Index] = d.Embedding
 	}
 
-	if p.dimensions == 0 && len(result) > 0 && len(result[0]) > 0 {
-		p.dimensions = len(result[0])
+	if len(result) > 0 && len(result[0]) > 0 {
+		p.dimensions.CompareAndSwap(0, int64(len(result[0])))
 	}
 
 	return result, nil

--- a/runtime/embedding_test.go
+++ b/runtime/embedding_test.go
@@ -1,0 +1,66 @@
+package agentruntime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestOpenAIEmbeddingProviderConcurrentDimensionsAccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{
+					"index":     0,
+					"embedding": []float32{0.1, 0.2, 0.3},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	provider := &OpenAIEmbeddingProvider{
+		baseURL: server.URL,
+		model:   "text-embedding-3-small",
+		client:  server.Client(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 32)
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 8; j++ {
+				if _, err := provider.Embed(ctx, []string{"hello"}); err != nil {
+					errCh <- err
+					return
+				}
+				if got := provider.Dimensions(); got != 0 && got != 3 {
+					errCh <- context.Canceled
+					t.Errorf("unexpected dimensions value %d", got)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrent embedding call failed: %v", err)
+		}
+	}
+	if got := provider.Dimensions(); got != 3 {
+		t.Fatalf("expected cached dimensions=3, got %d", got)
+	}
+}

--- a/runtime/mcp_integration_test.go
+++ b/runtime/mcp_integration_test.go
@@ -995,6 +995,45 @@ func TestBuildContainerStdioTransport(t *testing.T) {
 	})
 }
 
+func TestEnsureImagePulledDoesNotPullOnInspectInfrastructureError(t *testing.T) {
+	mgr := NewMcpSessionManager(nil)
+	mgr.imageInspect = func(context.Context, string, string) (bool, error) {
+		return false, context.DeadlineExceeded
+	}
+	pulled := false
+	mgr.imagePull = func(context.Context, string, string) error {
+		pulled = true
+		return nil
+	}
+
+	err := mgr.ensureImagePulled(context.Background(), "docker", "example:latest")
+	if err == nil {
+		t.Fatal("expected inspect infrastructure error")
+	}
+	if pulled {
+		t.Fatal("expected pull to be skipped when inspect fails for infrastructure reasons")
+	}
+}
+
+func TestEnsureImagePulledPullsOnlyWhenImageIsMissing(t *testing.T) {
+	mgr := NewMcpSessionManager(nil)
+	mgr.imageInspect = func(context.Context, string, string) (bool, error) {
+		return false, nil
+	}
+	pulls := 0
+	mgr.imagePull = func(context.Context, string, string) error {
+		pulls++
+		return nil
+	}
+
+	if err := mgr.ensureImagePulled(context.Background(), "docker", "example:latest"); err != nil {
+		t.Fatalf("ensureImagePulled failed: %v", err)
+	}
+	if pulls != 1 {
+		t.Fatalf("expected one image pull, got %d", pulls)
+	}
+}
+
 // trackingMcpTransport wraps mockMcpTransport and calls onClose when closed.
 type trackingMcpTransport struct {
 	mockMcpTransport

--- a/runtime/mcp_session.go
+++ b/runtime/mcp_session.go
@@ -32,12 +32,16 @@ type McpSessionManager struct {
 	secretResolver  SecretResolver
 	allowedCommands []string // if non-empty, only these binaries may be launched for stdio
 	containerConfig *ContainerToolRuntimeConfig
+	imageInspect    func(ctx context.Context, runtimeBinary, image string) (bool, error)
+	imagePull       func(ctx context.Context, runtimeBinary, image string) error
 }
 
 func NewMcpSessionManager(secretResolver SecretResolver) *McpSessionManager {
 	return &McpSessionManager{
 		sessions:       make(map[string]*McpSession),
 		secretResolver: secretResolver,
+		imageInspect:   defaultMcpImageInspect,
+		imagePull:      defaultMcpImagePull,
 	}
 }
 
@@ -327,13 +331,48 @@ func (m *McpSessionManager) containerRuntimeBinary() string {
 func (m *McpSessionManager) ensureImagePulled(ctx context.Context, runtimeBinary, image string) error {
 	inspectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	if err := exec.CommandContext(inspectCtx, runtimeBinary, "image", "inspect", image).Run(); err == nil {
+	present, err := m.inspectImage(inspectCtx, runtimeBinary, image)
+	if err != nil {
+		return err
+	}
+	if present {
 		return nil // already present
 	}
 
 	pullCtx, pullCancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer pullCancel()
-	pullCmd := exec.CommandContext(pullCtx, runtimeBinary, "pull", "--quiet", image)
+	return m.pullImage(pullCtx, runtimeBinary, image)
+}
+
+func (m *McpSessionManager) inspectImage(ctx context.Context, runtimeBinary, image string) (bool, error) {
+	if m != nil && m.imageInspect != nil {
+		return m.imageInspect(ctx, runtimeBinary, image)
+	}
+	return defaultMcpImageInspect(ctx, runtimeBinary, image)
+}
+
+func (m *McpSessionManager) pullImage(ctx context.Context, runtimeBinary, image string) error {
+	if m != nil && m.imagePull != nil {
+		return m.imagePull(ctx, runtimeBinary, image)
+	}
+	return defaultMcpImagePull(ctx, runtimeBinary, image)
+}
+
+func defaultMcpImageInspect(ctx context.Context, runtimeBinary, image string) (bool, error) {
+	cmd := exec.CommandContext(ctx, runtimeBinary, "image", "inspect", image)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+	lower := strings.ToLower(string(out))
+	if strings.Contains(lower, "no such image") || strings.Contains(lower, "no such object") || strings.Contains(lower, "not found") {
+		return false, nil
+	}
+	return false, fmt.Errorf("%s image inspect failed: %w\n%s", runtimeBinary, err, out)
+}
+
+func defaultMcpImagePull(ctx context.Context, runtimeBinary, image string) error {
+	pullCmd := exec.CommandContext(ctx, runtimeBinary, "pull", "--quiet", image)
 	if out, err := pullCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%s pull failed: %w\n%s", runtimeBinary, err, out)
 	}

--- a/runtime/mcp_transport_http.go
+++ b/runtime/mcp_transport_http.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -19,6 +20,8 @@ type StreamableHTTPMcpTransport struct {
 	client       HTTPDoer
 	sessionID    string
 	allowPrivate bool
+	sessionMu    sync.RWMutex
+	establishMu  sync.Mutex
 }
 
 // StreamableHTTPMcpTransportConfig configures the HTTP transport.
@@ -133,8 +136,10 @@ func (t *StreamableHTTPMcpTransport) postRequest(ctx context.Context, method str
 	for k, v := range t.headers {
 		httpReq.Header.Set(k, v)
 	}
-	if t.sessionID != "" {
-		httpReq.Header.Set("Mcp-Session-Id", t.sessionID)
+	sessionID, unlock := t.sessionForRequest()
+	defer unlock()
+	if sessionID != "" {
+		httpReq.Header.Set("Mcp-Session-Id", sessionID)
 	}
 
 	httpResp, err := t.client.Do(httpReq)
@@ -144,7 +149,7 @@ func (t *StreamableHTTPMcpTransport) postRequest(ctx context.Context, method str
 	defer httpResp.Body.Close()
 
 	if sid := httpResp.Header.Get("Mcp-Session-Id"); sid != "" {
-		t.sessionID = sid
+		t.setSessionID(sid)
 	}
 
 	respBody, err := io.ReadAll(io.LimitReader(httpResp.Body, 10*1024*1024))
@@ -185,8 +190,10 @@ func (t *StreamableHTTPMcpTransport) postNotification(ctx context.Context, metho
 	for k, v := range t.headers {
 		httpReq.Header.Set(k, v)
 	}
-	if t.sessionID != "" {
-		httpReq.Header.Set("Mcp-Session-Id", t.sessionID)
+	sessionID, unlock := t.sessionForRequest()
+	defer unlock()
+	if sessionID != "" {
+		httpReq.Header.Set("Mcp-Session-Id", sessionID)
 	}
 
 	httpResp, err := t.client.Do(httpReq)
@@ -194,6 +201,38 @@ func (t *StreamableHTTPMcpTransport) postNotification(ctx context.Context, metho
 		return nil, err
 	}
 	defer httpResp.Body.Close()
+	if sid := httpResp.Header.Get("Mcp-Session-Id"); sid != "" {
+		t.setSessionID(sid)
+	}
 	_, _ = io.ReadAll(httpResp.Body)
 	return httpResp, nil
+}
+
+func (t *StreamableHTTPMcpTransport) sessionForRequest() (string, func()) {
+	if t == nil {
+		return "", func() {}
+	}
+	if sessionID := t.currentSessionID(); sessionID != "" {
+		return sessionID, func() {}
+	}
+	t.establishMu.Lock()
+	return t.currentSessionID(), t.establishMu.Unlock
+}
+
+func (t *StreamableHTTPMcpTransport) currentSessionID() string {
+	if t == nil {
+		return ""
+	}
+	t.sessionMu.RLock()
+	defer t.sessionMu.RUnlock()
+	return t.sessionID
+}
+
+func (t *StreamableHTTPMcpTransport) setSessionID(sessionID string) {
+	if t == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	t.sessionMu.Lock()
+	t.sessionID = strings.TrimSpace(sessionID)
+	t.sessionMu.Unlock()
 }

--- a/runtime/mcp_transport_http_test.go
+++ b/runtime/mcp_transport_http_test.go
@@ -1,0 +1,126 @@
+package agentruntime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestStreamableHTTPMcpTransportConcurrentSessionAccess(t *testing.T) {
+	var nextSession atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		var envelope map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if sid := nextSession.Add(1); sid > 0 {
+			w.Header().Set("Mcp-Session-Id", fmt.Sprintf("sid-%d", sid))
+		}
+		time.Sleep(2 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+
+		method, _ := envelope["method"].(string)
+		if method == "notifications/initialized" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		idBytes, err := json.Marshal(envelope["id"])
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var result any
+		switch method {
+		case "initialize":
+			result = McpInitResult{
+				ProtocolVersion: "2025-03-26",
+				ServerInfo:      McpServerInfo{Name: "test-mcp", Version: "1.0.0"},
+				Capabilities:    McpCapabilities{Tools: &McpToolCapability{ListChanged: false}},
+			}
+		case "tools/list":
+			result = mcpToolsListResult{
+				Tools: []McpToolDefinition{{Name: "noop"}},
+			}
+		case "tools/call":
+			result = McpToolResult{
+				Content: []McpContent{{Type: "text", Text: "ok"}},
+			}
+		default:
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+			return
+		}
+
+		response := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      json.RawMessage(idBytes),
+			"result":  result,
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	endpointURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server url failed: %v", err)
+	}
+	_, port, err := net.SplitHostPort(endpointURL.Host)
+	if err != nil {
+		t.Fatalf("split host port failed: %v", err)
+	}
+	endpointURL.Host = net.JoinHostPort("localhost", port)
+
+	transport := NewStreamableHTTPMcpTransport(StreamableHTTPMcpTransportConfig{
+		Endpoint:     endpointURL.String(),
+		Client:       server.Client(),
+		AllowPrivate: true,
+	})
+
+	if _, err := transport.Initialize(context.Background()); err != nil {
+		t.Fatalf("initialize failed: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 32)
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < 8; j++ {
+				if idx%2 == 0 {
+					if _, err := transport.ListTools(context.Background()); err != nil {
+						errCh <- err
+						return
+					}
+					continue
+				}
+				if _, err := transport.CallTool(context.Background(), "noop", map[string]any{"attempt": j}); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrent MCP request failed: %v", err)
+		}
+	}
+}

--- a/runtime/tool_runtime_conformance_test.go
+++ b/runtime/tool_runtime_conformance_test.go
@@ -48,10 +48,16 @@ type fakeContainerRunner struct {
 	delayOnToken string
 }
 
-func (r *fakeContainerRunner) Run(_ context.Context, _ string, _ []string, stdin string, _ map[string]string) (string, string, error) {
+func (r *fakeContainerRunner) Run(ctx context.Context, _ string, _ []string, stdin string, _ map[string]string) (string, string, error) {
 	if r.delay > 0 {
 		if strings.TrimSpace(r.delayOnToken) == "" || strings.Contains(stdin, r.delayOnToken) {
-			time.Sleep(r.delay)
+			timer := time.NewTimer(r.delay)
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				return "", "", ctx.Err()
+			case <-timer.C:
+			}
 		}
 	}
 	return r.stdout, r.stderr, r.err
@@ -77,7 +83,13 @@ type fakeWASMExecutor struct {
 func (e fakeWASMExecutor) Execute(ctx context.Context, req agentruntime.WASMToolExecuteRequest) (agentruntime.WASMToolExecuteResponse, error) {
 	if e.delay > 0 {
 		if strings.TrimSpace(e.delayOnToken) == "" || strings.Contains(req.Input, e.delayOnToken) {
-			time.Sleep(e.delay)
+			timer := time.NewTimer(e.delay)
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				return agentruntime.WASMToolExecuteResponse{}, ctx.Err()
+			case <-timer.C:
+			}
 		}
 	}
 	return agentruntime.WASMToolExecuteResponse{Output: "ok:" + req.Tool}, nil
@@ -99,8 +111,14 @@ func TestGovernedToolRuntimeConformanceSuite(t *testing.T) {
 				<-ctx.Done()
 				return "", ctx.Err()
 			case "stuck_tool":
-				time.Sleep(250 * time.Millisecond)
-				return "late-result", nil
+				timer := time.NewTimer(250 * time.Millisecond)
+				defer timer.Stop()
+				select {
+				case <-ctx.Done():
+					return "", ctx.Err()
+				case <-timer.C:
+					return "late-result", nil
+				}
 			default:
 				return "ok:" + tool + ":" + input, nil
 			}

--- a/runtime/tool_runtime_container.go
+++ b/runtime/tool_runtime_container.go
@@ -449,26 +449,7 @@ func runContainerCommandBounded(
 	if runner == nil {
 		return "", "", fmt.Errorf("missing container command runner")
 	}
-	type runResult struct {
-		stdout string
-		stderr string
-		err    error
-	}
-	resultCh := make(chan runResult, 1)
-	go func() {
-		stdout, stderr, err := runner.Run(ctx, binary, args, stdin, env)
-		resultCh <- runResult{
-			stdout: stdout,
-			stderr: stderr,
-			err:    err,
-		}
-	}()
-	select {
-	case <-ctx.Done():
-		return "", "", ctx.Err()
-	case result := <-resultCh:
-		return result.stdout, result.stderr, result.err
-	}
+	return runner.Run(ctx, binary, args, stdin, env)
 }
 
 func mapContainerContextError(tool string, err error) error {

--- a/runtime/tool_runtime_container_test.go
+++ b/runtime/tool_runtime_container_test.go
@@ -26,9 +26,15 @@ type sleepingContainerRunner struct {
 	delay time.Duration
 }
 
-func (r sleepingContainerRunner) Run(_ context.Context, _ string, _ []string, _ string, _ map[string]string) (string, string, error) {
-	time.Sleep(r.delay)
-	return "", "", nil
+func (r sleepingContainerRunner) Run(ctx context.Context, _ string, _ []string, _ string, _ map[string]string) (string, string, error) {
+	timer := time.NewTimer(r.delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return "", "", ctx.Err()
+	case <-timer.C:
+		return "", "", nil
+	}
 }
 
 func (r *captureContainerRunner) Run(_ context.Context, binary string, args []string, stdin string, env map[string]string) (string, string, error) {

--- a/runtime/tool_runtime_governed.go
+++ b/runtime/tool_runtime_governed.go
@@ -674,24 +674,7 @@ func callToolRuntimeBounded(ctx context.Context, runtime ToolRuntime, tool strin
 			map[string]string{"tool": strings.TrimSpace(tool)},
 		)
 	}
-	type callResult struct {
-		output string
-		err    error
-	}
-	resultCh := make(chan callResult, 1)
-	go func() {
-		output, err := runtime.Call(ctx, tool, input)
-		resultCh <- callResult{
-			output: output,
-			err:    err,
-		}
-	}()
-	select {
-	case <-ctx.Done():
-		return "", ctx.Err()
-	case result := <-resultCh:
-		return result.output, result.err
-	}
+	return runtime.Call(ctx, tool, input)
 }
 
 func shouldRetryToolError(err error) bool {

--- a/runtime/tool_runtime_governed_test.go
+++ b/runtime/tool_runtime_governed_test.go
@@ -24,9 +24,15 @@ type blockingToolRuntime struct {
 	delay time.Duration
 }
 
-func (r blockingToolRuntime) Call(_ context.Context, _ string, _ string) (string, error) {
-	time.Sleep(r.delay)
-	return "late", nil
+func (r blockingToolRuntime) Call(ctx context.Context, _ string, _ string) (string, error) {
+	timer := time.NewTimer(r.delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case <-timer.C:
+		return "late", nil
+	}
 }
 
 func (r *scriptedToolRuntime) Call(_ context.Context, tool string, _ string) (string, error) {
@@ -391,7 +397,7 @@ func TestGovernedToolRuntimeWithGovernanceAppliesToolPermissionRule(t *testing.T
 	}
 }
 
-func TestGovernedToolRuntimeBoundedTimeoutWhenRuntimeIgnoresContext(t *testing.T) {
+func TestGovernedToolRuntimeBoundedTimeoutWhenRuntimeHonorsContext(t *testing.T) {
 	runtime := NewGovernedToolRuntime(
 		blockingToolRuntime{delay: 250 * time.Millisecond},
 		nil,

--- a/runtime/tool_runtime_wasm_runtime.go
+++ b/runtime/tool_runtime_wasm_runtime.go
@@ -309,21 +309,7 @@ func (r *WASMToolRuntime) resolveExecutor(ctx context.Context) (WASMToolExecutor
 }
 
 func executeWASMToolBounded(ctx context.Context, executor WASMToolExecutor, req WASMToolExecuteRequest) (WASMToolExecuteResponse, error) {
-	type executeResult struct {
-		resp WASMToolExecuteResponse
-		err  error
-	}
-	resultCh := make(chan executeResult, 1)
-	go func() {
-		resp, err := executor.Execute(ctx, req)
-		resultCh <- executeResult{resp: resp, err: err}
-	}()
-	select {
-	case <-ctx.Done():
-		return WASMToolExecuteResponse{}, ctx.Err()
-	case result := <-resultCh:
-		return result.resp, result.err
-	}
+	return executor.Execute(ctx, req)
 }
 
 func mapWASMContextError(tool string, err error) error {

--- a/runtime/tool_runtime_wasm_runtime_test.go
+++ b/runtime/tool_runtime_wasm_runtime_test.go
@@ -77,9 +77,15 @@ func TestWASMToolRuntimeBoundsTimeout(t *testing.T) {
 	runtime := NewWASMToolRuntime(NewStaticToolCapabilityRegistry(map[string]resources.ToolSpec{
 		"slow_tool": {RiskLevel: "high"},
 	}), testWASMExecutor{
-		call: func(_ context.Context, _ WASMToolExecuteRequest) (WASMToolExecuteResponse, error) {
-			time.Sleep(250 * time.Millisecond)
-			return WASMToolExecuteResponse{Output: "late"}, nil
+		call: func(ctx context.Context, _ WASMToolExecuteRequest) (WASMToolExecuteResponse, error) {
+			timer := time.NewTimer(250 * time.Millisecond)
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				return WASMToolExecuteResponse{}, ctx.Err()
+			case <-timer.C:
+				return WASMToolExecuteResponse{Output: "late"}, nil
+			}
 		},
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Millisecond)

--- a/runtime/tool_runtime_webhook_callback.go
+++ b/runtime/tool_runtime_webhook_callback.go
@@ -38,8 +38,8 @@ type WebhookCallbackToolRuntime struct {
 
 // callbackRegistry stores async responses delivered via push callback.
 type callbackRegistry struct {
-	mu       sync.Mutex
-	pending  map[string]chan ToolExecutionResponse
+	mu      sync.Mutex
+	pending map[string]chan ToolExecutionResponse
 }
 
 func newCallbackRegistry() *callbackRegistry {
@@ -363,7 +363,7 @@ func (r *WebhookCallbackToolRuntime) pollOnce(ctx context.Context, tool, pollURL
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 			return "", false, nil
 		}
-		return "", false, nil
+		return "", false, mapWebhookPollError(tool, err)
 	}
 	defer resp.Body.Close()
 
@@ -435,4 +435,16 @@ func mapWebhookHTTPError(tool string, err error) error {
 			map[string]string{"tool": tool, "isolation_mode": "webhook-callback"},
 		)
 	}
+}
+
+func mapWebhookPollError(tool string, err error) error {
+	return NewToolError(
+		ToolStatusError,
+		ToolCodeExecutionFailed,
+		ToolReasonBackendFailure,
+		true,
+		fmt.Sprintf("webhook-callback tool poll failed for tool=%s: %s", tool, RedactSensitive(err.Error())),
+		err,
+		map[string]string{"tool": tool, "isolation_mode": "webhook-callback"},
+	)
 }

--- a/runtime/tool_runtime_webhook_callback_test.go
+++ b/runtime/tool_runtime_webhook_callback_test.go
@@ -174,6 +174,45 @@ func TestWebhookCallbackToolRuntimeTimesOut(t *testing.T) {
 	}
 }
 
+func TestWebhookCallbackToolRuntimePollTransportFailureReturnsBackendError(t *testing.T) {
+	doer := &sequencedDoer{
+		responses: []fakeHTTPDoer{
+			{statusCode: 202, body: `{"status":"accepted"}`},
+			{err: errors.New("dial tcp 127.0.0.1:443: connection refused")},
+		},
+	}
+	registry := NewStaticToolCapabilityRegistry(map[string]resources.ToolSpec{
+		"wh_tool": {
+			Type:     "webhook-callback",
+			Endpoint: "https://wh.example.com/execute",
+		},
+	})
+	runtime := NewWebhookCallbackToolRuntime(registry, nil, doer, 10*time.Millisecond)
+
+	start := time.Now()
+	_, err := runtime.Call(context.Background(), "wh_tool", "input")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected poll transport failure")
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("expected poll failure to surface promptly, elapsed=%s", elapsed)
+	}
+	code, reason, retryable, ok := ToolErrorMeta(err)
+	if !ok {
+		t.Fatal("expected tool error metadata")
+	}
+	if code != ToolCodeExecutionFailed {
+		t.Fatalf("expected code %q, got %q", ToolCodeExecutionFailed, code)
+	}
+	if reason != ToolReasonBackendFailure {
+		t.Fatalf("expected reason %q, got %q", ToolReasonBackendFailure, reason)
+	}
+	if !retryable {
+		t.Fatal("expected backend poll failure to be retryable")
+	}
+}
+
 func TestWebhookCallbackToolRuntimeFailsOnMissingEndpoint(t *testing.T) {
 	registry := NewStaticToolCapabilityRegistry(map[string]resources.ToolSpec{
 		"wh_tool": {Type: "webhook-callback"},

--- a/startup/worker_heartbeat.go
+++ b/startup/worker_heartbeat.go
@@ -42,18 +42,18 @@ func HeartbeatWorkerRegistration(
 			},
 		}
 		for attempt := 0; attempt < 3; attempt++ {
-		if existing, ok, _ := workerStore.Get(ctx, workerID); ok {
-			worker.Metadata.ResourceVersion = existing.Metadata.ResourceVersion
-			worker.Metadata.Generation = existing.Metadata.Generation
-			worker.Metadata.CreatedAt = existing.Metadata.CreatedAt
-			worker.Status.ObservedGeneration = existing.Metadata.Generation
-			if strings.EqualFold(strings.TrimSpace(existing.Status.Phase), "ready") ||
-				strings.EqualFold(strings.TrimSpace(existing.Status.Phase), "pending") {
-				worker.Status.CurrentTasks = existing.Status.CurrentTasks
-			} else {
-				worker.Status.CurrentTasks = 0
+			if existing, ok, _ := workerStore.Get(ctx, workerID); ok {
+				worker.Metadata.ResourceVersion = existing.Metadata.ResourceVersion
+				worker.Metadata.Generation = existing.Metadata.Generation
+				worker.Metadata.CreatedAt = existing.Metadata.CreatedAt
+				worker.Status.ObservedGeneration = existing.Metadata.Generation
+				if strings.EqualFold(strings.TrimSpace(existing.Status.Phase), "ready") ||
+					strings.EqualFold(strings.TrimSpace(existing.Status.Phase), "pending") {
+					worker.Status.CurrentTasks = existing.Status.CurrentTasks
+				} else {
+					worker.Status.CurrentTasks = 0
+				}
 			}
-		}
 			_, err := workerStore.Upsert(ctx, worker)
 			if err == nil {
 				break
@@ -71,12 +71,14 @@ func HeartbeatWorkerRegistration(
 			final := worker
 			final.Status.Phase = "NotReady"
 			final.Status.LastError = "worker stopped"
-		if existing, ok, _ := workerStore.Get(ctx, workerID); ok {
-			final.Metadata.ResourceVersion = existing.Metadata.ResourceVersion
-			final.Metadata.Generation = existing.Metadata.Generation
-			final.Metadata.CreatedAt = existing.Metadata.CreatedAt
-		}
-			_, _ = workerStore.Upsert(ctx, final)
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if existing, ok, _ := workerStore.Get(shutdownCtx, workerID); ok {
+				final.Metadata.ResourceVersion = existing.Metadata.ResourceVersion
+				final.Metadata.Generation = existing.Metadata.Generation
+				final.Metadata.CreatedAt = existing.Metadata.CreatedAt
+			}
+			_, _ = workerStore.Upsert(shutdownCtx, final)
+			cancel()
 			return
 		case <-ticker.C:
 		}

--- a/startup/worker_heartbeat_test.go
+++ b/startup/worker_heartbeat_test.go
@@ -1,0 +1,197 @@
+package startup
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/OrlojHQ/orloj/resources"
+	"github.com/OrlojHQ/orloj/store"
+)
+
+func TestHeartbeatWorkerRegistrationMarksWorkerNotReadyOnShutdown(t *testing.T) {
+	db, state := openHeartbeatReproDB(t)
+	defer db.Close()
+
+	workerStore := store.NewWorkerStoreWithDB(db)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		HeartbeatWorkerRegistration(ctx, workerStore, nil, "worker-a", resources.WorkerSpec{
+			Region:             "default",
+			MaxConcurrentTasks: 1,
+		}, 5*time.Millisecond)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		worker, ok, err := workerStore.Get(context.Background(), "worker-a")
+		if err == nil && ok && strings.EqualFold(worker.Status.Phase, "ready") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for ready heartbeat; ok=%v err=%v state=%s", ok, err, state.phase())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for heartbeat shutdown")
+	}
+
+	worker, ok, err := workerStore.Get(context.Background(), "worker-a")
+	if err != nil {
+		t.Fatalf("get after shutdown failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected worker to remain stored after shutdown")
+	}
+	if !strings.EqualFold(worker.Status.Phase, "notready") {
+		t.Fatalf("expected shutdown to mark worker not ready, got %q", worker.Status.Phase)
+	}
+}
+
+type heartbeatReproState struct {
+	mu           sync.Mutex
+	payload      []byte
+	canceledCall int
+}
+
+func (s *heartbeatReproState) phase() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.payload) == 0 {
+		return ""
+	}
+	var worker resources.Worker
+	if err := json.Unmarshal(s.payload, &worker); err != nil {
+		return ""
+	}
+	return worker.Status.Phase
+}
+
+func (s *heartbeatReproState) recordCanceled() {
+	s.mu.Lock()
+	s.canceledCall++
+	s.mu.Unlock()
+}
+
+func (s *heartbeatReproState) loadPayload() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.payload...)
+}
+
+func (s *heartbeatReproState) storePayload(payload []byte) {
+	s.mu.Lock()
+	s.payload = append([]byte(nil), payload...)
+	s.mu.Unlock()
+}
+
+type heartbeatReproDriver struct {
+	state *heartbeatReproState
+}
+
+type heartbeatReproConn struct {
+	state *heartbeatReproState
+}
+
+type heartbeatReproTx struct{}
+
+type heartbeatReproRows struct {
+	columns []string
+	rows    [][]driver.Value
+	index   int
+}
+
+type heartbeatReproResult int64
+
+func openHeartbeatReproDB(t *testing.T) (*sql.DB, *heartbeatReproState) {
+	t.Helper()
+	state := &heartbeatReproState{}
+	driverName := "heartbeat-repro-" + strings.ReplaceAll(t.Name(), "/", "-")
+	sql.Register(driverName, &heartbeatReproDriver{state: state})
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("open repro db failed: %v", err)
+	}
+	return db, state
+}
+
+func (d *heartbeatReproDriver) Open(string) (driver.Conn, error) {
+	return &heartbeatReproConn{state: d.state}, nil
+}
+
+func (c *heartbeatReproConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not supported")
+}
+
+func (c *heartbeatReproConn) Close() error { return nil }
+
+func (c *heartbeatReproConn) Begin() (driver.Tx, error) { return heartbeatReproTx{}, nil }
+
+func (c *heartbeatReproConn) BeginTx(ctx context.Context, _ driver.TxOptions) (driver.Tx, error) {
+	if err := ctx.Err(); err != nil {
+		c.state.recordCanceled()
+		return nil, err
+	}
+	return heartbeatReproTx{}, nil
+}
+
+func (c *heartbeatReproConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	if err := ctx.Err(); err != nil {
+		c.state.recordCanceled()
+		return nil, err
+	}
+	if strings.Contains(strings.ToLower(query), "insert into workers") && len(args) >= 7 {
+		if payload, ok := args[6].Value.(string); ok {
+			c.state.storePayload([]byte(payload))
+		}
+	}
+	return heartbeatReproResult(1), nil
+}
+
+func (c *heartbeatReproConn) QueryContext(ctx context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+	if err := ctx.Err(); err != nil {
+		c.state.recordCanceled()
+		return nil, err
+	}
+	payload := c.state.loadPayload()
+	if len(payload) == 0 {
+		return &heartbeatReproRows{columns: []string{"payload"}}, nil
+	}
+	return &heartbeatReproRows{
+		columns: []string{"payload"},
+		rows:    [][]driver.Value{{string(payload)}},
+	}, nil
+}
+
+func (heartbeatReproTx) Commit() error   { return nil }
+func (heartbeatReproTx) Rollback() error { return nil }
+
+func (heartbeatReproResult) LastInsertId() (int64, error) { return 0, nil }
+func (heartbeatReproResult) RowsAffected() (int64, error) { return 1, nil }
+
+func (r *heartbeatReproRows) Columns() []string { return r.columns }
+func (r *heartbeatReproRows) Close() error      { return nil }
+
+func (r *heartbeatReproRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.index])
+	r.index++
+	return nil
+}

--- a/store/resource_stores.go
+++ b/store/resource_stores.go
@@ -2049,9 +2049,10 @@ func (s *TaskStore) Upsert(ctx context.Context, item resources.Task) (resources.
 			return resources.Task{}, err
 		}
 	}
-	s.items[key] = item
+	stored := item.DeepCopy()
+	s.items[key] = stored
 	s.mu.Unlock()
-	return item, nil
+	return stored.DeepCopy(), nil
 }
 
 func (s *TaskStore) Get(ctx context.Context, name string) (resources.Task, bool, error) {
@@ -2063,7 +2064,10 @@ func (s *TaskStore) Get(ctx context.Context, name string) (resources.Task, bool,
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	item, ok := s.items[key]
-	return item, ok, nil
+	if !ok {
+		return resources.Task{}, false, nil
+	}
+	return item.DeepCopy(), true, nil
 }
 
 func (s *TaskStore) List(ctx context.Context) ([]resources.Task, error) {
@@ -2084,7 +2088,7 @@ func (s *TaskStore) ListPaged(ctx context.Context, limit, offset int, namespace 
 		if namespace != "" && !strings.EqualFold(resources.NormalizeNamespace(item.Metadata.Namespace), namespace) {
 			continue
 		}
-		out = append(out, item)
+		out = append(out, item.DeepCopy())
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].Metadata.Name < out[j].Metadata.Name
@@ -2110,7 +2114,7 @@ func (s *TaskStore) ListCursor(ctx context.Context, limit int, after, namespace 
 	defer s.mu.RUnlock()
 	out := make([]resources.Task, 0, len(s.items))
 	for _, item := range s.items {
-		out = append(out, item)
+		out = append(out, item.DeepCopy())
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].Metadata.Name < out[j].Metadata.Name
@@ -2200,6 +2204,7 @@ func (s *TaskStore) ClaimIfDue(ctx context.Context, name, workerID string, lease
 	if !ok {
 		return resources.Task{}, false, nil
 	}
+	task = task.DeepCopy()
 	if !isTaskClaimable(task, workerID, now) {
 		return resources.Task{}, false, nil
 	}
@@ -2208,8 +2213,9 @@ func (s *TaskStore) ClaimIfDue(ctx context.Context, name, workerID string, lease
 	if err != nil {
 		return resources.Task{}, false, err
 	}
-	s.items[key] = claimedTask
-	return claimedTask, true, nil
+	stored := claimedTask.DeepCopy()
+	s.items[key] = stored
+	return stored.DeepCopy(), true, nil
 }
 
 func (s *TaskStore) ClaimNextDue(ctx context.Context, workerID string, lease time.Duration, hints WorkerClaimHints, matches func(resources.Task) bool) (resources.Task, bool, error) {
@@ -2230,7 +2236,7 @@ func (s *TaskStore) ClaimNextDue(ctx context.Context, workerID string, lease tim
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		task := s.items[name]
+		task := s.items[name].DeepCopy()
 		if !isTaskClaimable(task, workerID, now) {
 			continue
 		}
@@ -2241,8 +2247,9 @@ func (s *TaskStore) ClaimNextDue(ctx context.Context, workerID string, lease tim
 		if err != nil {
 			return resources.Task{}, false, err
 		}
-		s.items[name] = claimedTask
-		return claimedTask, true, nil
+		stored := claimedTask.DeepCopy()
+		s.items[name] = stored
+		return stored.DeepCopy(), true, nil
 	}
 	return resources.Task{}, false, nil
 }

--- a/store/sql_backend.go
+++ b/store/sql_backend.go
@@ -675,9 +675,9 @@ func claimTaskSQL(ctx context.Context, db *sql.DB, name, workerID string, lease 
 // SQL WHERE clause so a worker never fetches tasks it cannot run.
 // Zero-value fields mean "no filter".
 type WorkerClaimHints struct {
-	AssignedWorker  string // match tasks assigned to this worker (or unassigned)
-	Region          string // match tasks with this region requirement (case-insensitive), or no requirement
-	RequiresGPU     bool   // when false, skip GPU filter; when true only tasks with gpu=true
+	AssignedWorker  string   // match tasks assigned to this worker (or unassigned)
+	Region          string   // match tasks with this region requirement (case-insensitive), or no requirement
+	RequiresGPU     bool     // when true, restrict claims to tasks that explicitly require GPU
 	SupportedModels []string // if non-empty, only tasks whose model requirement is in this list (or unset)
 }
 
@@ -711,6 +711,27 @@ func claimNextDueTaskSQL(ctx context.Context, db *sql.DB, workerID string, lease
 			OR LOWER(assigned_worker) = LOWER($%d)
 		)`, len(args)+1)
 		args = append(args, hints.AssignedWorker)
+	}
+	if hints.RequiresGPU {
+		extraWhere += ` AND LOWER(COALESCE(payload->'spec'->'requirements'->>'gpu', 'false')) = 'true'`
+	}
+	if len(hints.SupportedModels) > 0 {
+		placeholders := make([]string, 0, len(hints.SupportedModels))
+		for _, model := range hints.SupportedModels {
+			model = strings.TrimSpace(model)
+			if model == "" {
+				continue
+			}
+			args = append(args, model)
+			placeholders = append(placeholders, fmt.Sprintf("LOWER($%d)", len(args)))
+		}
+		if len(placeholders) > 0 {
+			extraWhere += fmt.Sprintf(` AND (
+				payload->'spec'->'requirements'->>'model' IS NULL
+				OR payload->'spec'->'requirements'->>'model' = ''
+				OR LOWER(payload->'spec'->'requirements'->>'model') IN (%s)
+			)`, strings.Join(placeholders, ", "))
+		}
 	}
 
 	query := fmt.Sprintf(

--- a/store/sql_backend_integration_test.go
+++ b/store/sql_backend_integration_test.go
@@ -1,0 +1,211 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/OrlojHQ/orloj/resources"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+func TestPostgresTaskStoreClaimNextDueFiltersWorkerHints(t *testing.T) {
+	db := openPostgresForStoreTest(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	taskStore := NewTaskStoreWithDB(db)
+	workerID := "worker-a"
+
+	testCases := []struct {
+		name         string
+		hints        WorkerClaimHints
+		mismatchTask func(int) resources.Task
+		matchTask    resources.Task
+		matches      func(resources.Task) bool
+		wantName     string
+	}{
+		{
+			name:  "assigned_worker",
+			hints: WorkerClaimHints{AssignedWorker: workerID},
+			mismatchTask: func(i int) resources.Task {
+				return resources.Task{
+					APIVersion: "orloj.dev/v1",
+					Kind:       "Task",
+					Metadata:   resources.ObjectMeta{Name: fmt.Sprintf("assigned-worker-mismatch-%02d", i)},
+					Status:     resources.TaskStatus{AssignedWorker: "worker-b"},
+				}
+			},
+			matchTask: resources.Task{
+				APIVersion: "orloj.dev/v1",
+				Kind:       "Task",
+				Metadata:   resources.ObjectMeta{Name: "assigned-worker-match"},
+				Status:     resources.TaskStatus{AssignedWorker: workerID},
+			},
+			matches: func(task resources.Task) bool {
+				assigned := strings.TrimSpace(task.Status.AssignedWorker)
+				return assigned == "" || strings.EqualFold(assigned, workerID)
+			},
+			wantName: "assigned-worker-match",
+		},
+		{
+			name:  "region",
+			hints: WorkerClaimHints{Region: "us-west"},
+			mismatchTask: func(i int) resources.Task {
+				return resources.Task{
+					APIVersion: "orloj.dev/v1",
+					Kind:       "Task",
+					Metadata:   resources.ObjectMeta{Name: fmt.Sprintf("region-mismatch-%02d", i)},
+					Spec:       resources.TaskSpec{Requirements: resources.TaskRequirements{Region: "us-east"}},
+				}
+			},
+			matchTask: resources.Task{
+				APIVersion: "orloj.dev/v1",
+				Kind:       "Task",
+				Metadata:   resources.ObjectMeta{Name: "region-match"},
+				Spec:       resources.TaskSpec{Requirements: resources.TaskRequirements{Region: "us-west"}},
+			},
+			matches: func(task resources.Task) bool {
+				region := strings.TrimSpace(task.Spec.Requirements.Region)
+				return region == "" || strings.EqualFold(region, "us-west")
+			},
+			wantName: "region-match",
+		},
+		{
+			name:  "gpu",
+			hints: WorkerClaimHints{RequiresGPU: true},
+			mismatchTask: func(i int) resources.Task {
+				return resources.Task{
+					APIVersion: "orloj.dev/v1",
+					Kind:       "Task",
+					Metadata:   resources.ObjectMeta{Name: fmt.Sprintf("gpu-mismatch-%02d", i)},
+					Spec:       resources.TaskSpec{Requirements: resources.TaskRequirements{GPU: false}},
+				}
+			},
+			matchTask: resources.Task{
+				APIVersion: "orloj.dev/v1",
+				Kind:       "Task",
+				Metadata:   resources.ObjectMeta{Name: "gpu-match"},
+				Spec:       resources.TaskSpec{Requirements: resources.TaskRequirements{GPU: true}},
+			},
+			matches: func(task resources.Task) bool {
+				return task.Spec.Requirements.GPU
+			},
+			wantName: "gpu-match",
+		},
+		{
+			name:  "supported_model",
+			hints: WorkerClaimHints{SupportedModels: []string{"gpt-4o"}},
+			mismatchTask: func(i int) resources.Task {
+				return resources.Task{
+					APIVersion: "orloj.dev/v1",
+					Kind:       "Task",
+					Metadata:   resources.ObjectMeta{Name: fmt.Sprintf("model-mismatch-%02d", i)},
+					Spec:       resources.TaskSpec{Requirements: resources.TaskRequirements{Model: "gpt-4.1"}},
+				}
+			},
+			matchTask: resources.Task{
+				APIVersion: "orloj.dev/v1",
+				Kind:       "Task",
+				Metadata:   resources.ObjectMeta{Name: "model-match"},
+				Spec:       resources.TaskSpec{Requirements: resources.TaskRequirements{Model: "gpt-4o"}},
+			},
+			matches: func(task resources.Task) bool {
+				model := strings.TrimSpace(task.Spec.Requirements.Model)
+				return model == "" || strings.EqualFold(model, "gpt-4o")
+			},
+			wantName: "model-match",
+		},
+		{
+			name:  "supported_model_allows_unset",
+			hints: WorkerClaimHints{SupportedModels: []string{"gpt-4o"}},
+			mismatchTask: func(i int) resources.Task {
+				return resources.Task{
+					APIVersion: "orloj.dev/v1",
+					Kind:       "Task",
+					Metadata:   resources.ObjectMeta{Name: fmt.Sprintf("unset-model-mismatch-%02d", i)},
+					Spec:       resources.TaskSpec{Requirements: resources.TaskRequirements{Model: "gpt-4.1"}},
+				}
+			},
+			matchTask: resources.Task{
+				APIVersion: "orloj.dev/v1",
+				Kind:       "Task",
+				Metadata:   resources.ObjectMeta{Name: "unset-model-match"},
+			},
+			matches: func(task resources.Task) bool {
+				model := strings.TrimSpace(task.Spec.Requirements.Model)
+				return model == "" || strings.EqualFold(model, "gpt-4o")
+			},
+			wantName: "unset-model-match",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetPostgresStoreTestTables(t, db)
+
+			for i := 0; i < 64; i++ {
+				if _, err := taskStore.Upsert(ctx, tc.mismatchTask(i)); err != nil {
+					t.Fatalf("upsert mismatch task %d failed: %v", i, err)
+				}
+			}
+			time.Sleep(20 * time.Millisecond)
+			if _, err := taskStore.Upsert(ctx, tc.matchTask); err != nil {
+				t.Fatalf("upsert match task failed: %v", err)
+			}
+
+			claimed, ok, err := taskStore.ClaimNextDue(ctx, workerID, time.Minute, tc.hints, tc.matches)
+			if err != nil {
+				t.Fatalf("claim next due failed: %v", err)
+			}
+			if !ok {
+				t.Fatal("expected claim to succeed")
+			}
+			if claimed.Metadata.Name != tc.wantName {
+				t.Fatalf("expected claim %q, got %q", tc.wantName, claimed.Metadata.Name)
+			}
+		})
+	}
+}
+
+func openPostgresForStoreTest(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := os.Getenv("ORLOJ_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("ORLOJ_POSTGRES_DSN is not set; skipping Postgres integration test")
+	}
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open postgres failed: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		t.Skipf("postgres not reachable at ORLOJ_POSTGRES_DSN: %v", err)
+	}
+	if err := EnsurePostgresSchema(db); err != nil {
+		_ = db.Close()
+		t.Fatalf("ensure schema failed: %v", err)
+	}
+	resetPostgresStoreTestTables(t, db)
+	t.Cleanup(func() {
+		resetPostgresStoreTestTables(t, db)
+	})
+	return db
+}
+
+func resetPostgresStoreTestTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, statement := range []string{
+		`TRUNCATE TABLE task_logs`,
+		`TRUNCATE TABLE webhook_dedupe`,
+		`TRUNCATE TABLE resources`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("reset postgres test tables failed for %q: %v", statement, err)
+		}
+	}
+}

--- a/store/task_claim_test.go
+++ b/store/task_claim_test.go
@@ -88,3 +88,280 @@ func TestTaskStoreClaimFailoverOnLeaseExpiry(t *testing.T) {
 		t.Fatalf("expected claimedBy=worker-b, got %q", claimed.Status.ClaimedBy)
 	}
 }
+
+func TestTaskStoreIsolationAcrossBoundaries(t *testing.T) {
+	s := NewTaskStore()
+	bg := context.Background()
+	retryable := true
+	task := resources.Task{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "Task",
+		Metadata: resources.ObjectMeta{
+			Name:        "isolated-task",
+			Labels:      map[string]string{"env": "test"},
+			Annotations: map[string]string{"owner": "qa"},
+		},
+		Spec: resources.TaskSpec{
+			System: "sys",
+			Input:  map[string]string{"topic": "orig"},
+			MessageRetry: resources.TaskMessageRetryPolicy{
+				NonRetryable: []string{"denied"},
+			},
+		},
+		Status: resources.TaskStatus{
+			Output: map[string]string{"result": "orig"},
+			Trace: []resources.TaskTraceEvent{{
+				Type:      "tool_call",
+				Message:   "trace-orig",
+				Retryable: &retryable,
+			}},
+			History: []resources.TaskHistoryEvent{{
+				Type:    "claim",
+				Message: "history-orig",
+			}},
+			Messages: []resources.TaskMessage{{
+				MessageID: "msg-1",
+				Phase:     "Queued",
+				Content:   "message-orig",
+			}},
+			MessageIdempotency: []resources.TaskMessageIdempotency{{
+				Key:   "msg-1",
+				State: "completed",
+			}},
+			JoinStates: []resources.TaskJoinState{{
+				Node: "reviewer",
+				Sources: []resources.TaskJoinSource{{
+					MessageID: "msg-join",
+					Payload:   "join-orig",
+				}},
+			}},
+			DelegationStates: []resources.TaskDelegationState{{
+				Node: "delegate",
+				Sources: []resources.TaskJoinSource{{
+					MessageID: "msg-delegate",
+					Payload:   "delegate-orig",
+				}},
+			}},
+		},
+	}
+
+	stored, err := s.Upsert(bg, task)
+	if err != nil {
+		t.Fatalf("upsert failed: %v", err)
+	}
+
+	task.Metadata.Labels["env"] = "mutated-input"
+	task.Metadata.Annotations["owner"] = "mutated-input"
+	task.Spec.Input["topic"] = "mutated-input"
+	task.Spec.MessageRetry.NonRetryable[0] = "mutated-input"
+	task.Status.Output["result"] = "mutated-input"
+	task.Status.Trace[0].Message = "mutated-input"
+	*task.Status.Trace[0].Retryable = false
+	task.Status.History[0].Message = "mutated-input"
+	task.Status.Messages[0].Content = "mutated-input"
+	task.Status.MessageIdempotency[0].State = "mutated-input"
+	task.Status.JoinStates[0].Sources[0].Payload = "mutated-input"
+	task.Status.DelegationStates[0].Sources[0].Payload = "mutated-input"
+
+	stored.Metadata.Labels["env"] = "mutated-return"
+	stored.Metadata.Annotations["owner"] = "mutated-return"
+	stored.Spec.Input["topic"] = "mutated-return"
+	stored.Spec.MessageRetry.NonRetryable[0] = "mutated-return"
+	stored.Status.Output["result"] = "mutated-return"
+	stored.Status.Trace[0].Message = "mutated-return"
+	*stored.Status.Trace[0].Retryable = false
+	stored.Status.History[0].Message = "mutated-return"
+	stored.Status.Messages[0].Content = "mutated-return"
+	stored.Status.MessageIdempotency[0].State = "mutated-return"
+	stored.Status.JoinStates[0].Sources[0].Payload = "mutated-return"
+	stored.Status.DelegationStates[0].Sources[0].Payload = "mutated-return"
+
+	got, ok, err := s.Get(bg, "isolated-task")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected task to exist")
+	}
+	assertTaskIsolation(t, got)
+
+	list, err := s.List(bg)
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 listed task, got %d", len(list))
+	}
+	list[0].Spec.Input["topic"] = "mutated-list"
+	list[0].Status.Output["result"] = "mutated-list"
+	list[0].Status.JoinStates[0].Sources[0].Payload = "mutated-list"
+
+	cursor, err := s.ListCursor(bg, 10, "", "")
+	if err != nil {
+		t.Fatalf("list cursor failed: %v", err)
+	}
+	if len(cursor) != 1 {
+		t.Fatalf("expected 1 cursor task, got %d", len(cursor))
+	}
+	cursor[0].Metadata.Labels["env"] = "mutated-cursor"
+	cursor[0].Status.Messages[0].Content = "mutated-cursor"
+
+	afterList, ok, err := s.Get(bg, "isolated-task")
+	if err != nil {
+		t.Fatalf("get after list mutation failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected task to exist after list mutation")
+	}
+	assertTaskIsolation(t, afterList)
+}
+
+func TestTaskStoreClaimReturnsIsolatedCopy(t *testing.T) {
+	s := NewTaskStore()
+	bg := context.Background()
+	task := resources.Task{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "Task",
+		Metadata: resources.ObjectMeta{
+			Name:   "claim-copy-task",
+			Labels: map[string]string{"team": "core"},
+		},
+		Spec: resources.TaskSpec{
+			System: "sys",
+			Input:  map[string]string{"topic": "orig"},
+		},
+		Status: resources.TaskStatus{
+			Output: map[string]string{"result": "orig"},
+		},
+	}
+	if _, err := s.Upsert(bg, task); err != nil {
+		t.Fatalf("upsert failed: %v", err)
+	}
+
+	claimed, ok, err := s.ClaimIfDue(bg, "claim-copy-task", "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("claim failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claim success")
+	}
+
+	claimed.Metadata.Labels["team"] = "mutated"
+	claimed.Spec.Input["topic"] = "mutated"
+	claimed.Status.Output = map[string]string{"result": "mutated"}
+
+	stored, ok, err := s.Get(bg, "claim-copy-task")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claimed task to exist")
+	}
+	if stored.Metadata.Labels["team"] != "core" {
+		t.Fatalf("expected stored labels to remain unchanged, got %q", stored.Metadata.Labels["team"])
+	}
+	if stored.Spec.Input["topic"] != "orig" {
+		t.Fatalf("expected stored input to remain unchanged, got %q", stored.Spec.Input["topic"])
+	}
+	if len(stored.Status.Output) != 0 {
+		t.Fatalf("expected stored output to remain cleared after claim, got %+v", stored.Status.Output)
+	}
+	if stored.Status.ClaimedBy != "worker-a" {
+		t.Fatalf("expected stored claim owner worker-a, got %q", stored.Status.ClaimedBy)
+	}
+}
+
+func TestTaskStoreClaimNextDueReturnsIsolatedCopy(t *testing.T) {
+	s := NewTaskStore()
+	bg := context.Background()
+	task := resources.Task{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "Task",
+		Metadata: resources.ObjectMeta{
+			Name:   "claim-next-copy-task",
+			Labels: map[string]string{"team": "core"},
+		},
+		Spec: resources.TaskSpec{
+			System: "sys",
+			Input:  map[string]string{"topic": "orig"},
+		},
+		Status: resources.TaskStatus{
+			Output: map[string]string{"result": "orig"},
+		},
+	}
+	if _, err := s.Upsert(bg, task); err != nil {
+		t.Fatalf("upsert failed: %v", err)
+	}
+
+	claimed, ok, err := s.ClaimNextDue(bg, "worker-a", time.Minute, WorkerClaimHints{}, nil)
+	if err != nil {
+		t.Fatalf("claim next due failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claim next due success")
+	}
+
+	claimed.Metadata.Labels["team"] = "mutated"
+	claimed.Spec.Input["topic"] = "mutated"
+	claimed.Status.Output = map[string]string{"result": "mutated"}
+
+	stored, ok, err := s.Get(bg, "claim-next-copy-task")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claimed task to exist")
+	}
+	if stored.Metadata.Labels["team"] != "core" {
+		t.Fatalf("expected stored labels to remain unchanged, got %q", stored.Metadata.Labels["team"])
+	}
+	if stored.Spec.Input["topic"] != "orig" {
+		t.Fatalf("expected stored input to remain unchanged, got %q", stored.Spec.Input["topic"])
+	}
+	if len(stored.Status.Output) != 0 {
+		t.Fatalf("expected stored output to remain cleared after claim, got %+v", stored.Status.Output)
+	}
+	if stored.Status.ClaimedBy != "worker-a" {
+		t.Fatalf("expected stored claim owner worker-a, got %q", stored.Status.ClaimedBy)
+	}
+}
+
+func assertTaskIsolation(t *testing.T, task resources.Task) {
+	t.Helper()
+	if task.Metadata.Labels["env"] != "test" {
+		t.Fatalf("expected env label test, got %q", task.Metadata.Labels["env"])
+	}
+	if task.Metadata.Annotations["owner"] != "qa" {
+		t.Fatalf("expected owner annotation qa, got %q", task.Metadata.Annotations["owner"])
+	}
+	if task.Spec.Input["topic"] != "orig" {
+		t.Fatalf("expected task input orig, got %q", task.Spec.Input["topic"])
+	}
+	if len(task.Spec.MessageRetry.NonRetryable) != 1 || task.Spec.MessageRetry.NonRetryable[0] != "denied" {
+		t.Fatalf("expected non_retryable to remain unchanged, got %+v", task.Spec.MessageRetry.NonRetryable)
+	}
+	if task.Status.Output["result"] != "orig" {
+		t.Fatalf("expected output result orig, got %q", task.Status.Output["result"])
+	}
+	if len(task.Status.Trace) != 1 || task.Status.Trace[0].Message != "trace-orig" {
+		t.Fatalf("expected trace to remain unchanged, got %+v", task.Status.Trace)
+	}
+	if task.Status.Trace[0].Retryable == nil || !*task.Status.Trace[0].Retryable {
+		t.Fatalf("expected retryable pointer to remain true, got %+v", task.Status.Trace[0].Retryable)
+	}
+	if len(task.Status.History) != 1 || task.Status.History[0].Message != "history-orig" {
+		t.Fatalf("expected history to remain unchanged, got %+v", task.Status.History)
+	}
+	if len(task.Status.Messages) != 1 || task.Status.Messages[0].Content != "message-orig" {
+		t.Fatalf("expected messages to remain unchanged, got %+v", task.Status.Messages)
+	}
+	if len(task.Status.MessageIdempotency) != 1 || task.Status.MessageIdempotency[0].State != "completed" {
+		t.Fatalf("expected idempotency to remain unchanged, got %+v", task.Status.MessageIdempotency)
+	}
+	if len(task.Status.JoinStates) != 1 || len(task.Status.JoinStates[0].Sources) != 1 || task.Status.JoinStates[0].Sources[0].Payload != "join-orig" {
+		t.Fatalf("expected join state to remain unchanged, got %+v", task.Status.JoinStates)
+	}
+	if len(task.Status.DelegationStates) != 1 || len(task.Status.DelegationStates[0].Sources) != 1 || task.Status.DelegationStates[0].Sources[0].Payload != "delegate-orig" {
+		t.Fatalf("expected delegation state to remain unchanged, got %+v", task.Status.DelegationStates)
+	}
+}


### PR DESCRIPTION

- Eliminate goroutine leaks in rate limiter, bounded tool helpers, and work queue
- Fix send-on-closed-channel panics in event bus and agent message bus
- Add Task.DeepCopy to prevent shared-reference corruption in TaskStore
- Add GPU/model filters to SQL claim queries
- Switch watch streams from polling to event bus subscription
- Fix scoping bugs in task controller and worker heartbeat shutdown

