### PR TITLE
Add fallback model endpoint routing for agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Agent `spec.fallback_model_refs` enables ordered model endpoint failover; the router cascades to fallback endpoints on retryable provider errors (429, 5xx, connection failures).
+
 ## [0.10.2] - 2026-04-22
 
 ### Added

--- a/docs/pages/concepts/tools/model-endpoint.md
+++ b/docs/pages/concepts/tools/model-endpoint.md
@@ -162,6 +162,36 @@ spec:
     You are a writing agent.
 ```
 
+## Fallback Routing
+
+When a model provider is down or rate-limited, you can configure `fallback_model_refs` on an agent to cascade through backup endpoints automatically:
+
+```yaml
+apiVersion: orloj.dev/v1
+kind: Agent
+metadata:
+  name: writer-agent
+spec:
+  model_ref: anthropic-claude
+  fallback_model_refs:
+    - openai-gpt4
+    - ollama-local
+  prompt: |
+    You are a writing agent.
+```
+
+The router tries endpoints in order -- primary first, then each fallback. The first successful response wins. Fallback is triggered only on **retryable errors**:
+
+- **429** (rate limit)
+- **5xx** (server errors: 500, 502, 503, etc.)
+- Connection failures, DNS errors, and timeouts
+
+**Non-retryable errors** (400, 401, 403, 404, etc.) fail immediately without trying fallbacks -- these indicate configuration problems that retrying with a different provider won't solve.
+
+If all endpoints are exhausted, the last error is returned to the agent worker.
+
+Fallback is handled entirely within the model router. The agent worker and execution engine are unaware of it -- they still call `Complete()` once per step. [AgentPolicy](../agents/agent-policy.md) governance applies independently to each endpoint in the fallback chain.
+
 ## How Routing Works
 
 When a worker executes an agent turn:

--- a/docs/pages/concepts/tools/model-endpoint.md
+++ b/docs/pages/concepts/tools/model-endpoint.md
@@ -190,7 +190,7 @@ The router tries endpoints in order -- primary first, then each fallback. The fi
 
 If all endpoints are exhausted, the last error is returned to the agent worker.
 
-Fallback is handled entirely within the model router. The agent worker and execution engine are unaware of it -- they still call `Complete()` once per step. [AgentPolicy](../agents/agent-policy.md) governance applies independently to each endpoint in the fallback chain.
+Fallback is handled entirely within the model router. The agent worker and execution engine are unaware of it -- they still call `Complete()` once per step. [AgentPolicy](../governance/agent-policy.md) governance applies independently to each endpoint in the fallback chain.
 
 ## How Routing Works
 

--- a/openapi/schemas/agent.yaml
+++ b/openapi/schemas/agent.yaml
@@ -35,6 +35,10 @@ components:
       type: object
       properties:
         model_ref: { type: string }
+        fallback_model_refs:
+          type: array
+          items: { type: string }
+          description: Ordered list of fallback ModelEndpoint refs tried when the primary model_ref fails with a retryable error.
         prompt: { type: string }
         tools:
           type: array

--- a/resources/agent.go
+++ b/resources/agent.go
@@ -63,9 +63,10 @@ type AgentList struct {
 // AgentSpec defines desired runtime behavior.
 type AgentSpec struct {
 	// Model stores the resolved model id for runtime execution and is not part of the external Agent API.
-	Model        string             `json:"-"`
-	ModelRef     string             `json:"model_ref,omitempty"`
-	Prompt       string             `json:"prompt"`
+	Model             string             `json:"-"`
+	ModelRef          string             `json:"model_ref,omitempty"`
+	FallbackModelRefs []string           `json:"fallback_model_refs,omitempty"`
+	Prompt            string             `json:"prompt"`
 	Tools        []string           `json:"tools,omitempty"`
 	AllowedTools []string           `json:"allowed_tools,omitempty"`
 	Roles        []string           `json:"roles,omitempty"`
@@ -140,6 +141,21 @@ func (a *Agent) Normalize() error {
 	if a.Spec.ModelRef == "" {
 		return fmt.Errorf("spec.model_ref is required")
 	}
+	normalizedFallbacks := make([]string, 0, len(a.Spec.FallbackModelRefs))
+	seenFallbacks := make(map[string]struct{}, len(a.Spec.FallbackModelRefs))
+	for _, ref := range a.Spec.FallbackModelRefs {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			continue
+		}
+		key := strings.ToLower(ref)
+		if _, exists := seenFallbacks[key]; exists {
+			continue
+		}
+		seenFallbacks[key] = struct{}{}
+		normalizedFallbacks = append(normalizedFallbacks, ref)
+	}
+	a.Spec.FallbackModelRefs = normalizedFallbacks
 	a.Spec.Memory.Ref = strings.TrimSpace(a.Spec.Memory.Ref)
 	a.Spec.Memory.Type = strings.TrimSpace(a.Spec.Memory.Type)
 	a.Spec.Memory.Provider = strings.TrimSpace(a.Spec.Memory.Provider)

--- a/resources/agent_execution_contract_test.go
+++ b/resources/agent_execution_contract_test.go
@@ -158,3 +158,45 @@ func TestAgentNormalizeRejectsInvalidExecutionProfile(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestAgentNormalizeFallbackModelRefs(t *testing.T) {
+	agent := Agent{
+		Kind:     "Agent",
+		Metadata: ObjectMeta{Name: "fb-agent"},
+		Spec: AgentSpec{
+			Prompt:            "test",
+			ModelRef:          "primary",
+			FallbackModelRefs: []string{" openai-gpt4 ", "", "ollama-local", "  ", "OpenAI-GPT4", "ollama-local"},
+		},
+	}
+	if err := agent.Normalize(); err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+	got := agent.Spec.FallbackModelRefs
+	if len(got) != 2 {
+		t.Fatalf("expected 2 fallback refs after normalization, got %d: %v", len(got), got)
+	}
+	if got[0] != "openai-gpt4" {
+		t.Fatalf("expected first ref 'openai-gpt4', got %q", got[0])
+	}
+	if got[1] != "ollama-local" {
+		t.Fatalf("expected second ref 'ollama-local', got %q", got[1])
+	}
+}
+
+func TestAgentNormalizeFallbackModelRefsEmpty(t *testing.T) {
+	agent := Agent{
+		Kind:     "Agent",
+		Metadata: ObjectMeta{Name: "no-fb-agent"},
+		Spec: AgentSpec{
+			Prompt:   "test",
+			ModelRef: "primary",
+		},
+	}
+	if err := agent.Normalize(); err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+	if len(agent.Spec.FallbackModelRefs) != 0 {
+		t.Fatalf("expected empty fallback refs, got %v", agent.Spec.FallbackModelRefs)
+	}
+}

--- a/runtime/agent_worker.go
+++ b/runtime/agent_worker.go
@@ -190,9 +190,10 @@ func (w *AgentWorker) Run(ctx context.Context) {
 			})
 			modelStart := time.Now()
 			modelResp, modelErr := w.modelGateway.Complete(ctx, ModelRequest{
-				Model:        w.agent.Spec.Model,
-				ModelRef:     w.agent.Spec.ModelRef,
-				Namespace:    w.agent.Metadata.Namespace,
+				Model:             w.agent.Spec.Model,
+				ModelRef:          w.agent.Spec.ModelRef,
+				FallbackModelRefs: w.agent.Spec.FallbackModelRefs,
+				Namespace:         w.agent.Metadata.Namespace,
 				Agent:        w.agent.Metadata.Name,
 				Prompt:       w.agent.Spec.Prompt,
 				Step:         step,

--- a/runtime/contracts.go
+++ b/runtime/contracts.go
@@ -42,9 +42,10 @@ type ToolSchemaInfo struct {
 
 // ModelRequest defines one model inference request for an agent step.
 type ModelRequest struct {
-	Model        string
-	ModelRef     string
-	Namespace    string
+	Model             string
+	ModelRef          string
+	FallbackModelRefs []string
+	Namespace         string
 	Agent        string
 	Prompt       string
 	Step         int

--- a/runtime/model_gateway_router.go
+++ b/runtime/model_gateway_router.go
@@ -63,23 +63,58 @@ func (r *ModelRouter) Complete(ctx context.Context, req ModelRequest) (ModelResp
 		return ModelResponse{}, fmt.Errorf("model endpoint store is not configured")
 	}
 
-	endpoint, endpointKey, ok, err := r.resolveEndpoint(ctx, req.Namespace, modelRef)
-	if err != nil {
-		return ModelResponse{}, fmt.Errorf("model endpoint %q lookup failed: %w", modelRef, err)
-	}
-	if !ok {
-		return ModelResponse{}, fmt.Errorf("model endpoint %q not found in namespace %q", modelRef, resources.NormalizeNamespace(req.Namespace))
-	}
-	gateway, err := r.gatewayForEndpoint(ctx, endpoint, endpointKey)
-	if err != nil {
-		return ModelResponse{}, err
+	refs := make([]string, 0, 1+len(req.FallbackModelRefs))
+	refs = append(refs, modelRef)
+	for _, ref := range req.FallbackModelRefs {
+		if r := strings.TrimSpace(ref); r != "" {
+			refs = append(refs, r)
+		}
 	}
 
-	routedReq := req
-	if strings.TrimSpace(routedReq.Model) == "" {
-		routedReq.Model = strings.TrimSpace(endpoint.Spec.DefaultModel)
+	var lastErr error
+	for _, ref := range refs {
+		if ctx.Err() != nil {
+			if lastErr != nil {
+				return ModelResponse{}, lastErr
+			}
+			return ModelResponse{}, ctx.Err()
+		}
+
+		endpoint, endpointKey, ok, err := r.resolveEndpoint(ctx, req.Namespace, ref)
+		if err != nil {
+			lastErr = fmt.Errorf("model endpoint %q lookup failed: %w", ref, err)
+			continue
+		}
+		if !ok {
+			lastErr = fmt.Errorf("model endpoint %q not found in namespace %q", ref, resources.NormalizeNamespace(req.Namespace))
+			continue
+		}
+
+		gateway, err := r.gatewayForEndpoint(ctx, endpoint, endpointKey)
+		if err != nil {
+			lastErr = fmt.Errorf("configure model endpoint %s failed: %w", ref, err)
+			continue
+		}
+
+		routedReq := req
+		routedReq.ModelRef = ref
+		if strings.TrimSpace(routedReq.Model) == "" {
+			routedReq.Model = strings.TrimSpace(endpoint.Spec.DefaultModel)
+		}
+
+		resp, err := gateway.Complete(ctx, routedReq)
+		if err == nil {
+			return resp, nil
+		}
+
+		lastErr = err
+
+		if mge, retryable := IsModelGatewayError(err); mge != nil && !retryable {
+			return ModelResponse{}, err
+		}
 	}
-	return gateway.Complete(ctx, routedReq)
+
+	return ModelResponse{}, lastErr
 }
 
 func (r *ModelRouter) resolveEndpoint(ctx context.Context, namespace string, modelRef string) (resources.ModelEndpoint, string, bool, error) {

--- a/runtime/model_gateway_router_test.go
+++ b/runtime/model_gateway_router_test.go
@@ -347,3 +347,268 @@ func TestModelRouterOpenAICompatibleUsesProvidedSecretWhenPresent(t *testing.T) 
 		t.Fatalf("expected resolved api key %q, got %q", secretValue, gw.apiKey)
 	}
 }
+
+// --- Fallback routing test helpers ---
+
+type fallbackFailingGateway struct {
+	err error
+}
+
+func (g *fallbackFailingGateway) Complete(_ context.Context, _ ModelRequest) (ModelResponse, error) {
+	return ModelResponse{}, g.err
+}
+
+type countingModelGateway struct {
+	calls   int
+	wrapped ModelGateway
+}
+
+func (g *countingModelGateway) Complete(ctx context.Context, req ModelRequest) (ModelResponse, error) {
+	g.calls++
+	return g.wrapped.Complete(ctx, req)
+}
+
+func newFallbackRouter(endpoints map[string]resources.ModelEndpoint) *ModelRouter {
+	return NewModelRouter(ModelRouterConfig{
+		Endpoints: &stubModelEndpointLookup{items: endpoints},
+	})
+}
+
+func injectGateway(router *ModelRouter, key string, gw ModelGateway, rv string) {
+	router.mu.Lock()
+	router.cache[key] = cachedModelGateway{ResourceVersion: rv, Gateway: gw}
+	router.mu.Unlock()
+}
+
+// --- Fallback routing tests ---
+
+func TestModelRouterFallbackOnRetryableError(t *testing.T) {
+	endpoints := map[string]resources.ModelEndpoint{
+		"default/primary": {
+			Metadata: resources.ObjectMeta{Name: "primary", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "primary-model"},
+		},
+		"default/fallback": {
+			Metadata: resources.ObjectMeta{Name: "fallback", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "fallback-model"},
+		},
+	}
+	router := newFallbackRouter(endpoints)
+	injectGateway(router, "default/primary", &fallbackFailingGateway{
+		err: &ModelGatewayError{StatusCode: 500, Provider: "mock", Message: "server error"},
+	}, "1")
+
+	resp, err := router.Complete(context.Background(), ModelRequest{
+		Namespace:         "default",
+		ModelRef:          "primary",
+		FallbackModelRefs: []string{"fallback"},
+		Step:              1,
+	})
+	if err != nil {
+		t.Fatalf("expected fallback success, got error: %v", err)
+	}
+	if !strings.Contains(resp.Content, "fallback-model") {
+		t.Fatalf("expected fallback-model in response, got %q", resp.Content)
+	}
+}
+
+func TestModelRouterNoFallbackOnNonRetryableError(t *testing.T) {
+	endpoints := map[string]resources.ModelEndpoint{
+		"default/primary": {
+			Metadata: resources.ObjectMeta{Name: "primary", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "primary-model"},
+		},
+		"default/fallback": {
+			Metadata: resources.ObjectMeta{Name: "fallback", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "fallback-model"},
+		},
+	}
+	router := newFallbackRouter(endpoints)
+	injectGateway(router, "default/primary", &fallbackFailingGateway{
+		err: &ModelGatewayError{StatusCode: 401, Provider: "mock", Message: "unauthorized"},
+	}, "1")
+
+	fallbackGW := &countingModelGateway{wrapped: &MockModelGateway{}}
+	injectGateway(router, "default/fallback", fallbackGW, "1")
+
+	_, err := router.Complete(context.Background(), ModelRequest{
+		Namespace:         "default",
+		ModelRef:          "primary",
+		FallbackModelRefs: []string{"fallback"},
+		Step:              1,
+	})
+	if err == nil {
+		t.Fatal("expected 401 error, got nil")
+	}
+	mge, retryable := IsModelGatewayError(err)
+	if mge == nil || retryable {
+		t.Fatalf("expected non-retryable ModelGatewayError, got retryable=%v err=%v", retryable, err)
+	}
+	if fallbackGW.calls != 0 {
+		t.Fatalf("expected fallback gateway to not be called, got %d calls", fallbackGW.calls)
+	}
+}
+
+func TestModelRouterFallbackOn429(t *testing.T) {
+	endpoints := map[string]resources.ModelEndpoint{
+		"default/primary": {
+			Metadata: resources.ObjectMeta{Name: "primary", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "primary-model"},
+		},
+		"default/fallback": {
+			Metadata: resources.ObjectMeta{Name: "fallback", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "fallback-model"},
+		},
+	}
+	router := newFallbackRouter(endpoints)
+	injectGateway(router, "default/primary", &fallbackFailingGateway{
+		err: &ModelGatewayError{StatusCode: 429, Provider: "mock", Message: "rate limited"},
+	}, "1")
+
+	resp, err := router.Complete(context.Background(), ModelRequest{
+		Namespace:         "default",
+		ModelRef:          "primary",
+		FallbackModelRefs: []string{"fallback"},
+		Step:              1,
+	})
+	if err != nil {
+		t.Fatalf("expected fallback success on 429, got error: %v", err)
+	}
+	if !strings.Contains(resp.Content, "fallback-model") {
+		t.Fatalf("expected fallback-model in response, got %q", resp.Content)
+	}
+}
+
+func TestModelRouterAllEndpointsExhausted(t *testing.T) {
+	endpoints := map[string]resources.ModelEndpoint{
+		"default/primary": {
+			Metadata: resources.ObjectMeta{Name: "primary", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "primary-model"},
+		},
+		"default/fallback1": {
+			Metadata: resources.ObjectMeta{Name: "fallback1", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "fb1-model"},
+		},
+		"default/fallback2": {
+			Metadata: resources.ObjectMeta{Name: "fallback2", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "fb2-model"},
+		},
+	}
+	router := newFallbackRouter(endpoints)
+	injectGateway(router, "default/primary", &fallbackFailingGateway{
+		err: &ModelGatewayError{StatusCode: 500, Provider: "mock", Message: "primary down"},
+	}, "1")
+	injectGateway(router, "default/fallback1", &fallbackFailingGateway{
+		err: &ModelGatewayError{StatusCode: 502, Provider: "mock", Message: "fallback1 down"},
+	}, "1")
+	injectGateway(router, "default/fallback2", &fallbackFailingGateway{
+		err: &ModelGatewayError{StatusCode: 503, Provider: "mock", Message: "fallback2 down"},
+	}, "1")
+
+	_, err := router.Complete(context.Background(), ModelRequest{
+		Namespace:         "default",
+		ModelRef:          "primary",
+		FallbackModelRefs: []string{"fallback1", "fallback2"},
+		Step:              1,
+	})
+	if err == nil {
+		t.Fatal("expected error when all endpoints exhausted")
+	}
+	if !strings.Contains(err.Error(), "fallback2 down") {
+		t.Fatalf("expected last error from fallback2, got %v", err)
+	}
+}
+
+func TestModelRouterFallbackSkippedOnContextCancel(t *testing.T) {
+	endpoints := map[string]resources.ModelEndpoint{
+		"default/primary": {
+			Metadata: resources.ObjectMeta{Name: "primary", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "primary-model"},
+		},
+		"default/fallback": {
+			Metadata: resources.ObjectMeta{Name: "fallback", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "fallback-model"},
+		},
+	}
+	router := newFallbackRouter(endpoints)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	primaryGW := &fallbackFailingGateway{
+		err: &ModelGatewayError{StatusCode: 500, Provider: "mock", Message: "server error"},
+	}
+	injectGateway(router, "default/primary", primaryGW, "1")
+
+	fallbackGW := &countingModelGateway{wrapped: &MockModelGateway{}}
+	injectGateway(router, "default/fallback", fallbackGW, "1")
+
+	// Cancel the context before calling Complete so the fallback is skipped.
+	cancel()
+
+	_, err := router.Complete(ctx, ModelRequest{
+		Namespace:         "default",
+		ModelRef:          "primary",
+		FallbackModelRefs: []string{"fallback"},
+		Step:              1,
+	})
+	if err == nil {
+		t.Fatal("expected error with cancelled context")
+	}
+	if fallbackGW.calls != 0 {
+		t.Fatalf("expected fallback gateway to not be called with cancelled context, got %d calls", fallbackGW.calls)
+	}
+}
+
+func TestModelRouterFallbackEndpointNotFound(t *testing.T) {
+	endpoints := map[string]resources.ModelEndpoint{
+		"default/primary": {
+			Metadata: resources.ObjectMeta{Name: "primary", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "primary-model"},
+		},
+		"default/fallback2": {
+			Metadata: resources.ObjectMeta{Name: "fallback2", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "fb2-model"},
+		},
+	}
+	router := newFallbackRouter(endpoints)
+	injectGateway(router, "default/primary", &fallbackFailingGateway{
+		err: &ModelGatewayError{StatusCode: 500, Provider: "mock", Message: "primary down"},
+	}, "1")
+
+	resp, err := router.Complete(context.Background(), ModelRequest{
+		Namespace:         "default",
+		ModelRef:          "primary",
+		FallbackModelRefs: []string{"missing-endpoint", "fallback2"},
+		Step:              1,
+	})
+	if err != nil {
+		t.Fatalf("expected second fallback to succeed, got error: %v", err)
+	}
+	if !strings.Contains(resp.Content, "fb2-model") {
+		t.Fatalf("expected fb2-model in response, got %q", resp.Content)
+	}
+}
+
+func TestModelRouterNoFallbackRefsUsesOriginalBehavior(t *testing.T) {
+	endpoints := map[string]resources.ModelEndpoint{
+		"default/primary": {
+			Metadata: resources.ObjectMeta{Name: "primary", Namespace: "default", ResourceVersion: "1"},
+			Spec:     resources.ModelEndpointSpec{Provider: "mock", DefaultModel: "primary-model"},
+		},
+	}
+	router := newFallbackRouter(endpoints)
+	injectGateway(router, "default/primary", &fallbackFailingGateway{
+		err: &ModelGatewayError{StatusCode: 500, Provider: "mock", Message: "server error"},
+	}, "1")
+
+	_, err := router.Complete(context.Background(), ModelRequest{
+		Namespace: "default",
+		ModelRef:  "primary",
+		Step:      1,
+	})
+	if err == nil {
+		t.Fatal("expected error with no fallback refs")
+	}
+	if !strings.Contains(err.Error(), "server error") {
+		t.Fatalf("expected original server error, got %v", err)
+	}
+}


### PR DESCRIPTION
When a primary model endpoint fails with a retryable error (429, 5xx, connection failure), the ModelRouter now cascades through an ordered list of fallback endpoints before failing the step. Non-retryable errors (401, 400, etc.) still fail immediately.

Adds spec.fallback_model_refs to the Agent resource, wires it through ModelRequest, and handles the cascade entirely within the router -- the agent worker and execution engine are unaware of fallback.
