### PR TITLE
feat: agent-stack README; harden setup, HTTP, listings, names, and tool IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,259 +2,345 @@
   <img src="docs/public/logo.png" alt="Orloj" width="200" />
 </p>
 
-# Orloj
+# Agents are infrastructure.
 
-_Named after the [Prague Orloj](https://en.wikipedia.org/wiki/Prague_astronomical_clock), an astronomical clock that has coordinated complex mechanisms for over 600 years._
+## Orloj is the full stack for agentic systems.
 
-[![Release](https://img.shields.io/github/v/release/OrlojHQ/orloj?display_name=tag&sort=semver)](https://github.com/OrlojHQ/orloj/releases)
-[![CI](https://img.shields.io/github/actions/workflow/status/OrlojHQ/orloj/ci.yml?branch=main&label=ci)](https://github.com/OrlojHQ/orloj/actions/workflows/ci.yml)
-[![Docs](https://img.shields.io/github/actions/workflow/status/OrlojHQ/orloj/docs.yml?branch=main&label=docs)](https://docs.orloj.dev)
-[![Go Report Card](https://goreportcard.com/badge/github.com/OrlojHQ/orloj)](https://goreportcard.com/report/github.com/OrlojHQ/orloj)
-[![Go Reference](https://pkg.go.dev/badge/github.com/OrlojHQ/orloj.svg)](https://pkg.go.dev/github.com/OrlojHQ/orloj)
-[![PyPI - orloj-sdk](https://img.shields.io/pypi/v/orloj-sdk)](https://pypi.org/project/orloj-sdk/)
-[![npm - orloj](https://img.shields.io/npm/v/orloj)](https://www.npmjs.com/package/orloj)
-[![License](https://img.shields.io/github/license/OrlojHQ/orloj)](LICENSE)
+Build, run, govern, and observe multi-agent systems from one declarative stack: agents, tools, models, memory, schedules, webhooks, approvals, policies, workers, traces, metrics, and deployment primitives.
 
-**An orchestration runtime for multi-agent AI systems.**
+**[Quickstart](#quickstart)** | **[Docs](https://docs.orloj.dev)** | **[Stack](#the-orloj-agent-stack)** | **[How It Works](#how-it-works)** | **[Screenshots](#screenshots)**
 
-Declare your agents, tools, and policies as YAML. Orloj schedules, executes, routes, and governs them so you can run multi-agent systems in production with the same operational rigor you expect from infrastructure.
-
-> **Status:** Orloj is under active development. APIs and resource schemas may change between minor versions before 1.0.
-
-### Official SDKs
-
-Call the Orloj HTTP API from application code using the official clients (complementing **`orlojctl`** for operators). For REST shapes and generated types, see [HTTP API (OpenAPI)](#http-api-openapi).
-
-| Language     | Install                  | Links                                                                                    |
-| ------------ | ------------------------ | ---------------------------------------------------------------------------------------- |
-| Python       | `pip install orloj-sdk`  | [PyPI](https://pypi.org/project/orloj-sdk/) · [Repository](https://github.com/OrlojHQ/orloj-python-sdk) |
-| TypeScript   | `npm install orloj`      | [npm](https://www.npmjs.com/package/orloj) · [Repository](https://github.com/OrlojHQ/orloj-js-sdk)      |
-
-**Start here:** [See Orloj in Action](#orloj-in-action) · [5-minute tutorial](https://docs.orloj.dev/guides/five-minute-tutorial)
-
-## Orloj in Action
-
-Orloj is API/CLI-first; the web console is an optional operator UI.
-
-### Web Console Walkthrough
-
-These captures are from the web console running the `testing/scenarios-real/01-pipeline` scenario locally.
-
-### Run Lifecycle (GIF)
+> **Status:** Orloj is under active development. APIs and resource schemas may change before 1.0.
 
 ![Orloj task lifecycle animation](docs/public/readme/task-run-lifecycle.gif)
 
-Watch a full run flow from task creation through running to success in the live frontend.
+## What Is Orloj?
 
-### Dashboard Overview
+Orloj is the open-source full stack for developing and operating agentic systems.
+
+An agent system is no longer just a prompt and a loop. It has model routing, tool permissions, credentials, memory, retries,
+human approvals, schedules, webhooks, workers, traces, logs, metrics, and deployment topology. Orloj treats those pieces the
+way infrastructure platforms treat services: as versioned resources with desired state, status, controllers, leases,
+workers, runtime policy, and operational visibility.
+
+|                                            |                                                                                                                     |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| **If agents are services**                 | Orloj gives them manifests, runtime bounds, credentials, routing, observability, and lifecycle management.          |
+| **If agent teams are distributed systems** | Orloj gives them durable handoffs, fan-out, fan-in, retries, idempotency, dead-letter states, and worker ownership. |
+| **If tools are production access**         | Orloj gives them isolation, authorization, approval gates, retry policy, secrets, and audit-friendly traces.        |
+
+## The Orloj Agent Stack
+
+Orloj is not a single runtime component. It spans the layers teams need to develop, run, govern, and observe agentic systems.
+
+![The Orloj Agent Stack](docs/public/readme/orloj-agent-stack.svg)
+
+| Stack Layer                      | What Orloj Provides                                                                                                      |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **Interfaces**                   | YAML manifests, `orlojctl`, REST API, SDKs, and web console.                                                             |
+| **Agent Definitions**            | `Agent`, `AgentSystem`, prompts, graph topology, roles, execution contracts, and runtime bounds.                         |
+| **Execution Runtime**            | Sequential and message-driven execution, workers, leases, heartbeats, retries, idempotency keys, and dead-letter states. |
+| **Model & Context Layer**        | `ModelEndpoint` resources, provider routing, fallback models, secrets, token budgets, and `Memory`.                      |
+| **Tool & Integration Layer**     | HTTP, gRPC, external services, webhook callbacks, MCP, CLI, WASM, auth, isolation, timeouts, and retries.                |
+| **Governance & Human Review**    | `AgentPolicy`, `AgentRole`, `ToolPermission`, `ToolApproval`, and `TaskApproval`.                                        |
+| **Observability & Operations**   | Traces, logs, messages, task history, watch streams, events, Prometheus metrics, OpenTelemetry spans, and UI views.      |
+| **State & Deployment Substrate** | In-memory and Postgres state, NATS JetStream messaging, Docker Compose, VPS deployments, and Kubernetes paths.           |
+
+## How The Stack Operates
+
+|                                                                                                                       |                                                                                                                              |                                                                                                                      |
+| --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Declare:** Write YAML resources for agents, systems, tools, model endpoints, memory, tasks, and policy.             | **Reconcile:** Controllers validate resources, update status, discover MCP tools, manage schedules, and drive state forward. | **Schedule:** Tasks target an AgentSystem and are assigned to workers based on capacity and requirements.            |
+| **Claim:** Workers claim tasks with leases, renew heartbeats, and allow takeover when ownership expires.              | **Execute:** Bounded agent loops route model calls, invoke tools, use memory, and pass messages through the graph.           | **Govern:** Policies, roles, tool permissions, ToolApprovals, and TaskApprovals fail closed during runtime.          |
+| **Observe:** Every run records trace events, task history, messages, logs, metrics, and optional OpenTelemetry spans. | **Scale:** Start local with an embedded worker, then move to Postgres, NATS JetStream, and distributed workers.              | **Operate:** Use the CLI, REST API, watch streams, web console, Prometheus metrics, and standard deployment targets. |
+
+## Orloj Is Right For You If
+
+|                                                                                                                              |
+| ---------------------------------------------------------------------------------------------------------------------------- |
+| You are moving from agent demos to systems that need owners, policies, retries, credentials, and traces.                     |
+| You want agents, tools, models, and workflows in version-controlled manifests instead of scattered scripts.                  |
+| You need multiple agents to hand off work through pipelines, hierarchies, fan-out, fan-in, loops, or delegated review.       |
+| You need tool calls to be authorized, isolated, approved, retried, and observable.                                           |
+| You want to develop locally in one process and keep the same resource model when you scale to workers and durable messaging. |
+
+## Problems Orloj Solves
+
+| Without Orloj                                                                                   | With Orloj                                                                                                                      |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Agent scripts, prompts, tool configs, and credentials drift across repos and machines.          | Agents, tools, models, memory, triggers, workers, and policy are declared as resources and applied through one API.             |
+| Multi-agent handoffs are hidden in custom code and hard to inspect after the run.               | AgentSystem graphs define the routing, while Task status records messages, branches, joins, delegation, trace, and history.     |
+| A failed process can leave work half-owned, duplicated, or silently lost.                       | Workers claim tasks with leases and heartbeats. Retries, idempotency keys, and dead-letter phases make failure visible.         |
+| Tool access is whatever the prompt or script happens to allow.                                  | Tool execution passes through policies, roles, permissions, operation rules, isolation modes, timeouts, retries, and approvals. |
+| Switching model providers means editing every agent or duplicating config.                      | Agents reference ModelEndpoint resources, with provider-specific config, secrets, and fallback routing centralized.             |
+| Recurring and event-driven agent work needs separate cron jobs, webhook glue, and dedupe logic. | TaskSchedule and TaskWebhook resources create Tasks from templates with concurrency, signature verification, and idempotency.   |
+| Debugging requires reading scattered logs and guessing what each agent did.                     | Task traces capture model calls, tool calls, errors, token usage, latency, approvals, retries, messages, and output.            |
+
+## What Is In The Stack
+
+| Layer          | Resources and Runtime Behavior                                                                                                                 |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Agents**     | `Agent` resources define prompts, model refs, fallback models, tools, roles, memory access, execution contracts, and bounds.                   |
+| **Systems**    | `AgentSystem` resources compose agents into graphs with edges, conditional routing, fan-out, fan-in, delegation, and human review checkpoints. |
+| **Tasks**      | `Task` resources execute an AgentSystem and track phase, output, attempts, leases, messages, joins, delegation, trace, history, and blockers.  |
+| **Models**     | `ModelEndpoint` resources route calls to OpenAI, Anthropic, AWS Bedrock, Azure OpenAI, Ollama, mock, and OpenAI-compatible providers.          |
+| **Tools**      | `Tool` resources support HTTP, external services, gRPC, webhook callbacks, MCP, CLI, and WASM with runtime policy and auth.                    |
+| **Memory**     | `Memory` resources back task-scoped and persistent memory through in-memory, pgvector, or HTTP providers.                                      |
+| **Triggers**   | `TaskSchedule` and `TaskWebhook` resources create Tasks from cron schedules and signed HTTP events.                                            |
+| **Governance** | `AgentPolicy`, `AgentRole`, `ToolPermission`, `ToolApproval`, and `TaskApproval` enforce model, tool, and review controls at runtime.          |
+| **Workers**    | `Worker` resources declare capacity, region, supported models, GPU support, heartbeat, and current task load.                                  |
+
+## Example: An Agent System As Code
+
+Define an agent:
+
+```yaml
+apiVersion: orloj.dev/v1
+kind: Agent
+metadata:
+  name: research-agent
+spec:
+  model_ref: openai-default
+  prompt: |
+    You are the research stage.
+    Produce concise, verifiable findings for the writer.
+  tools:
+    - web_search
+  allowed_tools:
+    - web_search
+  limits:
+    max_steps: 6
+    timeout: 30s
+```
+
+Bind it to a model endpoint:
+
+```yaml
+apiVersion: orloj.dev/v1
+kind: ModelEndpoint
+metadata:
+  name: openai-default
+spec:
+  provider: openai
+  base_url: https://api.openai.com/v1
+  default_model: gpt-4o
+  auth:
+    secretRef: openai-api-key
+```
+
+Wire agents into a graph:
+
+```yaml
+apiVersion: orloj.dev/v1
+kind: AgentSystem
+metadata:
+  name: report-system
+spec:
+  agents:
+    - planner-agent
+    - research-agent
+    - writer-agent
+  graph:
+    planner-agent:
+      edges:
+        - to: research-agent
+    research-agent:
+      edges:
+        - to: writer-agent
+```
+
+Run it as a task:
+
+```yaml
+apiVersion: orloj.dev/v1
+kind: Task
+metadata:
+  name: weekly-report
+spec:
+  system: report-system
+  input:
+    topic: enterprise AI copilots
+  retry:
+    max_attempts: 2
+    backoff: 2s
+  message_retry:
+    max_attempts: 2
+    backoff: 250ms
+    max_backoff: 2s
+    jitter: full
+```
+
+## Governance Built Into The Runtime
+
+Governance in Orloj is not a documentation convention. It is evaluated while work is being executed.
+
+|                    |                                                                                               |
+| ------------------ | --------------------------------------------------------------------------------------------- |
+| **AgentPolicy**    | Constrains allowed models, blocked tools, token budget, child depth, and child task creation. |
+| **AgentRole**      | Grants named permissions to agents.                                                           |
+| **ToolPermission** | Defines what permissions or operation rules are required for a tool invocation.               |
+| **ToolApproval**   | Pauses risky tool calls until a reviewer approves or denies them.                             |
+| **TaskApproval**   | Pauses graph nodes or final output for human review, denial, or request-changes loops.        |
+
+Unauthorized actions fail closed and appear in the task trace.
+
+## How It Works
+
+| Component         | Responsibility                                                                                                                                                 |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `orlojd`          | Runs the REST API, web console, resource stores, watch/event endpoints, controllers, schedulers, and optional embedded worker.                                 |
+| `orlojworker`     | Claims tasks, renews leases, executes agent graphs, consumes message-driven inboxes, routes models, invokes tools, and reports status.                         |
+| `orlojctl`        | Applies manifests, scaffolds systems, creates secrets, runs tasks, watches resources, reviews approvals, inspects logs, traces, graphs, messages, and metrics. |
+| **Storage**       | Uses in-memory storage for local development or Postgres for production resource state, task claiming, leases, and persistence.                                |
+| **Messaging**     | Uses sequential mode for local simplicity or message-driven mode with memory or NATS JetStream for distributed handoffs.                                       |
+| **Observability** | Exposes task trace and history, task logs, message lifecycle, Prometheus metrics, OpenTelemetry spans, structured logs, and web console views.                 |
+
+## Screenshots
+
+### Operator Dashboard
 
 ![Orloj dashboard overview](docs/public/readme/dashboard-overview.png)
 
-View the operator dashboard with system status and active workload at a glance.
+System status and active workload at a glance.
 
 ### System Topology
 
 ![Orloj system topology view](docs/public/readme/system-topology.png)
 
-Inspect the agent-system graph topology and understand how nodes connect.
+Inspect the graph that connects agents.
 
-## Why Orloj
+### Task Graph
 
-Running AI agents in production today looks a lot like running containers before container orchestration: ad-hoc scripts, no governance, no observability, and no standard way to manage an agent fleet. Orloj provides:
+![Orloj task detail graph view](docs/public/readme/task-detail-graph.png)
 
-- **Agents-as-Code** -- declare agents, their models, tools, and constraints in version-controlled YAML manifests.
-- **DAG-based orchestration** -- pipeline, hierarchical, and swarm-loop topologies with fan-out/fan-in support.
-- **Model routing** -- bind agents to OpenAI, Anthropic, Azure OpenAI, Ollama, and other endpoints. Switch providers without changing agent definitions.
-- **Tool isolation** -- execute tools in containers, WASM sandboxes, or process isolation with configurable timeout and retry.
-- **Governance built in** -- policies, roles, and tool permissions enforced at the execution layer. Unauthorized tool calls fail closed.
-- **Production reliability** -- lease-based task ownership, idempotent replay, capped exponential retry with jitter, and dead-letter handling.
-- **Web console** -- built-in UI with topology views, task inspection, and live event streaming.
+Follow node-level execution progress.
+
+### Trace And Logs
+
+![Orloj task trace and logs view](docs/public/readme/task-trace-logs.png)
+
+Debug model calls, tool calls, latency, errors, and output.
 
 ## Quickstart
 
-**[Get started in 5 minutes](https://docs.orloj.dev/guides/five-minute-tutorial)** — scaffold with `orlojctl init`, add your API key, apply manifests, and run a pipeline with `orlojctl run`.
-
-Install **orlojctl** (CLI) via Homebrew:
+Install the CLI:
 
 ```bash
 brew tap OrlojHQ/orloj
 brew install orlojctl
 ```
 
-Formula versions follow [Orloj releases](https://github.com/OrlojHQ/orloj/releases).
-
-Or install all binaries (**orlojd**, **orlojworker**, **orlojctl**) with the install script:
+Or install the binaries:
 
 ```bash
 curl -sSfL https://raw.githubusercontent.com/OrlojHQ/orloj/main/scripts/install.sh | sh
 ```
 
-You can also download binaries manually from [GitHub Releases](https://github.com/OrlojHQ/orloj/releases). Then run:
+Start Orloj with an embedded worker and in-memory state:
 
 ```bash
-# Start the server with an embedded worker
-./orlojd --storage-backend=memory --task-execution-mode=sequential --embedded-worker
+orlojd --storage-backend=memory --embedded-worker
 ```
 
-Open **[http://127.0.0.1:8080/](http://127.0.0.1:8080/)** to explore the web console, then apply a starter blueprint. The example manifests live in this repo -- clone it or [browse them on GitHub](https://github.com/OrlojHQ/orloj/tree/main/examples):
+Scaffold a pipeline:
 
 ```bash
-# Apply a starter blueprint (pipeline: planner -> research -> writer)
-./orlojctl apply -f examples/blueprints/pipeline/ --run
-
-# Check the result
-./orlojctl get task bp-pipeline-task
+orlojctl init demo
 ```
 
-Or build from source (requires Go 1.25+):
+Create the model secret expected by the scaffold:
 
 ```bash
-go build -o orlojd ./cmd/orlojd
-go build -o orlojctl ./cmd/orlojctl
+orlojctl create secret openai-api-key --from-literal value=sk-your-key-here
 ```
 
-When you are ready to scale, switch to message-driven mode with distributed workers and Postgres persistence. See the [Quickstart guide](https://docs.orloj.dev/getting-started/quickstart#scaling-to-production) for details. Full walkthrough: [5-minute tutorial](https://docs.orloj.dev/guides/five-minute-tutorial).
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────┐
-│                  Server (orlojd)                     │
-│                                                     │
-│  ┌──────────────┐   ┌────────────────┐              │
-│  │  API Server   │──►│ Resource Store  │             │
-│  │   (REST)      │   │ mem / postgres  │             │
-│  └──────┬───────┘   └────────────────┘              │
-│         │                                           │
-│         ▼                                           │
-│  ┌──────────────┐   ┌────────────────┐              │
-│  │   Services    │──►│ Task Scheduler │              │
-│  └──────────────┘   └───────┬────────┘              │
-└─────────────────────────────┼───────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────┐
-│                 Workers (orlojworker)                │
-│                                                     │
-│  ┌──────────────┐   ┌───────────────┐               │
-│  │  Task Worker  │──►│ Model Gateway │               │
-│  │              │   └───────────────┘               │
-│  │              │──►┌───────────────┐               │
-│  │              │   │  Tool Runtime  │               │
-│  │              │   └───────────────┘               │
-│  │       ◄──────┼───┌───────────────┐               │
-│  │              │──►│  Message Bus   │               │
-│  └──────────────┘   └───────────────┘               │
-└─────────────────────────────────────────────────────┘
-```
-
-**Server** (`orlojd`) -- API server, resource store (in-memory or Postgres), background services, and task scheduler.
-
-**Workers** (`orlojworker`) -- claim tasks, execute agent graphs, route model requests, run tools, and handle inter-agent messaging.
-
-**Governance** -- AgentPolicy, AgentRole, and ToolPermission resources enforced inline during every tool call and model interaction.
-
-Persistence is backed by Postgres (or in-memory for local dev). Message-driven mode uses NATS JetStream for durable agent-to-agent messaging.
-
-## HTTP API (OpenAPI)
-
-The v1 REST API is described in [openapi/openapi.yaml](openapi/openapi.yaml) (OpenAPI 3.1). Shared request/response models live under [openapi/schemas/](openapi/schemas/); the root file is **generated** by [openapi/build_openapi.py](openapi/build_openapi.py) (`python3 openapi/build_openapi.py`). CI runs `npx @redocly/cli lint openapi/openapi.yaml`. Contributors: see [Contributing — OpenAPI](CONTRIBUTING.md#openapi) for what to edit and what not to hand-edit.
-
-## Resources
-
-Orloj manages 15 resource types, all defined as declarative YAML with `apiVersion`, `kind`, `metadata`, `spec`, and `status` fields:
-
-**Core**
-
-
-| Resource      | Purpose                                              |
-| ------------- | ---------------------------------------------------- |
-| Agent         | Unit of work backed by a language model              |
-| AgentSystem   | Directed graph composing multiple agents             |
-| ModelEndpoint | Connection to a model provider                       |
-| Tool          | External capability with isolation and retry         |
-| Secret        | Credential storage                                   |
-| Memory        | Vector-backed retrieval for agents                   |
-| McpServer     | MCP server connection that discovers/syncs MCP tools |
-
-
-**Governance**
-
-
-| Resource       | Purpose                                    |
-| -------------- | ------------------------------------------ |
-| AgentPolicy    | Token, model, and tool constraints         |
-| AgentRole      | Named permission set bound to agents       |
-| ToolPermission | Required permissions for tool invocation   |
-| ToolApproval   | Approval record for gated tool invocations |
-
-
-**Scheduling & Triggers**
-
-
-| Resource     | Purpose                                    |
-| ------------ | ------------------------------------------ |
-| Task         | Request to execute an AgentSystem          |
-| TaskSchedule | Cron-based task creation                   |
-| TaskWebhook  | Event-triggered task creation              |
-| Worker       | Execution unit with capability declaration |
-
-
-## More Screenshots
-
-### Task Detail and Graph
-
-![Orloj task detail graph view](docs/public/readme/task-detail-graph.png)
-
-Drill into a task to see node-level execution state and graph progress.
-
-### Trace and Logs
-
-![Orloj task trace and logs view](docs/public/readme/task-trace-logs.png)
-
-Open trace and log detail to debug runtime behavior without leaving the task view.
-
-## Documentation
-
-Browse **[docs.orloj.dev](https://docs.orloj.dev)**.
-
-- [Changelog](CHANGELOG.md) -- notable changes by release
-- [5-minute tutorial](https://docs.orloj.dev/guides/five-minute-tutorial) -- scaffold, model key, first run
-- [Getting Started](https://docs.orloj.dev/getting-started/install) -- install, quickstart
-- [Concepts](https://docs.orloj.dev/concepts/architecture) -- architecture, agents, tasks, tools, model routing, governance
-- [Guides](https://docs.orloj.dev/guides/) -- deploy a pipeline, configure routing, build tools, set up governance
-- [Deploy & Operate](https://docs.orloj.dev/deploy/) -- local, VPS, Kubernetes, [remote CLI access](https://docs.orloj.dev/deploy/remote-cli-access)
-- [Reference](https://docs.orloj.dev/reference/cli) -- CLI, API, resource schemas
-- [Security](https://docs.orloj.dev/operations/security) -- control plane API tokens, secrets, tool isolation
-- [Examples](examples/README.md) -- per-kind YAML under `examples/resources/`, starter `blueprints/`, and `use-cases/` (in this repo)
-
-## Docker Compose
-
-Run the full stack (Postgres + server + 2 workers) with Docker Compose:
+Apply the resources and include the sample task:
 
 ```bash
-docker compose up --build -d
-docker compose ps
+orlojctl apply -f demo/ --run
 ```
 
-The Compose images include the server and workers only. To drive the API from your machine, install **`orlojctl`**:
+Run a new task with your own input:
 
 ```bash
-brew tap OrlojHQ/orloj
-brew install orlojctl
+orlojctl run --system demo-system topic="The future of open source AI"
 ```
 
-Or via the install script:
+Inspect the run:
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/OrlojHQ/orloj/main/scripts/install.sh | ORLOJ_BINARIES="orlojctl" sh
+orlojctl get tasks
+orlojctl trace task <task-name>
+orlojctl logs task/<task-name>
 ```
 
-You can also download it from [GitHub Releases](https://github.com/OrlojHQ/orloj/releases). See [Deploy & Operate](https://docs.orloj.dev/deploy/) for more details.
+Open the console at [http://127.0.0.1:8080/](http://127.0.0.1:8080/).
+
+## Production Shape
+
+Local development can run in one process. Production can split the Orloj server and workers:
+
+|                      |                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| **Local**            | `orlojd --storage-backend=memory --embedded-worker`                                      |
+| **Persistent**       | `orlojd --storage-backend=postgres` with Postgres-backed resource state.                 |
+| **Distributed**      | `orlojd` plus one or more `orlojworker` processes with message-driven execution.         |
+| **Durable handoffs** | `--agent-message-bus-backend=nats-jetstream` for runtime agent messages.                 |
+| **Observability**    | `/metrics`, OpenTelemetry export, task traces, logs, message views, and the web console. |
+
+Configure `ORLOJ_POSTGRES_DSN` before using the Postgres examples. Configure `ORLOJ_NATS_URL` or
+`ORLOJ_AGENT_MESSAGE_NATS_URL` when NATS is not running on the default local address.
+
+```bash
+orlojd \
+  --storage-backend=postgres \
+  --task-execution-mode=message-driven \
+  --agent-message-bus-backend=nats-jetstream
+```
+
+```bash
+orlojworker \
+  --storage-backend=postgres \
+  --task-execution-mode=message-driven \
+  --agent-message-bus-backend=nats-jetstream \
+  --agent-message-consume
+```
+
+## What Orloj Is Not
+
+|                               |                                                                                                                                                 |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Not an agent framework**    | Orloj does not force a prompt style or reasoning pattern. It operates the stack around agents as infrastructure resources.                      |
+| **Not a prompt manager**      | Prompts live in Agent manifests, but the product is the operating stack around execution, routing, policy, and operations.                      |
+| **Not just governance**       | Governance is built in, but Orloj also handles scheduling, workers, model routing, memory, tools, triggers, messaging, traces, and deployments. |
+| **Not just a dashboard**      | The web console is an operator UI over the same API and resource model used by `orlojctl` and automation.                                       |
+| **Not a toy workflow runner** | The same manifest model can run locally, with Postgres persistence, or across distributed workers and durable message queues.                   |
+
+## Docs And Examples
+
+|                                                                         |                                                                                |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [5-minute tutorial](https://docs.orloj.dev/guides/five-minute-tutorial) | Scaffold, configure a model key, and run a first agent system.                 |
+| [Architecture](https://docs.orloj.dev/concepts/architecture)            | Server, workers, governance, execution modes, and reliability characteristics. |
+| [Starter blueprints](https://docs.orloj.dev/guides/starter-blueprints)  | Pipeline, hierarchical, and swarm-loop topologies.                             |
+| [Governance guide](https://docs.orloj.dev/guides/setup-governance)      | Policies, roles, tool permissions, and runtime enforcement.                    |
+| [Deploy and operate](https://docs.orloj.dev/deploy/)                    | Local, VPS, Kubernetes, remote CLI access, and production configuration.       |
+| Examples                                                                | Resource samples, blueprints, and use-case bundles.                            |
+
+## SDKs
+
+Use the REST API directly, operate through `orlojctl`, or call Orloj from application code with official SDKs.
+
+| Language   | Install                 | Links                                       |
+| ---------- | ----------------------- | ------------------------------------------- | --------------------------------------------------------- |
+| Python     | `pip install orloj-sdk` | [PyPI](https://pypi.org/project/orloj-sdk/) | [Repository](https://github.com/OrlojHQ/orloj-python-sdk) |
+| TypeScript | `npm install orloj`     | [npm](https://www.npmjs.com/package/orloj)  | [Repository](https://github.com/OrlojHQ/orloj-js-sdk)     |
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for environment setup, test matrix, and PR lifecycle details.
+
+Helpful starting points:
 
 - [Good first issue](https://github.com/OrlojHQ/orloj/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
 - [Help wanted](https://github.com/OrlojHQ/orloj/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22)

--- a/api/auth_handlers.go
+++ b/api/auth_handlers.go
@@ -103,21 +103,15 @@ func (s *Server) handleAuthSetup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	userCount, err := s.stores.LocalAdmins.CountUsers()
-	if err != nil {
-		http.Error(w, "auth store error", http.StatusInternalServerError)
-		return
-	}
-	if userCount > 0 {
-		http.Error(w, "admin account is already configured", http.StatusConflict)
-		return
-	}
 	hash, err := store.GeneratePasswordHash(req.Password)
 	if err != nil {
 		http.Error(w, "failed to hash password", http.StatusInternalServerError)
 		return
 	}
-	user, err := s.stores.LocalAdmins.CreateUser(req.Username, hash, "admin")
+	// CreateFirstAdmin atomically checks that no users exist and inserts the
+	// admin in one operation, preventing the TOCTOU race where concurrent
+	// setup requests both observe zero users.
+	user, err := s.stores.LocalAdmins.CreateFirstAdmin(req.Username, hash)
 	if err != nil {
 		if errors.Is(err, store.ErrAuthUserExists) {
 			http.Error(w, "admin account is already configured", http.StatusConflict)

--- a/api/auth_ratelimit_test.go
+++ b/api/auth_ratelimit_test.go
@@ -221,8 +221,11 @@ func TestAuthRateLimiter_ExhaustsBurst(t *testing.T) {
 	req := mustReq(t, http.MethodPost, "/v1/auth/login", nil)
 	req.RemoteAddr = "192.0.2.99:1"
 
-	if !rl.allow(req) || !rl.allow(req) {
-		t.Fatal("expected first two requests to be allowed")
+	if !rl.allow(req) {
+		t.Fatal("expected first request to be allowed")
+	}
+	if !rl.allow(req) {
+		t.Fatal("expected second request to be allowed")
 	}
 	if rl.allow(req) {
 		t.Fatal("expected third request to be rate limited")

--- a/cli/orlojctl_seal.go
+++ b/cli/orlojctl_seal.go
@@ -86,6 +86,10 @@ func newSealSecretCommand() *cobra.Command {
 				return err
 			}
 
+			// Status is server-side state set on apply; omit it from
+			// the CLI output so sealed manifests are clean for VCS.
+			sealed.Status = resources.SealedSecretStatus{}
+
 			body, err := marshalSealOutput(sealed, format)
 			if err != nil {
 				return err

--- a/cli/tool.go
+++ b/cli/tool.go
@@ -252,14 +252,14 @@ spec:
     isolation_mode: wasm
     timeout: 5s
 `, name, name, name),
-		"fixtures/test_echo.json": fmt.Sprintf(`{
+		"fixtures/test_echo.json": `{
   "name": "echo hello",
   "input": "{\"query\": \"hello\"}",
   "expected_status": "ok",
   "expected_output": "processed: {\"query\": \"hello\"}",
   "timeout": "5s"
 }
-`),
+`,
 		"README.md": fmt.Sprintf(`# %s
 
 A WASM tool for Orloj agents.

--- a/cmd/orlojd/main.go
+++ b/cmd/orlojd/main.go
@@ -393,8 +393,15 @@ func main() {
 	}
 
 	httpServer := &http.Server{
-		Addr:    *addr,
-		Handler: telemetry.RequestIDMiddleware(server.Handler()),
+		Addr:              *addr,
+		Handler:           telemetry.RequestIDMiddleware(server.Handler()),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		// WriteTimeout is deliberately omitted: watch/SSE endpoints stream
+		// indefinitely and a global write deadline would break them. Per-
+		// handler timeouts via http.TimeoutHandler should be used for non-
+		// streaming routes instead.
 	}
 
 	go func() {

--- a/controllers/task_controller.go
+++ b/controllers/task_controller.go
@@ -1876,9 +1876,7 @@ func (c *TaskController) executeTask(ctx context.Context, task *resources.Task, 
 				MaxDepth:        orlojMaxDepth,
 				MaxChildren:     orlojMaxChildren,
 			})
-			for _, name := range agentruntime.BuiltinOrlojToolNames() {
-				agent.Spec.Tools = append(agent.Spec.Tools, name)
-			}
+			agent.Spec.Tools = append(agent.Spec.Tools, agentruntime.BuiltinOrlojToolNames()...)
 			agent.Spec.Tools = dedupeStringsController(agent.Spec.Tools)
 		}
 		result, err := c.executor.ExecuteAgentWithRuntime(agentCtx, agent, runtimeInput, finalRT)
@@ -2283,9 +2281,7 @@ func (c *TaskController) executeTaskFromResume(
 				MaxDepth:        orlojMaxDepth,
 				MaxChildren:     orlojMaxChildren,
 			})
-			for _, name := range agentruntime.BuiltinOrlojToolNames() {
-				agent.Spec.Tools = append(agent.Spec.Tools, name)
-			}
+			agent.Spec.Tools = append(agent.Spec.Tools, agentruntime.BuiltinOrlojToolNames()...)
 			agent.Spec.Tools = dedupeStringsController(agent.Spec.Tools)
 		}
 
@@ -2862,18 +2858,6 @@ func (c *TaskController) appendTaskTrace(task *resources.Task, event resources.T
 	if len(task.Status.Trace) > 500 {
 		task.Status.Trace = task.Status.Trace[len(task.Status.Trace)-500:]
 	}
-}
-
-func hasTraceEventForType(trace []resources.TaskTraceEvent, eventType string, attempt int) bool {
-	for _, event := range trace {
-		if !strings.EqualFold(strings.TrimSpace(event.Type), strings.TrimSpace(eventType)) {
-			continue
-		}
-		if attempt <= 0 || event.Attempt == 0 || event.Attempt == attempt {
-			return true
-		}
-	}
-	return false
 }
 
 func countTraceEventsForType(trace []resources.TaskTraceEvent, eventType string, attempt int) int {

--- a/controllers/task_scheduler_controller.go
+++ b/controllers/task_scheduler_controller.go
@@ -110,12 +110,9 @@ func (c *TaskSchedulerController) ReconcileOnce(ctx context.Context) error {
 			continue
 		}
 
-		changed, err := c.reconcileTaskAssignment(ctx, task, eligible, newAssignments)
+		_, err := c.reconcileTaskAssignment(ctx, task, eligible, newAssignments)
 		if err != nil {
 			return err
-		}
-		if changed {
-			continue
 		}
 	}
 

--- a/docs/public/readme/orloj-agent-stack.svg
+++ b/docs/public/readme/orloj-agent-stack.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1250" height="520" viewBox="0 0 1250 520" role="img" aria-labelledby="title desc">
+  <title id="title">Orloj Agent Stack</title>
+  <desc id="desc">Four core layers — interface, definition, runtime, infrastructure — with governance and observability as cross-cutting pillars, styled in dark galaxy tones with gold accents.</desc>
+
+  <defs>
+    <radialGradient id="galaxy" cx="50%" cy="40%" r="70%">
+      <stop offset="0%" stop-color="#141b2d"/>
+      <stop offset="100%" stop-color="#080c18"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1250" height="520" fill="url(#galaxy)"/>
+
+  <!-- Subtle stars -->
+  <g fill="#ffffff" opacity="0.15">
+    <circle cx="120" cy="30" r="1"/><circle cx="290" cy="470" r="0.8"/><circle cx="1180" cy="60" r="1.2"/>
+    <circle cx="950" cy="480" r="0.8"/><circle cx="1100" cy="120" r="1"/><circle cx="60" cy="350" r="0.7"/>
+    <circle cx="700" cy="25" r="1"/><circle cx="1200" cy="400" r="0.9"/><circle cx="180" cy="490" r="0.7"/>
+    <circle cx="400" cy="15" r="0.8"/><circle cx="830" cy="495" r="1"/><circle cx="50" cy="150" r="0.6"/>
+    <circle cx="1220" cy="260" r="0.8"/><circle cx="550" cy="500" r="0.7"/><circle cx="150" cy="250" r="0.9"/>
+  </g>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+    <text x="48" y="120" fill="#e8c55a" font-size="30" font-weight="800">ORLOJ</text>
+    <text x="48" y="158" fill="#e8c55a" font-size="30" font-weight="800">AGENT</text>
+    <text x="48" y="196" fill="#e8c55a" font-size="30" font-weight="800">STACK</text>
+
+    <g font-size="15" font-weight="700" fill="#c8b88a">
+      <text x="340" y="110" text-anchor="end">INTERFACE</text>
+      <text x="340" y="210" text-anchor="end">DEFINITION</text>
+      <text x="340" y="310" text-anchor="end">RUNTIME</text>
+      <text x="340" y="410" text-anchor="end">INFRASTRUCTURE</text>
+    </g>
+
+    <g stroke-width="2" stroke-linecap="round">
+      <line x1="356" y1="105" x2="440" y2="105" stroke="#e8c55a"/>
+      <line x1="356" y1="205" x2="410" y2="205" stroke="#c9a033"/>
+      <line x1="356" y1="305" x2="380" y2="305" stroke="#a07a1e"/>
+      <line x1="356" y1="405" x2="365" y2="405" stroke="#7a5c10"/>
+    </g>
+
+    <g transform="translate(100 0)">
+      <polygon points="430,60 910,60 860,150 380,150" fill="#c9a033"/>
+      <polygon points="400,160 880,160 830,250 350,250" fill="#a07a1e"/>
+      <polygon points="370,260 850,260 800,350 320,350" fill="#7a5c10"/>
+      <polygon points="340,360 820,360 770,450 290,450" fill="#5c440a"/>
+    </g>
+
+    <g transform="translate(100 0)" font-size="13" font-weight="700" text-anchor="middle">
+      <g fill="#ffffff">
+        <circle cx="470" cy="105" r="20" fill="#ffffff" opacity="0.12"/>
+        <text x="470" y="110">YAML</text>
+        <circle cx="565" cy="105" r="20" fill="#ffffff" opacity="0.12"/>
+        <text x="565" y="110">CLI</text>
+        <circle cx="660" cy="105" r="20" fill="#ffffff" opacity="0.12"/>
+        <text x="660" y="110">API</text>
+        <circle cx="755" cy="105" r="20" fill="#ffffff" opacity="0.12"/>
+        <text x="755" y="110">SDK</text>
+        <circle cx="850" cy="105" r="20" fill="#ffffff" opacity="0.12"/>
+        <text x="850" y="110">UI</text>
+      </g>
+
+      <g fill="#ffffff">
+        <circle cx="440" cy="205" r="20" fill="#ffffff" opacity="0.10"/>
+        <text x="440" y="210">AGENT</text>
+        <circle cx="535" cy="205" r="20" fill="#ffffff" opacity="0.10"/>
+        <text x="535" y="210">SYSTEM</text>
+        <circle cx="630" cy="205" r="20" fill="#ffffff" opacity="0.10"/>
+        <text x="630" y="210">TOOL</text>
+        <circle cx="725" cy="205" r="20" fill="#ffffff" opacity="0.10"/>
+        <text x="725" y="210">MODEL</text>
+        <circle cx="820" cy="205" r="20" fill="#ffffff" opacity="0.10"/>
+        <text x="820" y="210">MEMORY</text>
+      </g>
+
+      <g fill="#ffffff">
+        <circle cx="410" cy="305" r="20" fill="#ffffff" opacity="0.08"/>
+        <text x="410" y="310">SERVER</text>
+        <circle cx="505" cy="305" r="20" fill="#ffffff" opacity="0.08"/>
+        <text x="505" y="310">WORKER</text>
+        <circle cx="600" cy="305" r="20" fill="#ffffff" opacity="0.08"/>
+        <text x="600" y="310">SCHEDULE</text>
+        <circle cx="695" cy="305" r="20" fill="#ffffff" opacity="0.08"/>
+        <text x="695" y="310">ROUTE</text>
+        <circle cx="790" cy="305" r="20" fill="#ffffff" opacity="0.08"/>
+        <text x="790" y="310">RECOVER</text>
+      </g>
+
+      <g fill="#ffffff">
+        <circle cx="380" cy="405" r="20" fill="#ffffff" opacity="0.07"/>
+        <text x="380" y="410">STORE</text>
+        <circle cx="475" cy="405" r="20" fill="#ffffff" opacity="0.07"/>
+        <text x="475" y="410">SQL</text>
+        <circle cx="570" cy="405" r="20" fill="#ffffff" opacity="0.07"/>
+        <text x="570" y="410">STREAM</text>
+        <circle cx="665" cy="405" r="20" fill="#ffffff" opacity="0.07"/>
+        <text x="665" y="410">CONTAINER</text>
+        <circle cx="760" cy="405" r="20" fill="#ffffff" opacity="0.07"/>
+        <text x="760" y="410">CLUSTER</text>
+      </g>
+    </g>
+
+    <!-- Governance pillar -->
+    <rect x="1040" y="155" width="55" height="200" rx="12" fill="#c9a033" opacity="0.7"/>
+    <text x="1067" y="255" fill="#ffffff" font-size="11" font-weight="700" letter-spacing="3" text-anchor="middle" transform="rotate(-90 1067 255)">GOVERNANCE</text>
+
+    <!-- Observability pillar -->
+    <rect x="1115" y="255" width="55" height="200" rx="12" fill="#7a5c10" opacity="0.7"/>
+    <text x="1142" y="355" fill="#d4c4a0" font-size="11" font-weight="700" letter-spacing="3" text-anchor="middle" transform="rotate(-90 1142 355)">OBSERVABILITY</text>
+  </g>
+</svg>

--- a/frontend/embed.go
+++ b/frontend/embed.go
@@ -72,11 +72,4 @@ func patchedIndex(fsys fs.FS, basePath string) []byte {
 	return out
 }
 
-func hasDistIndex() bool {
-	file, err := staticFS.Open("dist/index.html")
-	if err != nil {
-		return false
-	}
-	_ = file.Close()
-	return true
-}
+

--- a/resources/agent.go
+++ b/resources/agent.go
@@ -39,6 +39,32 @@ func NormalizeObjectMetaNamespace(meta *ObjectMeta) {
 	meta.Namespace = NormalizeNamespace(meta.Namespace)
 }
 
+// reservedSubresourceSuffixes are path segments that collide with API sub-
+// resource routes (e.g. /agents/{name}/status).
+var reservedSubresourceSuffixes = []string{"status", "logs", "exec", "scale", "proxy", "binding"}
+
+// ValidateMetadataName checks that a resource name is safe for use as a URL
+// path segment and as a store key component. It rejects empty names, names
+// containing '/', whitespace, or reserved subresource suffixes.
+func ValidateMetadataName(name string) error {
+	if name == "" {
+		return fmt.Errorf("metadata.name is required")
+	}
+	if strings.ContainsAny(name, "/ \t\n\r") {
+		return fmt.Errorf("metadata.name %q must not contain '/', spaces, or whitespace", name)
+	}
+	if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "..") {
+		return fmt.Errorf("metadata.name %q must not start with '.'", name)
+	}
+	lower := strings.ToLower(name)
+	for _, suffix := range reservedSubresourceSuffixes {
+		if lower == suffix {
+			return fmt.Errorf("metadata.name %q is a reserved subresource name", name)
+		}
+	}
+	return nil
+}
+
 // ListMeta carries pagination metadata in list responses. Continue holds the
 // cursor (last item's name) for the next page; empty means no more results.
 type ListMeta struct {
@@ -133,8 +159,8 @@ func (a *Agent) Normalize() error {
 		return fmt.Errorf("unsupported kind %q: only Agent is supported in MVP", a.Kind)
 	}
 	NormalizeObjectMetaNamespace(&a.Metadata)
-	if a.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(a.Metadata.Name); err != nil {
+		return err
 	}
 	a.Spec.Model = strings.TrimSpace(a.Spec.Model)
 	a.Spec.ModelRef = strings.TrimSpace(a.Spec.ModelRef)

--- a/resources/model_endpoint.go
+++ b/resources/model_endpoint.go
@@ -58,8 +58,9 @@ func (m *ModelEndpoint) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for ModelEndpoint", m.Kind)
 	}
 	NormalizeObjectMetaNamespace(&m.Metadata)
-	if strings.TrimSpace(m.Metadata.Name) == "" {
-		return fmt.Errorf("metadata.name is required")
+	m.Metadata.Name = strings.TrimSpace(m.Metadata.Name)
+	if err := ValidateMetadataName(m.Metadata.Name); err != nil {
+		return err
 	}
 
 	provider := strings.ToLower(strings.TrimSpace(m.Spec.Provider))

--- a/resources/resource_types.go
+++ b/resources/resource_types.go
@@ -201,8 +201,8 @@ func (a *AgentSystem) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for AgentSystem", a.Kind)
 	}
 	NormalizeObjectMetaNamespace(&a.Metadata)
-	if a.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(a.Metadata.Name); err != nil {
+		return err
 	}
 	if a.Spec.Graph == nil {
 		a.Spec.Graph = make(map[string]GraphEdge)
@@ -414,8 +414,8 @@ func (t *Tool) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for Tool", t.Kind)
 	}
 	NormalizeObjectMetaNamespace(&t.Metadata)
-	if t.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(t.Metadata.Name); err != nil {
+		return err
 	}
 	toolType := strings.ToLower(strings.TrimSpace(t.Spec.Type))
 	if toolType == "" {
@@ -655,8 +655,8 @@ func (s *Secret) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for Secret", s.Kind)
 	}
 	NormalizeObjectMetaNamespace(&s.Metadata)
-	if s.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(s.Metadata.Name); err != nil {
+		return err
 	}
 	if s.Spec.Data == nil {
 		s.Spec.Data = make(map[string]string)
@@ -731,8 +731,8 @@ func (m *Memory) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for Memory", m.Kind)
 	}
 	NormalizeObjectMetaNamespace(&m.Metadata)
-	if m.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(m.Metadata.Name); err != nil {
+		return err
 	}
 	if m.Status.Phase == "" {
 		m.Status.Phase = "Pending"
@@ -782,8 +782,8 @@ func (p *AgentPolicy) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for AgentPolicy", p.Kind)
 	}
 	NormalizeObjectMetaNamespace(&p.Metadata)
-	if p.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(p.Metadata.Name); err != nil {
+		return err
 	}
 	if p.Spec.ApplyMode == "" {
 		p.Spec.ApplyMode = "scoped"
@@ -833,8 +833,8 @@ func (r *AgentRole) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for AgentRole", r.Kind)
 	}
 	NormalizeObjectMetaNamespace(&r.Metadata)
-	if r.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(r.Metadata.Name); err != nil {
+		return err
 	}
 	normalized := make([]string, 0, len(r.Spec.Permissions))
 	seen := make(map[string]struct{}, len(r.Spec.Permissions))
@@ -901,8 +901,8 @@ func (p *ToolPermission) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for ToolPermission", p.Kind)
 	}
 	NormalizeObjectMetaNamespace(&p.Metadata)
-	if p.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(p.Metadata.Name); err != nil {
+		return err
 	}
 	p.Spec.ToolRef = strings.TrimSpace(p.Spec.ToolRef)
 	if p.Spec.ToolRef == "" {
@@ -1046,8 +1046,8 @@ func (a *ToolApproval) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for ToolApproval", a.Kind)
 	}
 	NormalizeObjectMetaNamespace(&a.Metadata)
-	if a.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(a.Metadata.Name); err != nil {
+		return err
 	}
 	a.Spec.TaskRef = strings.TrimSpace(a.Spec.TaskRef)
 	if a.Spec.TaskRef == "" {
@@ -1204,8 +1204,8 @@ func (a *TaskApproval) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for TaskApproval", a.Kind)
 	}
 	NormalizeObjectMetaNamespace(&a.Metadata)
-	if a.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(a.Metadata.Name); err != nil {
+		return err
 	}
 	a.Spec.TaskRef = strings.TrimSpace(a.Spec.TaskRef)
 	if a.Spec.TaskRef == "" {
@@ -1489,8 +1489,8 @@ func (t *Task) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for Task", t.Kind)
 	}
 	NormalizeObjectMetaNamespace(&t.Metadata)
-	if t.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(t.Metadata.Name); err != nil {
+		return err
 	}
 	if t.Spec.Input == nil {
 		t.Spec.Input = make(map[string]string)
@@ -1630,8 +1630,8 @@ func (t *TaskSchedule) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for TaskSchedule", t.Kind)
 	}
 	NormalizeObjectMetaNamespace(&t.Metadata)
-	if t.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(t.Metadata.Name); err != nil {
+		return err
 	}
 
 	t.Spec.TaskRef = strings.TrimSpace(t.Spec.TaskRef)
@@ -1768,8 +1768,8 @@ func (t *TaskWebhook) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for TaskWebhook", t.Kind)
 	}
 	NormalizeObjectMetaNamespace(&t.Metadata)
-	if t.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(t.Metadata.Name); err != nil {
+		return err
 	}
 
 	t.Spec.TaskRef = strings.TrimSpace(t.Spec.TaskRef)
@@ -2066,8 +2066,8 @@ func (w *Worker) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for Worker", w.Kind)
 	}
 	NormalizeObjectMetaNamespace(&w.Metadata)
-	if w.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(w.Metadata.Name); err != nil {
+		return err
 	}
 	if w.Spec.MaxConcurrentTasks <= 0 {
 		w.Spec.MaxConcurrentTasks = 1
@@ -2144,8 +2144,8 @@ func (m *McpServer) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for McpServer", m.Kind)
 	}
 	NormalizeObjectMetaNamespace(&m.Metadata)
-	if m.Metadata.Name == "" {
-		return fmt.Errorf("metadata.name is required")
+	if err := ValidateMetadataName(m.Metadata.Name); err != nil {
+		return err
 	}
 	transport := strings.ToLower(strings.TrimSpace(m.Spec.Transport))
 	if transport == "" {

--- a/resources/sealed_secret.go
+++ b/resources/sealed_secret.go
@@ -57,8 +57,9 @@ func (s *SealedSecret) Normalize() error {
 		return fmt.Errorf("unsupported kind %q for SealedSecret", s.Kind)
 	}
 	NormalizeObjectMetaNamespace(&s.Metadata)
-	if strings.TrimSpace(s.Metadata.Name) == "" {
-		return fmt.Errorf("metadata.name is required")
+	s.Metadata.Name = strings.TrimSpace(s.Metadata.Name)
+	if err := ValidateMetadataName(s.Metadata.Name); err != nil {
+		return err
 	}
 
 	if s.Spec.EncryptedData == nil {

--- a/runtime/agent_message_consumer.go
+++ b/runtime/agent_message_consumer.go
@@ -118,7 +118,6 @@ type AgentMessageConsumerManager struct {
 	taskApprovals  TaskApprovalUpserter
 	policies       AgentPolicyLookup
 	mu             sync.Mutex
-	seenMu         sync.Mutex
 	consumers      map[string]context.CancelFunc
 	seenMessage    map[string]time.Time
 	taskMemory     map[string]*SharedMemoryStore
@@ -517,9 +516,7 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 			}
 		}
 		toolRT = NewOrlojToolRuntime(toolRT, orlojStore, orlojCfg)
-		for _, name := range BuiltinOrlojToolNames() {
-			agent.Spec.Tools = append(agent.Spec.Tools, name)
-		}
+		agent.Spec.Tools = append(agent.Spec.Tools, BuiltinOrlojToolNames()...)
 		agent.Spec.Tools = dedupeStrings(agent.Spec.Tools)
 	}
 	if memRef := strings.TrimSpace(agent.Spec.Memory.Ref); memRef != "" {
@@ -532,9 +529,7 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 			}
 		}
 		toolRT = memRT
-		for _, name := range resources.MemoryToolNamesForOperations(agent.Spec.Memory.Allow) {
-			agent.Spec.Tools = append(agent.Spec.Tools, name)
-		}
+		agent.Spec.Tools = append(agent.Spec.Tools, resources.MemoryToolNamesForOperations(agent.Spec.Memory.Allow)...)
 		agent.Spec.Tools = dedupeStrings(agent.Spec.Tools)
 	}
 	agentCtx, agentSpan := telemetry.StartAgentSpan(ctx, agent.Metadata.Name, msg.MessageID, msg.Attempt)
@@ -1653,39 +1648,6 @@ func (m *AgentMessageConsumerManager) recordRetryOrDeadLetter(ctx context.Contex
 	return false, 0, lastErr
 }
 
-func (m *AgentMessageConsumerManager) isDuplicate(msg AgentMessage) bool {
-	now := time.Now().UTC()
-	id := strings.TrimSpace(msg.MessageID)
-	if id == "" {
-		id = fmt.Sprintf("%s|%s|%s|%s|%d", strings.TrimSpace(msg.TaskID), strings.TrimSpace(msg.FromAgent), strings.TrimSpace(msg.ToAgent), strings.TrimSpace(msg.Timestamp), msg.Attempt)
-	}
-
-	m.seenMu.Lock()
-	defer m.seenMu.Unlock()
-	cutoff := now.Add(-m.dedupeTTL)
-	for seenID, seenAt := range m.seenMessage {
-		if seenAt.Before(cutoff) {
-			delete(m.seenMessage, seenID)
-		}
-	}
-	if seenAt, exists := m.seenMessage[id]; exists && now.Sub(seenAt) <= m.dedupeTTL {
-		return true
-	}
-	m.seenMessage[id] = now
-	return false
-}
-
-func appendIncomingMessage(task *resources.Task, msg AgentMessage) {
-	if task == nil {
-		return
-	}
-	_ = ensureTaskMessageRecord(task, msg)
-	trimTaskMessages(task)
-}
-
-func appendOutgoingMessage(task *resources.Task, msg AgentMessage) {
-	appendIncomingMessage(task, msg)
-}
 
 func ensureTaskMessageRecord(task *resources.Task, msg AgentMessage) int {
 	if task == nil {
@@ -1967,18 +1929,6 @@ func extendWorkerLease(task *resources.Task, workerID string, duration time.Dura
 	task.Status.LeaseUntil = now.Add(duration).Format(time.RFC3339Nano)
 }
 
-func hasTaskMessage(messages []resources.TaskMessage, messageID string) bool {
-	messageID = strings.TrimSpace(messageID)
-	if messageID == "" {
-		return false
-	}
-	for _, message := range messages {
-		if strings.EqualFold(strings.TrimSpace(message.MessageID), messageID) {
-			return true
-		}
-	}
-	return false
-}
 
 func hasTraceMarker(trace []resources.TaskTraceEvent, eventType, messageID string) bool {
 	messageID = strings.TrimSpace(messageID)
@@ -2298,10 +2248,6 @@ func durableName(workerID, namespace, agent string) string {
 		base = "worker"
 	}
 	return sanitizeSubjectToken(base) + "-" + sanitizeSubjectToken(namespace) + "-" + sanitizeSubjectToken(agent)
-}
-
-func nextAgentsFromSystem(system resources.AgentSystem, current string) []string {
-	return nextAgentsFromSystemForOutput(system, current, "", "")
 }
 
 func nextAgentsFromSystemForOutput(system resources.AgentSystem, current string, output string, delegateOf string) []string {

--- a/runtime/agent_worker.go
+++ b/runtime/agent_worker.go
@@ -231,7 +231,7 @@ func (w *AgentWorker) Run(ctx context.Context) {
 			if len(modelResp.ToolCalls) > 0 {
 				chatCalls := make([]ChatToolCall, len(modelResp.ToolCalls))
 				for i, tc := range modelResp.ToolCalls {
-					chatCalls[i] = ChatToolCall{ID: tc.ID, Name: tc.Name, Input: tc.Input}
+					chatCalls[i] = ChatToolCall(tc)
 				}
 				w.history = append(w.history, ChatMessage{
 					Role: "assistant", Content: modelOutput, ToolCalls: chatCalls,

--- a/runtime/bounded_writer.go
+++ b/runtime/bounded_writer.go
@@ -1,0 +1,66 @@
+package agentruntime
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+)
+
+// DefaultMaxToolOutputBytes is the default cap for tool stdout/stderr capture.
+// 16 MiB is generous for legitimate tool output while preventing OOM from
+// runaway processes.
+const DefaultMaxToolOutputBytes = 16 * 1024 * 1024
+
+// ErrOutputLimitExceeded is returned when a tool's stdout or stderr exceeds
+// the configured maximum.
+var ErrOutputLimitExceeded = fmt.Errorf("tool output exceeded maximum allowed size")
+
+// BoundedWriter wraps a bytes.Buffer and stops accepting writes once the
+// configured maximum is reached. It is safe for concurrent use.
+type BoundedWriter struct {
+	mu       sync.Mutex
+	buf      bytes.Buffer
+	max      int
+	exceeded bool
+}
+
+// NewBoundedWriter returns a writer that accepts at most max bytes.
+func NewBoundedWriter(max int) *BoundedWriter {
+	return &BoundedWriter{max: max}
+}
+
+// Write implements io.Writer. Once the cap is reached, further bytes are
+// silently discarded and Exceeded() returns true.
+func (w *BoundedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.exceeded {
+		// Accept the write (so the process doesn't get a broken-pipe) but
+		// discard the data.
+		return len(p), nil
+	}
+	remaining := w.max - w.buf.Len()
+	if len(p) > remaining {
+		// Write what fits, then mark exceeded.
+		if remaining > 0 {
+			w.buf.Write(p[:remaining])
+		}
+		w.exceeded = true
+		return len(p), nil
+	}
+	return w.buf.Write(p)
+}
+
+// String returns the captured output.
+func (w *BoundedWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// Exceeded reports whether the cap was hit.
+func (w *BoundedWriter) Exceeded() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.exceeded
+}

--- a/runtime/embedding.go
+++ b/runtime/embedding.go
@@ -101,7 +101,7 @@ func (p *OpenAIEmbeddingProvider) Embed(ctx context.Context, texts []string) ([]
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 32*1024*1024))
 	if err != nil {
 		return nil, fmt.Errorf("embedding: read response: %w", err)
 	}

--- a/runtime/model_gateway_openai.go
+++ b/runtime/model_gateway_openai.go
@@ -141,7 +141,7 @@ func (g *OpenAIModelGateway) Complete(ctx context.Context, req ModelRequest) (Mo
 	}
 	defer httpResp.Body.Close()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(httpResp.Body, 32*1024*1024))
 	if err != nil {
 		return ModelResponse{}, fmt.Errorf("read model response: %w", err)
 	}

--- a/runtime/persistent_memory_http.go
+++ b/runtime/persistent_memory_http.go
@@ -120,7 +120,7 @@ func (b *HTTPMemoryBackend) post(ctx context.Context, path string, body []byte) 
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 32*1024*1024))
 	if err != nil {
 		return nil, fmt.Errorf("memory http %s: read body: %w", path, err)
 	}

--- a/runtime/tool_error.go
+++ b/runtime/tool_error.go
@@ -92,9 +92,7 @@ func (e *ToolError) Error() string {
 		fmt.Sprintf("retryable=%t", e.Retryable),
 		fmt.Sprintf("message=%s", msg),
 	}
-	for _, detail := range formatToolDetails(e.Details) {
-		parts = append(parts, detail)
-	}
+	parts = append(parts, formatToolDetails(e.Details)...)
 	return strings.Join(parts, " ")
 }
 

--- a/runtime/tool_isolation_backend_registry_test.go
+++ b/runtime/tool_isolation_backend_registry_test.go
@@ -1,23 +1,8 @@
 package agentruntime
 
 import (
-	"context"
 	"testing"
 )
-
-type noopWASMExecutorFactory struct {
-	executor WASMToolExecutor
-}
-
-func (f noopWASMExecutorFactory) Build(_ context.Context, _ WASMToolRuntimeConfig) (WASMToolExecutor, error) {
-	return f.executor, nil
-}
-
-type noopWASMExecutor struct{}
-
-func (e noopWASMExecutor) Execute(_ context.Context, _ WASMToolExecuteRequest) (WASMToolExecuteResponse, error) {
-	return WASMToolExecuteResponse{Output: "ok"}, nil
-}
 
 func TestToolIsolationBackendRegistryBuildsDefaults(t *testing.T) {
 	noneRuntime, err := BuildToolIsolationRuntime(ToolIsolationBackendOptions{Mode: "none"})

--- a/runtime/tool_runtime_cli.go
+++ b/runtime/tool_runtime_cli.go
@@ -1,7 +1,6 @@
 package agentruntime
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,9 +22,10 @@ func (r *osExecCLICommandRunner) Run(ctx context.Context, command string, args [
 	if stdin != "" {
 		cmd.Stdin = strings.NewReader(stdin)
 	}
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	stdout := NewBoundedWriter(DefaultMaxToolOutputBytes)
+	stderr := NewBoundedWriter(DefaultMaxToolOutputBytes)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	if len(env) > 0 {
 		cmd.Env = env
 	}

--- a/runtime/tool_runtime_container.go
+++ b/runtime/tool_runtime_container.go
@@ -1,7 +1,6 @@
 package agentruntime
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -143,10 +142,10 @@ type osExecContainerCommandRunner struct{}
 func (r *osExecContainerCommandRunner) Run(ctx context.Context, binary string, args []string, stdin string, env map[string]string) (string, string, error) {
 	cmd := exec.CommandContext(ctx, binary, args...) //nolint:gosec
 	cmd.Stdin = strings.NewReader(stdin)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	stdout := NewBoundedWriter(DefaultMaxToolOutputBytes)
+	stderr := NewBoundedWriter(DefaultMaxToolOutputBytes)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	if len(env) > 0 {
 		cmd.Env = append(os.Environ(), mapToEnv(env)...)
 	}

--- a/runtime/tool_runtime_wasm_wazero.go
+++ b/runtime/tool_runtime_wasm_wazero.go
@@ -160,7 +160,8 @@ func (e *WazeroExecutor) Execute(ctx context.Context, req WASMToolExecuteRequest
 		)
 	}
 
-	var stdout, stderr bytes.Buffer
+	stdout := NewBoundedWriter(DefaultMaxToolOutputBytes)
+	stderr := NewBoundedWriter(DefaultMaxToolOutputBytes)
 	instanceID := atomic.AddUint64(&wasmInstanceCounter, 1)
 	moduleName := strings.TrimSpace(req.Tool)
 	if moduleName == "" {
@@ -170,8 +171,8 @@ func (e *WazeroExecutor) Execute(ctx context.Context, req WASMToolExecuteRequest
 
 	modCfg := wazero.NewModuleConfig().
 		WithStdin(bytes.NewReader(payload)).
-		WithStdout(&stdout).
-		WithStderr(&stderr).
+		WithStdout(stdout).
+		WithStderr(stderr).
 		WithName(moduleName).
 		WithStartFunctions("_start")
 

--- a/store/auth_store.go
+++ b/store/auth_store.go
@@ -15,12 +15,6 @@ import (
 	"time"
 )
 
-const (
-	tableAuthLocalAdmin = "auth_local_admin"
-	tableAuthLocalUsers = "auth_local_users"
-	tableAuthSessions   = "auth_sessions"
-	tableAuthAPITokens  = "auth_api_tokens"
-)
 
 var (
 	ErrAuthUserExists     = errors.New("auth user already exists")
@@ -360,6 +354,70 @@ func (s *LocalAdminStore) CreateUser(username, passwordHash, role string) (Local
 	account := LocalAdminAccount{
 		Username:     username,
 		Role:         r,
+		PasswordHash: passwordHash,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	s.users[username] = account
+	return account, nil
+}
+
+// CreateFirstAdmin atomically creates the first admin account. It returns
+// ErrAuthUserExists if any user already exists, preventing the TOCTOU race
+// where concurrent setup requests both observe zero users.
+func (s *LocalAdminStore) CreateFirstAdmin(username, passwordHash string) (LocalAdminAccount, error) {
+	username = normalizeLocalUsername(username)
+	passwordHash = strings.TrimSpace(passwordHash)
+	if username == "" {
+		return LocalAdminAccount{}, fmt.Errorf("username is required")
+	}
+	if passwordHash == "" {
+		return LocalAdminAccount{}, fmt.Errorf("password hash is required")
+	}
+
+	if s.db != nil {
+		// Atomic insert-if-no-users via INSERT ... WHERE NOT EXISTS.
+		result, err := s.db.Exec(
+			`INSERT INTO auth_local_users(username, role, password_hash, created_at, updated_at)
+			 SELECT $1, $2, $3, NOW(), NOW()
+			 WHERE NOT EXISTS (SELECT 1 FROM auth_local_users)`,
+			username,
+			"admin",
+			passwordHash,
+		)
+		if err != nil {
+			if strings.Contains(strings.ToLower(err.Error()), "duplicate") || strings.Contains(strings.ToLower(err.Error()), "unique") {
+				return LocalAdminAccount{}, ErrAuthUserExists
+			}
+			return LocalAdminAccount{}, err
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return LocalAdminAccount{}, err
+		}
+		if rows == 0 {
+			return LocalAdminAccount{}, ErrAuthUserExists
+		}
+		user, ok, err := s.GetByUsername(username)
+		if err != nil {
+			return LocalAdminAccount{}, err
+		}
+		if !ok {
+			return LocalAdminAccount{}, fmt.Errorf("created admin %q not found", username)
+		}
+		return user, nil
+	}
+
+	// In-memory path: hold the write lock across check-and-insert.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.users) > 0 {
+		return LocalAdminAccount{}, ErrAuthUserExists
+	}
+	account := LocalAdminAccount{
+		Username:     username,
+		Role:         "admin",
 		PasswordHash: passwordHash,
 		CreatedAt:    now,
 		UpdatedAt:    now,

--- a/store/sealing_key_store.go
+++ b/store/sealing_key_store.go
@@ -11,8 +11,6 @@ import (
 	"github.com/OrlojHQ/orloj/resources"
 )
 
-const tableSealingKeys = "sealing_keys"
-
 type SealingKey struct {
 	KeyID         string
 	Status        string

--- a/store/sql_backend.go
+++ b/store/sql_backend.go
@@ -194,6 +194,17 @@ func listFromTableCursor[T any](ctx context.Context, db dbExecer, table string, 
 		limit = defaultListLimit
 	}
 
+	// afterName arrives as unscoped metadata.name from the API continue
+	// token, but the name column stores scoped keys (namespace/name). Scope
+	// it so the cursor comparison is against the same key format.
+	if afterName != "" && !strings.Contains(afterName, "/") {
+		if namespace != "" {
+			afterName = scopedName(namespace, afterName)
+		} else {
+			afterName = scopedName(resources.DefaultNamespace, afterName)
+		}
+	}
+
 	var rows *sql.Rows
 	var err error
 	switch {


### PR DESCRIPTION

- Rewrite README around full-stack positioning; add agent-stack diagram SVG
- Atomic CreateFirstAdmin to fix concurrent auth/setup race
- Add HTTP server read/header/idle timeouts (no global WriteTimeout for SSE)
- Validate metadata names against reserved segments and unsafe characters
- Fix scoped continue token handling in SQL list pagination
- Cap tool stdout/stderr and large HTTP upstream response reads
- Strip SealedSecret status from seal CLI output for clean diffs

BREAKING CHANGE: resource metadata.name validation may reject previously accepted names (e.g. reserved subresource-like names or invalid characters).

