### PR TITLE
Fix orphaned tool_use IDs on parallel tool errors and graph layout issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parallel tool calls with mixed success/error results break subsequent model calls**: when the model issued multiple tool calls in one step and some failed (e.g. MCP `tool_backend_failure`), the failed results were not included as `tool_result` blocks in the conversation history. This left orphaned `tool_use` IDs that the Anthropic API rejected with a 400 error on every subsequent step, causing the agent to exhaust `max_steps` without making progress. Error tool results are now always appended to history with `is_error` set (Anthropic `is_error: true`, Bedrock `Status: error`), so the model receives feedback for every tool call regardless of outcome.
+- **Web UI system topology: inline webhook task node squished between webhook and system**: `TaskWebhook` resources with an inline `task_template` (no `task_ref`) created a synthetic task node with edges pointing back toward the system node (`inline_task → system`), causing dagre to place it to the left of the system and squeeze it into the webhook–system gap. The edge direction now matches normal tasks (`system → inline_task`), so inline webhook tasks sit alongside other tasks to the right of the system node.
+- **Web UI system topology: nodes with long names overlap across ranks**: dagre allocated a fixed 180px width for secondary nodes (tools, roles, secrets, models, memory) regardless of label length. Nodes with long names rendered wider than their allocated slot, causing visual overlap with adjacent ranks. Node width is now estimated from label length (capped at 340px) so dagre reserves enough horizontal space for the actual rendered content.
+
+### Changed
+
+- **Web UI system topology: initial zoom clamped for large systems**: the graph view now constrains `fitView` to a 0.45×–1.0× zoom range on load, matching the Argo CD convention. Large systems start at a readable zoom level (nodes visible, pan to explore) instead of shrinking to fit the entire graph; small systems no longer over-zoom beyond 1:1 scale. Manual zoom remains unrestricted (0.15×–2×).
+
 ## [0.10.0] - 2026-04-18
 
 ### Added

--- a/frontend/src/components/GraphView.tsx
+++ b/frontend/src/components/GraphView.tsx
@@ -369,7 +369,10 @@ function buildTree(
     if (registeredNodes.has(id)) return;
     registeredNodes.add(id);
     const small = SECONDARY_KINDS.has(kind);
-    g.setNode(id, { width: small ? NODE_W_SM : NODE_W, height: small ? NODE_H_SM : NODE_H });
+    const baseW = small ? NODE_W_SM : NODE_W;
+    const textW = Math.ceil(label.length * 7.2) + (small ? 56 : 64);
+    const w = Math.min(Math.max(baseW, textW), 340);
+    g.setNode(id, { width: w, height: small ? NODE_H_SM : NODE_H });
     nodeMeta[id] = { kind, label, phase, subtitle, extra };
   }
 
@@ -637,13 +640,14 @@ function buildTree(
       );
 
       // Create a synthetic task node for the inline template so the graph
-      // shows webhook → task (same visual as the task_ref path) rather than
-      // an orphan webhook hanging off the system node.
+      // shows webhook → task → worker (same visual as the task_ref path)
+      // rather than an orphan webhook hanging off the system node.
+      // Edge direction matches normal tasks: system → task, webhook → task.
       const inlineTaskId = nid("task", `${webhook.metadata.name}-inline`);
       const tmpl = webhook.spec.task_template;
       regNode(inlineTaskId, "task", `${webhook.metadata.name} (inline)`, undefined, tmpl.priority ?? "normal");
       regEdge(webhookId, inlineTaskId, false);
-      regEdge(inlineTaskId, sysId, false);
+      regEdge(sysId, inlineTaskId, false);
     }
   }
 
@@ -660,9 +664,8 @@ function buildTree(
   for (const id of registeredNodes) {
     const pos = g.node(id);
     const meta = nodeMeta[id];
-    const small = SECONDARY_KINDS.has(meta.kind);
-    const w = small ? NODE_W_SM : NODE_W;
-    const h = small ? NODE_H_SM : NODE_H;
+    const w = pos.width as number;
+    const h = pos.height as number;
     nodePos[id] = { x: pos.x, y: pos.y };
     const data: CrdNodeData = { label: meta.label, kind: meta.kind, phase: meta.phase, subtitle: meta.subtitle, ...meta.extra };
     if (meta.kind === "agent" && agentDepCounts[meta.label]) {
@@ -938,7 +941,7 @@ export function GraphView({ system, related, onNodeClick, animated, runningAgent
         onNodeMouseLeave={handleNodeMouseLeave}
         nodeTypes={nodeTypes}
         fitView
-        fitViewOptions={{ padding: 0.25 }}
+        fitViewOptions={{ padding: 0.25, minZoom: 0.45, maxZoom: 1.0 }}
         minZoom={0.15}
         maxZoom={2}
         proOptions={{ hideAttribution: true }}

--- a/runtime/agent_worker.go
+++ b/runtime/agent_worker.go
@@ -429,6 +429,12 @@ func (w *AgentWorker) Run(ctx context.Context) {
 					if w.onEvent != nil {
 						w.onEvent(fmt.Sprintf("step=%d tool=%s tool_contract=%s tool_request_id=%s tool_attempt=%d duration_ms=%d error=%v", step, tool, contractVersion, toolRequestID, toolAttempt, toolDurationMS, err))
 					}
+					w.history = append(w.history, ChatMessage{
+						Role:       "tool",
+						Content:    fmt.Sprintf("<tool_error>\n%s\n</tool_error>", err.Error()),
+						ToolCallID: requested.ID,
+						IsError:    true,
+					})
 					continue
 				}
 				toolResultCache[cacheKey] = result

--- a/runtime/contracts.go
+++ b/runtime/contracts.go
@@ -23,6 +23,7 @@ type ChatMessage struct {
 	Content    string
 	ToolCallID string         // role="tool": the ID of the tool call this result answers
 	ToolCalls  []ChatToolCall // role="assistant": tool calls the model made this turn
+	IsError    bool           // role="tool": true when this tool result represents a failure
 }
 
 // ChatToolCall captures one tool invocation from an assistant message.

--- a/runtime/model_gateway_anthropic.go
+++ b/runtime/model_gateway_anthropic.go
@@ -405,16 +405,17 @@ func chatMessagesToAnthropic(msgs []ChatMessage) (string, []anthropicMessagesInp
 		}
 
 		if role == "tool" && m.ToolCallID != "" {
-			blocks := []map[string]interface{}{
-				{
-					"type":        "tool_result",
-					"tool_use_id": m.ToolCallID,
-					"content":     content,
-				},
+			block := map[string]interface{}{
+				"type":        "tool_result",
+				"tool_use_id": m.ToolCallID,
+				"content":     content,
+			}
+			if m.IsError {
+				block["is_error"] = true
 			}
 			out = append(out, anthropicMessagesInput{
 				Role:    "user",
-				Content: blocks,
+				Content: []map[string]interface{}{block},
 			})
 			continue
 		}

--- a/runtime/model_gateway_anthropic_test.go
+++ b/runtime/model_gateway_anthropic_test.go
@@ -384,6 +384,109 @@ func TestChatMessagesToAnthropicStructuredToolMessages(t *testing.T) {
 	}
 }
 
+func TestChatMessagesToAnthropicErrorToolResult(t *testing.T) {
+	msgs := []ChatMessage{
+		{Role: "user", Content: "step=1"},
+		{Role: "assistant", Content: "calling tools", ToolCalls: []ChatToolCall{
+			{ID: "toolu_01A", Name: "kubectl-get", Input: `{"resource":"pods"}`},
+			{ID: "toolu_01B", Name: "prometheus-query", Input: `{"query":"up"}`},
+		}},
+		{Role: "tool", Content: "<tool_result>\npod list\n</tool_result>", ToolCallID: "toolu_01A"},
+		{Role: "tool", Content: "<tool_error>\nmcp tool prometheus-query returned error: connection refused\n</tool_error>", ToolCallID: "toolu_01B", IsError: true},
+		{Role: "user", Content: "step=2"},
+	}
+
+	system, anthropicMsgs := chatMessagesToAnthropic(msgs)
+	if system != "" {
+		t.Fatalf("expected empty system, got %q", system)
+	}
+	if len(anthropicMsgs) != 5 {
+		t.Fatalf("expected 5 messages (user, assistant, tool-result, tool-error-result, user), got %d", len(anthropicMsgs))
+	}
+
+	successResult := anthropicMsgs[2]
+	successBlocks, ok := successResult.Content.([]map[string]interface{})
+	if !ok || len(successBlocks) != 1 {
+		t.Fatalf("expected 1 tool_result block for success, got %v", successResult.Content)
+	}
+	if successBlocks[0]["tool_use_id"] != "toolu_01A" {
+		t.Fatalf("expected tool_use_id=toolu_01A, got %v", successBlocks[0]["tool_use_id"])
+	}
+	if _, hasIsError := successBlocks[0]["is_error"]; hasIsError {
+		t.Fatal("successful tool_result should not have is_error field")
+	}
+
+	errorResult := anthropicMsgs[3]
+	if errorResult.Role != "user" {
+		t.Fatalf("expected user role for error tool_result, got %q", errorResult.Role)
+	}
+	errorBlocks, ok := errorResult.Content.([]map[string]interface{})
+	if !ok || len(errorBlocks) != 1 {
+		t.Fatalf("expected 1 tool_result block for error, got %v", errorResult.Content)
+	}
+	if errorBlocks[0]["type"] != "tool_result" {
+		t.Fatalf("expected type=tool_result, got %v", errorBlocks[0]["type"])
+	}
+	if errorBlocks[0]["tool_use_id"] != "toolu_01B" {
+		t.Fatalf("expected tool_use_id=toolu_01B, got %v", errorBlocks[0]["tool_use_id"])
+	}
+	if errorBlocks[0]["is_error"] != true {
+		t.Fatalf("expected is_error=true on error tool_result, got %v", errorBlocks[0]["is_error"])
+	}
+}
+
+func TestChatMessagesToAnthropicMixedToolResultsAllHaveMatchingIDs(t *testing.T) {
+	toolUseIDs := []string{"toolu_01A", "toolu_01B", "toolu_01C", "toolu_01D"}
+	msgs := []ChatMessage{
+		{Role: "user", Content: "step=1"},
+		{Role: "assistant", Content: "running 4 tools", ToolCalls: []ChatToolCall{
+			{ID: toolUseIDs[0], Name: "kubectl-get", Input: `{"resource":"pods"}`},
+			{ID: toolUseIDs[1], Name: "kubectl-get", Input: `{"resource":"nodes"}`},
+			{ID: toolUseIDs[2], Name: "prometheus-query", Input: `{"query":"up"}`},
+			{ID: toolUseIDs[3], Name: "prometheus-query", Input: `{"query":"down"}`},
+		}},
+		{Role: "tool", Content: "<tool_result>\npod list\n</tool_result>", ToolCallID: toolUseIDs[0]},
+		{Role: "tool", Content: "<tool_result>\nnode list\n</tool_result>", ToolCallID: toolUseIDs[1]},
+		{Role: "tool", Content: "<tool_error>\nconnection refused\n</tool_error>", ToolCallID: toolUseIDs[2], IsError: true},
+		{Role: "tool", Content: "<tool_error>\nconnection refused\n</tool_error>", ToolCallID: toolUseIDs[3], IsError: true},
+	}
+
+	_, anthropicMsgs := chatMessagesToAnthropic(msgs)
+
+	// Collect all tool_use IDs from assistant message
+	assistantMsg := anthropicMsgs[1]
+	blocks, _ := assistantMsg.Content.([]map[string]interface{})
+	emittedToolUseIDs := map[string]bool{}
+	for _, block := range blocks {
+		if block["type"] == "tool_use" {
+			emittedToolUseIDs[block["id"].(string)] = true
+		}
+	}
+
+	// Collect all tool_result IDs from subsequent messages
+	emittedToolResultIDs := map[string]bool{}
+	for _, msg := range anthropicMsgs[2:] {
+		resultBlocks, ok := msg.Content.([]map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, block := range resultBlocks {
+			if block["type"] == "tool_result" {
+				emittedToolResultIDs[block["tool_use_id"].(string)] = true
+			}
+		}
+	}
+
+	for _, id := range toolUseIDs {
+		if !emittedToolUseIDs[id] {
+			t.Errorf("tool_use ID %s missing from assistant message", id)
+		}
+		if !emittedToolResultIDs[id] {
+			t.Errorf("tool_result for tool_use ID %s missing — would cause orphaned tool_use error", id)
+		}
+	}
+}
+
 func TestAnthropicModelGatewaySendsOutputConfig(t *testing.T) {
 	var capturedBody map[string]any
 

--- a/runtime/model_gateway_bedrock.go
+++ b/runtime/model_gateway_bedrock.go
@@ -220,16 +220,20 @@ func chatMessagesToBedrock(req ModelRequest) ([]types.SystemContentBlock, []type
 		}
 
 		if role == "tool" && m.ToolCallID != "" {
+			resultBlock := types.ToolResultBlock{
+				ToolUseId: aws.String(m.ToolCallID),
+				Content: []types.ToolResultContentBlock{
+					&types.ToolResultContentBlockMemberText{Value: content},
+				},
+			}
+			if m.IsError {
+				resultBlock.Status = types.ToolResultStatusError
+			}
 			out = append(out, types.Message{
 				Role: types.ConversationRoleUser,
 				Content: []types.ContentBlock{
 					&types.ContentBlockMemberToolResult{
-						Value: types.ToolResultBlock{
-							ToolUseId: aws.String(m.ToolCallID),
-							Content: []types.ToolResultContentBlock{
-								&types.ToolResultContentBlockMemberText{Value: content},
-							},
-						},
+						Value: resultBlock,
 					},
 				},
 			})


### PR DESCRIPTION

When parallel tool calls had mixed success/error results, failed calls were not appended as tool_result blocks to the conversation history, leaving orphaned tool_use IDs that caused repeated 400 errors from the Anthropic API until max_steps was exhausted.

Also fixes three UI issues in the system topology graph: inline webhook task nodes were placed between the webhook and system due to a reversed edge direction, secondary nodes with long names overlapped across ranks due to fixed dagre width, and large systems zoomed out too far on load.
