### PR TITLE
fix(frontend): add error states to list pages, improve accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Agent `spec.fallback_model_refs` enables ordered model endpoint failover; the router cascades to fallback endpoints on retryable provider errors (429, 5xx, connection failures).
 
+### Fixed
+
+- Frontend: list pages (Agents, Tasks, Agent Systems, Secrets) now show error states with retry instead of silently displaying "No resources" on API failures.
+- Frontend: Capabilities page error state upgraded from raw `<p>` to reusable `ListFetchError` component with retry button.
+- Frontend: TaskDetail sub-resource queries (messages, metrics, logs) surface fetch errors instead of showing empty placeholders.
+- Frontend: clickable cards and navigation spans replaced with keyboard-accessible elements (`role="button"`, `tabIndex`, or `<button>`).
+- Frontend: TaskDetail tab bar uses ARIA `role="tablist"` / `role="tab"` / `aria-selected` semantics.
+- Frontend: removed inline styles in TaskDetail and Capabilities; replaced with utility CSS classes.
+
 ## [0.10.2] - 2026-04-22
 
 ### Added

--- a/frontend/src/components/ListFetchError.tsx
+++ b/frontend/src/components/ListFetchError.tsx
@@ -1,0 +1,20 @@
+import { AlertTriangle } from "lucide-react";
+
+interface ListFetchErrorProps {
+  message: string;
+  onRetry?: () => void;
+}
+
+export function ListFetchError({ message, onRetry }: ListFetchErrorProps) {
+  return (
+    <div className="list-fetch-error">
+      <AlertTriangle size={20} />
+      <p>{message}</p>
+      {onRetry && (
+        <button type="button" className="btn-secondary" onClick={onRetry}>
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/AgentSystems.tsx
+++ b/frontend/src/pages/AgentSystems.tsx
@@ -4,6 +4,7 @@ import { useAgentSystems } from "../api/hooks";
 import { ResourceTable, type Column } from "../components/ResourceTable";
 import { StatusBadge } from "../components/StatusBadge";
 import { EmptyState } from "../components/EmptyState";
+import { ListFetchError } from "../components/ListFetchError";
 import { Network, Grid3X3, List } from "lucide-react";
 import clsx from "clsx";
 import type { AgentSystem } from "../api/types";
@@ -13,7 +14,7 @@ import { Plus } from "lucide-react";
 type ViewMode = "cards" | "table";
 
 export function AgentSystems() {
-  const { data, isLoading } = useAgentSystems();
+  const { data, isLoading, isError, error, refetch } = useAgentSystems();
   const navigate = useNavigate();
   const [view, setView] = useState<ViewMode>("cards");
   const [showCreate, setShowCreate] = useState(false);
@@ -81,7 +82,14 @@ export function AgentSystems() {
         </div>
       </div>
 
-      {systems.length === 0 && !isLoading ? (
+      {isError && (
+        <ListFetchError
+          message={error instanceof Error ? error.message : "Failed to load agent systems"}
+          onRetry={() => void refetch()}
+        />
+      )}
+
+      {systems.length === 0 && !isLoading && !isError ? (
         <EmptyState
           icon={<Network size={40} />}
           title="No Agent Systems"
@@ -93,7 +101,10 @@ export function AgentSystems() {
             <div
               key={sys.metadata.name}
               className="resource-card"
+              role="button"
+              tabIndex={0}
               onClick={() => navigate(`/systems/${sys.metadata.name}`)}
+              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); navigate(`/systems/${sys.metadata.name}`); } }}
             >
               <div className="resource-card__header">
                 <Network size={16} className="resource-card__icon" />

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -4,12 +4,13 @@ import { useAgents } from "../api/hooks";
 import { ResourceTable, type Column } from "../components/ResourceTable";
 import { StatusBadge } from "../components/StatusBadge";
 import { EmptyState } from "../components/EmptyState";
+import { ListFetchError } from "../components/ListFetchError";
 import { Bot, Plus } from "lucide-react";
 import type { Agent } from "../api/types";
 import { CreateResourceDialog } from "../components/CreateResourceDialog";
 
 export function Agents() {
-  const { data, isLoading } = useAgents();
+  const { data, isLoading, isError, error, refetch } = useAgents();
   const navigate = useNavigate();
   const [showCreate, setShowCreate] = useState(false);
   const agents = data ?? [];
@@ -23,6 +24,22 @@ export function Agents() {
     { key: "namespace", header: "Namespace", render: (r) => <span className="text-muted">{r.metadata.namespace}</span> },
     { key: "phase", header: "Status", render: (r) => <StatusBadge phase={r.status?.phase} />, width: "120px" },
   ];
+
+  if (isError) {
+    return (
+      <div className="page">
+        <div className="page__header">
+          <div>
+            <h1 className="page__title">Agents</h1>
+          </div>
+        </div>
+        <ListFetchError
+          message={error instanceof Error ? error.message : "Failed to load agents"}
+          onRetry={() => void refetch()}
+        />
+      </div>
+    );
+  }
 
   if (agents.length === 0 && !isLoading) {
     return (

--- a/frontend/src/pages/Capabilities.tsx
+++ b/frontend/src/pages/Capabilities.tsx
@@ -1,10 +1,11 @@
 import { ContextBackButton } from "../components/ContextBackButton";
 import { useCapabilities } from "../api/hooks";
 import { EmptyState } from "../components/EmptyState";
+import { ListFetchError } from "../components/ListFetchError";
 import { Sparkles } from "lucide-react";
 
 export function Capabilities() {
-  const { data, isLoading, isError, error } = useCapabilities();
+  const { data, isLoading, isError, error, refetch } = useCapabilities();
 
   return (
     <div className="page">
@@ -23,12 +24,15 @@ export function Capabilities() {
       {isLoading && <div className="loading-placeholder">Loading capabilities…</div>}
 
       {isError && (
-        <p className="text-red">{error instanceof Error ? error.message : "Failed to load capabilities"}</p>
+        <ListFetchError
+          message={error instanceof Error ? error.message : "Failed to load capabilities"}
+          onRetry={() => void refetch()}
+        />
       )}
 
       {!isLoading && !isError && data && (
         <>
-          <p className="text-muted" style={{ marginBottom: "1rem" }}>
+          <p className="text-muted mb-md">
             Generated at: {data.generated_at ? new Date(data.generated_at).toLocaleString() : "—"}
           </p>
           {(data.capabilities ?? []).length === 0 ? (

--- a/frontend/src/pages/Secrets.tsx
+++ b/frontend/src/pages/Secrets.tsx
@@ -6,6 +6,7 @@ import { useSecrets } from "../api/hooks";
 import { ResourceTable, type Column } from "../components/ResourceTable";
 import { StatusBadge } from "../components/StatusBadge";
 import { EmptyState } from "../components/EmptyState";
+import { ListFetchError } from "../components/ListFetchError";
 import { Lock, Plus } from "lucide-react";
 import type { Secret } from "../api/types";
 import { CreateResourceDialog } from "../components/CreateResourceDialog";
@@ -13,7 +14,7 @@ import { CreateResourceDialog } from "../components/CreateResourceDialog";
 export function Secrets() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { data, isLoading } = useSecrets();
+  const { data, isLoading, isError, error, refetch } = useSecrets();
   const [showCreate, setShowCreate] = useState(false);
   const secrets = data ?? [];
 
@@ -45,7 +46,14 @@ export function Secrets() {
           </button>
         </div>
       </div>
-      {secrets.length === 0 && !isLoading ? (
+      {isError && (
+        <ListFetchError
+          message={error instanceof Error ? error.message : "Failed to load secrets"}
+          onRetry={() => void refetch()}
+        />
+      )}
+
+      {secrets.length === 0 && !isLoading && !isError ? (
         <EmptyState icon={<Lock size={40} />} title="No Secrets" description="Secrets store sensitive values for tool authentication." />
       ) : (
         <ResourceTable

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -125,10 +125,13 @@ export function TaskDetail() {
         </button>
       </div>
 
-      <div className="tab-bar">
+      <div className="tab-bar" role="tablist">
         {tabs.map((t) => (
           <button
             key={t.id}
+            role="tab"
+            aria-selected={tab === t.id}
+            aria-controls={`tabpanel-${t.id}`}
             className={clsx("tab-bar__tab", tab === t.id && "tab-bar__tab--active")}
             onClick={() => setTab(t.id)}
           >
@@ -137,19 +140,20 @@ export function TaskDetail() {
         ))}
       </div>
 
-      <div className="tab-content">
+      <div className="tab-content" role="tabpanel" id={`tabpanel-${tab}`} aria-labelledby={tab}>
         {tab === "overview" && (
           <>
             {task.status?.blocked_on?.name && (
-              <div className="card" style={{ marginBottom: 16 }}>
+              <div className="card card--mb">
                 <div className="detail-field">
                   <span className="detail-field__label">Blocked On</span>
-                  <span
-                    className="detail-field__value detail-field__link"
+                  <button
+                    type="button"
+                    className="detail-field__value detail-field__link btn-link"
                     onClick={() => navigate((task.status?.blocked_on?.kind ?? "").toLowerCase() === "taskapproval" ? `/approvals/task/${task.status?.blocked_on?.name}` : `/approvals/${task.status?.blocked_on?.name}`)}
                   >
-                    {task.status?.blocked_on?.kind ?? "Approval"} · {task.status?.blocked_on?.name}
-                  </span>
+                    {task.status?.blocked_on?.kind ?? "Approval"} &middot; {task.status?.blocked_on?.name}
+                  </button>
                 </div>
               </div>
             )}
@@ -160,12 +164,13 @@ export function TaskDetail() {
             </div>
             <div className="detail-field">
               <span className="detail-field__label">System</span>
-              <span
-                className="detail-field__value detail-field__link"
+              <button
+                type="button"
+                className="detail-field__value detail-field__link btn-link"
                 onClick={() => navigate(`/systems/${task.spec.system}`)}
               >
                 {task.spec.system}
-              </span>
+              </button>
             </div>
             <div className="detail-field">
               <span className="detail-field__label">Priority</span>
@@ -261,7 +266,12 @@ export function TaskDetail() {
               </button>
             </div>
             {messages.isLoading && <p className="text-muted">Loading messages…</p>}
-            {(messages.data ?? []).length === 0 && !messages.isLoading && (
+            {messages.isError && (
+              <p className="text-red">
+                {messages.error instanceof Error ? messages.error.message : "Failed to load messages"}
+              </p>
+            )}
+            {(messages.data ?? []).length === 0 && !messages.isLoading && !messages.isError && (
               <p className="text-muted">
                 {Object.keys(msgFiltersApplied).length > 0
                   ? "No messages match the current filters"
@@ -314,11 +324,22 @@ export function TaskDetail() {
           </div>
         )}
         {tab === "metrics" && !metrics.isLoading && !m && (
-          <p className="text-muted">No metrics available</p>
+          metrics.isError ? (
+            <p className="text-red">
+              {metrics.error instanceof Error ? metrics.error.message : "Failed to load metrics"}
+            </p>
+          ) : (
+            <p className="text-muted">No metrics available</p>
+          )
         )}
 
         {tab === "trace" && <TraceView trace={traceEvents} />}
 
+        {tab === "logs" && logs.isError && (
+          <p className="text-red">
+            {logs.error instanceof Error ? logs.error.message : "Failed to load logs"}
+          </p>
+        )}
         {tab === "logs" && <LogViewer logs={logs.data ?? ""} loading={logs.isLoading} />}
 
         {tab === "graph" && system.data && (

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -5,6 +5,7 @@ import { ResourceTable, type Column } from "../components/ResourceTable";
 import { StatusBadge } from "../components/StatusBadge";
 import { FilterPills } from "../components/FilterPills";
 import { EmptyState } from "../components/EmptyState";
+import { ListFetchError } from "../components/ListFetchError";
 import { ListTodo, Plus } from "lucide-react";
 import type { Task } from "../api/types";
 import { CreateResourceDialog } from "../components/CreateResourceDialog";
@@ -21,6 +22,9 @@ export function Tasks() {
   const {
     data,
     isLoading,
+    isError,
+    error,
+    refetch,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
@@ -129,7 +133,14 @@ export function Tasks() {
         onSelect={setPhaseFilter}
       />
 
-      {filtered.length === 0 && !isLoading ? (
+      {isError && (
+        <ListFetchError
+          message={error instanceof Error ? error.message : "Failed to load tasks"}
+          onRetry={() => void refetch()}
+        />
+      )}
+
+      {filtered.length === 0 && !isLoading && !isError ? (
         <EmptyState
           icon={<ListTodo size={40} />}
           title={phaseFilter === "All" ? "No Tasks" : `No ${phaseFilter} Tasks`}

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1180,6 +1180,35 @@
   font-size: 0.9rem;
 }
 
+.list-fetch-error {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 20px;
+  color: var(--red);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 10px;
+  font-size: 0.9rem;
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.card--mb {
+  margin-bottom: 1rem;
+}
+
+.mb-md {
+  margin-bottom: 1rem;
+}
+
 .table-skeleton {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
List pages (Agents, Tasks, Agent Systems, Secrets) now show a ListFetchError component with retry on API failures instead of silently rendering empty states. TaskDetail sub-queries (messages, metrics, logs) surface fetch errors. Clickable divs/spans replaced with keyboard-accessible elements, tab bar uses ARIA semantics, and inline styles replaced with utility CSS classes.


