### PR TITLE
Fix YAML parser silently dropping spec fields across 7 resource types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **TaskSchedule `spec.task_template`**: Schedules now support inline task specs via `task_template`, matching the existing TaskWebhook capability. This eliminates the need for a separate template Task resource when only the schedule references it. `task_ref` and `task_template` are mutually exclusive; existing schedules using `task_ref` continue to work unchanged.
+
+### Fixed
+
+- **YAML manifest parser silently drops fields**: the constrained-YAML parser ignored several documented spec fields, causing them to be silently discarded on `apply`. Fixed: `image_pull_secret` on Tool CLI and McpServer, `fallback_model_refs` and `allowed_tools` on Agent, `allowPrivate` on ModelEndpoint, `max_child_depth` and `max_child_tasks` on AgentPolicy, `headerName`/`tokenURL`/`scopes` on McpServer auth, `algorithm`/`payload_format`/`payload_prefix`/`payload_separator`/`signature_encoding`/`header_format`/`signature_key`/`timestamp_key` on TaskWebhook auth, and `task_template.mode` on TaskSchedule and TaskWebhook. JSON manifests were unaffected.
+
 ## [0.12.0] - 2026-04-30
 
 ### Added

--- a/controllers/task_schedule_controller.go
+++ b/controllers/task_schedule_controller.go
@@ -229,24 +229,33 @@ func evaluateDueSlot(item resources.TaskSchedule, expr cronexpr.Expression, loc 
 }
 
 func (c *TaskScheduleController) ensureRunTask(ctx context.Context, item resources.TaskSchedule, slot time.Time) (string, error) {
-	templateNS, templateName, err := resolveTaskRef(item.Metadata.Namespace, item.Spec.TaskRef)
-	if err != nil {
-		return "", err
-	}
-	templateKey := store.ScopedName(templateNS, templateName)
-	template, ok, err := c.taskStore.Get(ctx, templateKey)
-	if err != nil {
-		return "", fmt.Errorf("task template %q lookup failed: %w", item.Spec.TaskRef, err)
-	}
-	if !ok {
-		return "", fmt.Errorf("task template %q not found", item.Spec.TaskRef)
-	}
-	if !strings.EqualFold(strings.TrimSpace(template.Spec.Mode), "template") {
-		return "", fmt.Errorf("task template %q must set spec.mode=template", item.Spec.TaskRef)
+	var templateSpec resources.TaskSpec
+	var runNamespace string
+
+	if item.Spec.TaskTemplate != nil {
+		templateSpec = cloneTaskSpec(*item.Spec.TaskTemplate)
+		runNamespace = resources.NormalizeNamespace(item.Metadata.Namespace)
+	} else {
+		templateNS, templateName, err := resolveTaskRef(item.Metadata.Namespace, item.Spec.TaskRef)
+		if err != nil {
+			return "", err
+		}
+		templateKey := store.ScopedName(templateNS, templateName)
+		template, ok, err := c.taskStore.Get(ctx, templateKey)
+		if err != nil {
+			return "", fmt.Errorf("task template %q lookup failed: %w", item.Spec.TaskRef, err)
+		}
+		if !ok {
+			return "", fmt.Errorf("task template %q not found", item.Spec.TaskRef)
+		}
+		if !strings.EqualFold(strings.TrimSpace(template.Spec.Mode), "template") {
+			return "", fmt.Errorf("task template %q must set spec.mode=template", item.Spec.TaskRef)
+		}
+		templateSpec = cloneTaskSpec(template.Spec)
+		runNamespace = template.Metadata.Namespace
 	}
 
 	runName := scheduledTaskName(item.Metadata.Name, slot)
-	runNamespace := template.Metadata.Namespace
 	runKey := store.ScopedName(runNamespace, runName)
 
 	if existing, ok, _ := c.taskStore.Get(ctx, runKey); ok {
@@ -260,16 +269,12 @@ func (c *TaskScheduleController) ensureRunTask(ctx context.Context, item resourc
 		return "", fmt.Errorf("scheduled run task name conflict for %q", runKey)
 	}
 
-	labels := copyStringMap(template.Metadata.Labels)
-	if labels == nil {
-		labels = make(map[string]string)
-	}
+	labels := make(map[string]string)
 	labels[taskScheduleNameLabel] = item.Metadata.Name
 	labels[taskScheduleNamespaceLabel] = resources.NormalizeNamespace(item.Metadata.Namespace)
 	labels[taskScheduleSlotLabel] = slot.UTC().Format(time.RFC3339Nano)
 
-	spec := cloneTaskSpec(template.Spec)
-	spec.Mode = "run"
+	templateSpec.Mode = "run"
 	runTask := resources.Task{
 		APIVersion: "orloj.dev/v1",
 		Kind:       "Task",
@@ -278,7 +283,7 @@ func (c *TaskScheduleController) ensureRunTask(ctx context.Context, item resourc
 			Namespace: runNamespace,
 			Labels:    labels,
 		},
-		Spec: spec,
+		Spec: templateSpec,
 	}
 	if _, err := c.taskStore.Upsert(ctx, runTask); err != nil {
 		return "", err

--- a/controllers/task_schedule_controller_test.go
+++ b/controllers/task_schedule_controller_test.go
@@ -377,3 +377,64 @@ func TestScheduledTaskNameSanitizes(t *testing.T) {
 		t.Fatalf("unexpected task name %q", name)
 	}
 }
+
+func TestTaskScheduleControllerInlineTemplateCreatesRun(t *testing.T) {
+	taskStore := store.NewTaskStore()
+	taskScheduleStore := store.NewTaskScheduleStore()
+	logger := log.New(io.Discard, "", 0)
+
+	schedule := resources.TaskSchedule{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "TaskSchedule",
+		Metadata:   resources.ObjectMeta{Name: "inline-sched", Namespace: "team-a"},
+		Spec: resources.TaskScheduleSpec{
+			TaskTemplate: &resources.TaskSpec{
+				System:   "inline-system",
+				Priority: "high",
+				Input:    map[string]string{"topic": "inline"},
+			},
+			Schedule:          "* * * * *",
+			TimeZone:          "UTC",
+			Suspend:           false,
+			ConcurrencyPolicy: "forbid",
+		},
+		Status: resources.TaskScheduleStatus{
+			LastScheduleTime: time.Now().UTC().Add(-2 * time.Minute).Format(time.RFC3339Nano),
+		},
+	}
+	if _, err := taskScheduleStore.Upsert(context.Background(), schedule); err != nil {
+		t.Fatalf("upsert schedule failed: %v", err)
+	}
+
+	controller := NewTaskScheduleController(taskScheduleStore, taskStore, logger, 5*time.Millisecond)
+	if err := controller.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	tasks, err := taskStore.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	generated := 0
+	for _, task := range tasks {
+		if task.Metadata.Labels[taskScheduleNameLabel] != "inline-sched" {
+			continue
+		}
+		generated++
+		if task.Spec.Mode != "run" {
+			t.Fatalf("expected generated task mode=run, got %q", task.Spec.Mode)
+		}
+		if task.Spec.System != "inline-system" {
+			t.Fatalf("expected generated task system=inline-system, got %q", task.Spec.System)
+		}
+		if task.Spec.Priority != "high" {
+			t.Fatalf("expected generated task priority=high, got %q", task.Spec.Priority)
+		}
+		if task.Spec.Input["topic"] != "inline" {
+			t.Fatalf("expected generated task input topic=inline, got %q", task.Spec.Input["topic"])
+		}
+	}
+	if generated != 1 {
+		t.Fatalf("expected exactly one generated task, got %d", generated)
+	}
+}

--- a/openapi/schemas/task-schedule.yaml
+++ b/openapi/schemas/task-schedule.yaml
@@ -3,7 +3,8 @@ components:
     TaskScheduleSpec:
       type: object
       properties:
-        task_ref: { type: string }
+        task_ref: { type: string, description: "Reference to a template Task (name or namespace/name). Mutually exclusive with task_template." }
+        task_template: { $ref: "task.yaml#/components/schemas/TaskSpec", description: "Inline task spec used instead of a separate template Task. Mutually exclusive with task_ref." }
         schedule: { type: string }
         time_zone: { type: string }
         suspend: { type: boolean }

--- a/resources/manifest_parser.go
+++ b/resources/manifest_parser.go
@@ -119,11 +119,19 @@ func ParseAgentManifest(data []byte) (Agent, error) {
 				if section == "metadata" {
 					subsection = "labels"
 				}
-			case "tools":
-				if section == "spec" {
-					subsection = "tools"
-				}
-			case "roles":
+		case "tools":
+			if section == "spec" {
+				subsection = "tools"
+			}
+		case "allowed_tools", "allowedTools":
+			if section == "spec" {
+				subsection = "allowed_tools"
+			}
+		case "fallback_model_refs", "fallbackModelRefs":
+			if section == "spec" {
+				subsection = "fallback_model_refs"
+			}
+		case "roles":
 				if section == "spec" {
 					subsection = "roles"
 				}
@@ -157,6 +165,14 @@ func ParseAgentManifest(data []byte) (Agent, error) {
 
 		if section == "spec" && subsection == "tools" && strings.HasPrefix(trimmed, "- ") {
 			agent.Spec.Tools = append(agent.Spec.Tools, stripQuotes(strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))))
+			continue
+		}
+		if section == "spec" && subsection == "allowed_tools" && strings.HasPrefix(trimmed, "- ") {
+			agent.Spec.AllowedTools = append(agent.Spec.AllowedTools, stripQuotes(strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))))
+			continue
+		}
+		if section == "spec" && subsection == "fallback_model_refs" && strings.HasPrefix(trimmed, "- ") {
+			agent.Spec.FallbackModelRefs = append(agent.Spec.FallbackModelRefs, stripQuotes(strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))))
 			continue
 		}
 		if section == "spec" && subsection == "roles" && strings.HasPrefix(trimmed, "- ") {

--- a/resources/manifest_parser_completeness_test.go
+++ b/resources/manifest_parser_completeness_test.go
@@ -1,0 +1,813 @@
+package resources
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestYAMLParserFieldCompleteness ensures the constrained-YAML parser handles
+// every JSON-tagged field on each resource struct. The strategy:
+//
+//  1. Build a fully-populated Go struct (every field set to a non-zero value).
+//  2. Marshal it to JSON and parse via the JSON code path → "reference".
+//  3. Parse a hand-written constrained-YAML fixture → "yaml result".
+//  4. Walk the reference struct with reflection; for every exported field that
+//     carries a `json` tag (excluding `json:"-"`), assert the YAML result has
+//     the same non-zero value.
+//
+// When someone adds a new field to a resource struct, the test fails immediately
+// because the YAML fixture doesn't set it, producing a clear error like:
+//
+//	field Spec.Cli.ImagePullSecret (json:"image_pull_secret") is zero after YAML parse
+//
+// To fix: add the field to the YAML fixture AND the parser's switch statement.
+
+// skipPaths lists struct field paths that are intentionally not round-tripped
+// through the constrained-YAML parser (server-set, internal, or complex nested
+// types handled via separate code paths like input_schema / output_schema).
+var skipPaths = map[string]map[string]bool{
+	// --- Global metadata fields that are server-managed ---
+	// Annotations, ResourceVersion, Generation, CreatedAt are set by the
+	// server on write and round-tripped on read. Users rarely set them in
+	// manifests; the YAML parser supports resourceVersion/generation/createdAt
+	// already but annotations are a map that needs separate subsection handling.
+	// We skip them globally rather than in every resource.
+	"*": {
+		"Metadata.Annotations":     true, // map[string]string, server-managed
+		"Metadata.ResourceVersion": true, // server-set on write
+		"Metadata.Generation":      true, // server-set on write
+		"Metadata.CreatedAt":       true, // server-set on create
+	},
+	"Agent": {
+		"Spec.Model":                    true, // json:"-", internal
+		"Spec.Execution.OutputSchema":   true, // map[string]any, parsed via separate pass
+		"Status":                        true,
+	},
+	"Tool": {
+		"Spec.McpServerRef": true, // server-generated, not user-set
+		"Spec.McpToolName":  true,
+		"Spec.InputSchema":  true, // parsed via separate parseSimpleYAMLMap pass
+		"Status":            true,
+	},
+	"Tool/CLI": {
+		"Spec.McpServerRef": true,
+		"Spec.McpToolName":  true,
+		"Spec.InputSchema":  true,
+		"Spec.Endpoint":     true, // not used for CLI type
+		"Spec.Auth":         true, // not valid for CLI type
+		"Spec.Wasm":         true, // not used for CLI type
+		"Status":            true,
+	},
+	"Tool/HTTP": {
+		"Spec.McpServerRef": true,
+		"Spec.McpToolName":  true,
+		"Spec.InputSchema":  true,
+		"Spec.Cli":          true, // not used for HTTP type
+		"Spec.Wasm":         true, // not used for HTTP type
+		"Status":            true,
+	},
+	"Tool/WASM": {
+		"Spec.McpServerRef": true,
+		"Spec.McpToolName":  true,
+		"Spec.InputSchema":  true,
+		"Spec.Endpoint":     true, // not used for WASM type
+		"Spec.Cli":          true, // not used for WASM type
+		"Spec.Auth":         true, // not used for WASM type
+		"Status":            true,
+	},
+	"TaskApproval": {
+		"Status":                   true,
+		"Spec.Output":              true, // any type, parsed separately
+		"Spec.ResumeContext":       true, // map[string]any, parsed separately
+		"Spec.AllowRequestChanges": true, // *bool default-set by Normalize
+		"Spec.MaxReviewCycles":     true, // default-set by Normalize
+		"Spec.ReviewCycle":         true, // default-set by Normalize
+		"Spec.OutputFormat":        true, // default-set by Normalize
+	},
+	"ToolApproval": {
+		"Status": true,
+	},
+	"TaskSchedule": {
+		"Status":                                  true,
+		"Spec.TaskRef":                            true, // mutually exclusive with task_template
+		"Spec.TaskTemplate.MessageRetry.NonRetryable": true, // list inside nested template — not wired yet
+		"Spec.TaskTemplate.Requirements":          true, // nested sub-object inside template — not wired yet
+	},
+	"TaskWebhook": {
+		"Status":                                  true,
+		"Spec.TaskRef":                            true, // mutually exclusive with task_template
+		"Spec.TaskTemplate.MessageRetry.NonRetryable": true,
+		"Spec.TaskTemplate.Requirements":          true,
+		"Spec.Idempotency.EventIDFromBody":        true, // mutually exclusive with event_id_header
+	},
+	"Task": {
+		"Status":            true,
+		"Spec.Input":        true, // map parsed inline, validated elsewhere
+		"Spec.MaxTurns":     true, // zero is valid (unlimited)
+		"Spec.Retry":        true, // defaults set by Normalize
+		"Spec.MessageRetry": true,
+		"Spec.Requirements": true,
+	},
+	"Worker": {
+		"Status": true,
+	},
+	"McpServer": {
+		"Status":        true,
+		"Spec.Endpoint": true, // mutually exclusive with command (stdio transport)
+	},
+	"ModelEndpoint": {
+		"Status": true,
+	},
+	"AgentSystem": {
+		"Status":     true,
+		"Spec.Graph": true, // complex nested map, covered by dedicated tests
+	},
+	"AgentPolicy": {
+		"Status": true,
+	},
+	"AgentRole": {
+		"Status": true,
+	},
+	"ToolPermission": {
+		"Status": true,
+	},
+	"Memory": {
+		"Status": true,
+	},
+	"Secret": {
+		"Status":          true,
+		"Spec.Data":       true, // map, tested separately
+		"Spec.StringData": true,
+	},
+}
+
+func shouldSkip(kind, path string) bool {
+	for _, k := range []string{"*", kind} {
+		if m, ok := skipPaths[k]; ok {
+			if m[path] {
+				return true
+			}
+			for prefix := range m {
+				if strings.HasPrefix(path, prefix+".") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// checkNonZero walks v and reports every json-tagged field that is at its zero value.
+func checkNonZero(t *testing.T, kind string, v reflect.Value, path string) {
+	t.Helper()
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			if !shouldSkip(kind, path) {
+				t.Errorf("YAML parser gap: %s (kind %s) is nil — add to YAML fixture and parser", path, kind)
+			}
+			return
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return
+	}
+	vt := v.Type()
+	for i := 0; i < vt.NumField(); i++ {
+		field := vt.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		tag := field.Tag.Get("json")
+		if tag == "-" || tag == "" {
+			continue
+		}
+		jsonName := strings.Split(tag, ",")[0]
+		if jsonName == "" {
+			continue
+		}
+
+		fieldPath := path + "." + field.Name
+		if path == "" {
+			fieldPath = field.Name
+		}
+
+		if shouldSkip(kind, fieldPath) {
+			continue
+		}
+
+		fv := v.Field(i)
+
+		// Recurse into struct / *struct fields.
+		ft := field.Type
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+		if ft.Kind() == reflect.Struct && ft != reflect.TypeOf(json.RawMessage{}) {
+			checkNonZero(t, kind, fv, fieldPath)
+			continue
+		}
+
+		if fv.IsZero() {
+			t.Errorf("YAML parser gap: field %s (json:%q) is zero after YAML parse — add to fixture AND parser for %s",
+				fieldPath, jsonName, kind)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Maximal YAML fixtures — every user-settable field must appear.
+// ---------------------------------------------------------------------------
+
+var agentMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: Agent
+metadata:
+  name: completeness-agent
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  model_ref: openai-default
+  prompt: "You are a test agent."
+  tools:
+    - web_search
+  allowed_tools:
+    - web_search
+  fallback_model_refs:
+    - anthropic-fallback
+  roles:
+    - analyst
+  memory:
+    type: vector
+    provider: builtin
+    ref: my-memory
+    allow:
+      - read
+  execution:
+    profile: dynamic
+    duplicate_tool_call_policy: short_circuit
+    on_contract_violation: observe
+    tool_use_behavior: stop_on_first_tool
+    tool_sequence:
+      - web_search
+    required_output_markers:
+      - DONE
+  limits:
+    max_steps: 10
+    timeout: 5m
+`)
+
+// Tool CLI fixture — exercises cli-specific fields (auth not valid for CLI type).
+var toolCLIMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: Tool
+metadata:
+  name: completeness-tool-cli
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  type: cli
+  description: A CLI test tool
+  risk_level: medium
+  capabilities:
+    - web.search.invoke
+  operation_classes:
+    - read
+  runtime:
+    timeout: 30s
+    isolation_mode: container
+    retry:
+      max_attempts: 3
+      backoff: 1s
+      max_backoff: 30s
+      jitter: full
+  cli:
+    command: mytool
+    image: ghcr.io/org/tool:v1
+    image_pull_secret: ghcr-creds
+    network: host
+    output: stdout
+    working_dir: /app
+    stdin_from_input: true
+    args:
+      - --verbose
+    env:
+      MY_VAR: value
+    env_from:
+      - name: API_KEY
+        secretRef: my-secret
+        key: api-key
+`)
+
+// Tool HTTP fixture — exercises auth and wasm fields.
+var toolHTTPMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: Tool
+metadata:
+  name: completeness-tool-http
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  type: http
+  description: An HTTP test tool
+  endpoint: https://example.com/tool
+  risk_level: medium
+  capabilities:
+    - web.search.invoke
+  operation_classes:
+    - read
+  auth:
+    profile: bearer
+    secretRef: my-secret
+    headerName: Authorization
+    tokenURL: https://auth.example.com/token
+    scopes:
+      - read
+  runtime:
+    timeout: 30s
+    retry:
+      max_attempts: 3
+      backoff: 1s
+      max_backoff: 30s
+      jitter: full
+`)
+
+// Tool WASM fixture — exercises wasm-specific fields.
+var toolWASMMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: Tool
+metadata:
+  name: completeness-tool-wasm
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  type: wasm
+  description: A WASM test tool
+  risk_level: medium
+  capabilities:
+    - wasm.echo.invoke
+  runtime:
+    timeout: 30s
+    retry:
+      max_attempts: 3
+      backoff: 1s
+      max_backoff: 30s
+      jitter: full
+  wasm:
+    module: oci://registry.example.com/tool:v1
+    entrypoint: run
+    max_memory_bytes: 67108864
+    fuel: 1000000
+    enable_wasi: true
+    image_pull_secret: oci-creds
+`)
+
+var modelEndpointMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: ModelEndpoint
+metadata:
+  name: completeness-mep
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  provider: openai
+  base_url: https://api.openai.com/v1
+  default_model: gpt-4o-mini
+  allowPrivate: true
+  options:
+    anthropic_version: "2023-06-01"
+  auth:
+    secretRef: openai-key
+`)
+
+var mcpServerMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: McpServer
+metadata:
+  name: completeness-mcp
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  transport: stdio
+  command: mcp-server
+  image: ghcr.io/org/mcp:v1
+  image_pull_secret: ghcr-creds
+  idle_timeout: 5m
+  args:
+    - --port=8080
+  env:
+    - name: API_KEY
+      value: test-value
+  auth:
+    secretRef: mcp-secret
+    profile: bearer
+    headerName: Authorization
+    tokenURL: https://auth.example.com/token
+    scopes:
+      - read
+  tool_filter:
+    include:
+      - search
+  reconnect:
+    max_attempts: 5
+    backoff: 2s
+`)
+
+var agentPolicyMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: AgentPolicy
+metadata:
+  name: completeness-policy
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  max_tokens_per_run: 10000
+  apply_mode: scoped
+  max_child_depth: 3
+  max_child_tasks: 10
+  allowed_models:
+    - gpt-4o
+  blocked_tools:
+    - dangerous-tool
+  target_systems:
+    - my-system
+  target_tasks:
+    - my-task
+  target_agents:
+    - my-agent
+`)
+
+var agentRoleMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: AgentRole
+metadata:
+  name: completeness-role
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  description: A test role
+  permissions:
+    - tool:web_search:invoke
+`)
+
+var toolPermissionMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: ToolPermission
+metadata:
+  name: completeness-tp
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  tool_ref: web_search
+  action: invoke
+  match_mode: all
+  apply_mode: scoped
+  required_permissions:
+    - tool:web_search:invoke
+  target_agents:
+    - my-agent
+  operation_rules:
+    - operation_class: read
+      verdict: allow
+`)
+
+var memoryMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: Memory
+metadata:
+  name: completeness-memory
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  type: vector
+  provider: builtin
+  embedding_model: text-embedding-3-small
+  endpoint: https://memory.example.com
+  endpoint_secret_ref: mem-secret
+  auth:
+    secretRef: mem-auth
+`)
+
+var workerMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: Worker
+metadata:
+  name: completeness-worker
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  region: us-east-1
+  max_concurrent_tasks: 4
+  capabilities:
+    gpu: true
+    supported_models:
+      - gpt-4o
+`)
+
+var taskMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: Task
+metadata:
+  name: completeness-task
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  system: my-system
+  mode: run
+  priority: high
+  input:
+    query: test
+`)
+
+var taskScheduleMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: TaskSchedule
+metadata:
+  name: completeness-schedule
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  schedule: "*/5 * * * *"
+  time_zone: America/New_York
+  suspend: true
+  starting_deadline_seconds: 600
+  concurrency_policy: forbid
+  successful_history_limit: 5
+  failed_history_limit: 2
+  task_template:
+    system: my-system
+    mode: run
+    priority: high
+    max_turns: 10
+    input:
+      query: scheduled test
+    retry:
+      max_attempts: 2
+      backoff: 5s
+    message_retry:
+      max_attempts: 3
+      backoff: 2s
+      max_backoff: 1m
+      jitter: full
+`)
+
+var taskWebhookMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: TaskWebhook
+metadata:
+  name: completeness-webhook
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  suspend: true
+  task_template:
+    system: my-system
+    mode: run
+    priority: high
+    max_turns: 10
+    input:
+      query: webhook test
+    retry:
+      max_attempts: 2
+      backoff: 5s
+    message_retry:
+      max_attempts: 3
+      backoff: 2s
+      max_backoff: 1m
+      jitter: full
+  auth:
+    profile: hmac
+    secret_ref: webhook-secret
+    signature_header: X-Signature-256
+    signature_prefix: "sha256="
+    timestamp_header: X-Timestamp
+    max_skew_seconds: 600
+    algorithm: sha256
+    payload_format: timestamp_dot_body
+    payload_prefix: "v0"
+    payload_separator: ":"
+    signature_encoding: hex
+    header_format: kv_pairs
+    signature_key: s
+    timestamp_key: t
+  idempotency:
+    event_id_header: X-Event-Id
+    dedupe_window_seconds: 3600
+  payload:
+    mode: raw
+    input_key: body
+`)
+
+var toolApprovalMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: ToolApproval
+metadata:
+  name: completeness-ta
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  task_ref: task/default/t1
+  tool: deploy
+  operation_class: write
+  agent: deployer
+  input: '{"target":"prod"}'
+  reason: needs approval
+  ttl: 15m
+`)
+
+var taskApprovalMaximalYAML = []byte(`apiVersion: orloj.dev/v1
+kind: TaskApproval
+metadata:
+  name: completeness-tap
+  namespace: test-ns
+  labels:
+    env: test
+spec:
+  task_ref: task/default/t1
+  checkpoint_id: cp-1
+  checkpoint_type: agent_output
+  agent: writer
+  reason: review needed
+  ttl: 10m
+  supersedes: old-approval
+`)
+
+// ---------------------------------------------------------------------------
+// Test runner
+// ---------------------------------------------------------------------------
+
+func TestYAMLParserFieldCompleteness(t *testing.T) {
+	cases := []struct {
+		kind    string
+		yaml    []byte
+		parseFn func([]byte) (any, error)
+	}{
+		{"Agent", agentMaximalYAML, func(b []byte) (any, error) { return ParseAgentManifest(b) }},
+		{"Tool/CLI", toolCLIMaximalYAML, func(b []byte) (any, error) { return ParseToolManifest(b) }},
+		{"Tool/HTTP", toolHTTPMaximalYAML, func(b []byte) (any, error) { return ParseToolManifest(b) }},
+		{"Tool/WASM", toolWASMMaximalYAML, func(b []byte) (any, error) { return ParseToolManifest(b) }},
+		{"ModelEndpoint", modelEndpointMaximalYAML, func(b []byte) (any, error) { return ParseModelEndpointManifest(b) }},
+		{"McpServer", mcpServerMaximalYAML, func(b []byte) (any, error) { return ParseMcpServerManifest(b) }},
+		{"AgentPolicy", agentPolicyMaximalYAML, func(b []byte) (any, error) { return ParseAgentPolicyManifest(b) }},
+		{"AgentRole", agentRoleMaximalYAML, func(b []byte) (any, error) { return ParseAgentRoleManifest(b) }},
+		{"ToolPermission", toolPermissionMaximalYAML, func(b []byte) (any, error) { return ParseToolPermissionManifest(b) }},
+		{"Memory", memoryMaximalYAML, func(b []byte) (any, error) { return ParseMemoryManifest(b) }},
+		{"Worker", workerMaximalYAML, func(b []byte) (any, error) { return ParseWorkerManifest(b) }},
+		{"Task", taskMaximalYAML, func(b []byte) (any, error) { return ParseTaskManifest(b) }},
+		{"TaskSchedule", taskScheduleMaximalYAML, func(b []byte) (any, error) { return ParseTaskScheduleManifest(b) }},
+		{"TaskWebhook", taskWebhookMaximalYAML, func(b []byte) (any, error) { return ParseTaskWebhookManifest(b) }},
+		{"ToolApproval", toolApprovalMaximalYAML, func(b []byte) (any, error) { return ParseToolApprovalManifest(b) }},
+		{"TaskApproval", taskApprovalMaximalYAML, func(b []byte) (any, error) { return ParseTaskApprovalManifest(b) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			obj, err := tc.parseFn(tc.yaml)
+			if err != nil {
+				t.Fatalf("YAML parse failed for %s: %v", tc.kind, err)
+			}
+			checkNonZero(t, tc.kind, reflect.ValueOf(obj), "")
+		})
+	}
+}
+
+// TestYAMLJSONParity ensures YAML and JSON parsing produce identical results for
+// each resource type. A fully-populated struct is marshaled to JSON, parsed via
+// the JSON path, then the same data expressed as YAML is parsed via the YAML path.
+// Any field that differs means the YAML parser is not handling it correctly.
+func TestYAMLJSONParity(t *testing.T) {
+	cases := []struct {
+		kind    string
+		yaml    []byte
+		parseFn func([]byte) (any, error)
+	}{
+		{"Agent", agentMaximalYAML, func(b []byte) (any, error) { return ParseAgentManifest(b) }},
+		{"Tool/CLI", toolCLIMaximalYAML, func(b []byte) (any, error) { return ParseToolManifest(b) }},
+		{"Tool/HTTP", toolHTTPMaximalYAML, func(b []byte) (any, error) { return ParseToolManifest(b) }},
+		{"Tool/WASM", toolWASMMaximalYAML, func(b []byte) (any, error) { return ParseToolManifest(b) }},
+		{"ModelEndpoint", modelEndpointMaximalYAML, func(b []byte) (any, error) { return ParseModelEndpointManifest(b) }},
+		{"McpServer", mcpServerMaximalYAML, func(b []byte) (any, error) { return ParseMcpServerManifest(b) }},
+		{"AgentPolicy", agentPolicyMaximalYAML, func(b []byte) (any, error) { return ParseAgentPolicyManifest(b) }},
+		{"AgentRole", agentRoleMaximalYAML, func(b []byte) (any, error) { return ParseAgentRoleManifest(b) }},
+		{"ToolPermission", toolPermissionMaximalYAML, func(b []byte) (any, error) { return ParseToolPermissionManifest(b) }},
+		{"Memory", memoryMaximalYAML, func(b []byte) (any, error) { return ParseMemoryManifest(b) }},
+		{"Worker", workerMaximalYAML, func(b []byte) (any, error) { return ParseWorkerManifest(b) }},
+		{"TaskSchedule", taskScheduleMaximalYAML, func(b []byte) (any, error) { return ParseTaskScheduleManifest(b) }},
+		{"TaskWebhook", taskWebhookMaximalYAML, func(b []byte) (any, error) { return ParseTaskWebhookManifest(b) }},
+		{"ToolApproval", toolApprovalMaximalYAML, func(b []byte) (any, error) { return ParseToolApprovalManifest(b) }},
+		{"TaskApproval", taskApprovalMaximalYAML, func(b []byte) (any, error) { return ParseTaskApprovalManifest(b) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			// Parse YAML
+			yamlObj, err := tc.parseFn(tc.yaml)
+			if err != nil {
+				t.Fatalf("YAML parse failed: %v", err)
+			}
+
+			// Marshal to JSON, then re-parse via JSON path
+			jsonBytes, err := json.Marshal(yamlObj)
+			if err != nil {
+				t.Fatalf("JSON marshal failed: %v", err)
+			}
+			jsonObj, err := tc.parseFn(jsonBytes)
+			if err != nil {
+				t.Fatalf("JSON re-parse failed: %v", err)
+			}
+
+			// Marshal both to JSON for comparison
+			yamlJSON, _ := json.Marshal(yamlObj)
+			jsonJSON, _ := json.Marshal(jsonObj)
+
+			if string(yamlJSON) != string(jsonJSON) {
+				diffFields(t, tc.kind, yamlObj, jsonObj, "")
+			}
+		})
+	}
+}
+
+// diffFields reports individual field differences between two structs.
+func diffFields(t *testing.T, kind string, yamlObj, jsonObj any, path string) {
+	t.Helper()
+	yv := reflect.ValueOf(yamlObj)
+	jv := reflect.ValueOf(jsonObj)
+	if yv.Kind() == reflect.Ptr {
+		yv = yv.Elem()
+	}
+	if jv.Kind() == reflect.Ptr {
+		jv = jv.Elem()
+	}
+	if yv.Kind() != reflect.Struct || jv.Kind() != reflect.Struct {
+		return
+	}
+	yt := yv.Type()
+	for i := 0; i < yt.NumField(); i++ {
+		field := yt.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		tag := field.Tag.Get("json")
+		if tag == "-" || tag == "" {
+			continue
+		}
+		fp := field.Name
+		if path != "" {
+			fp = path + "." + field.Name
+		}
+		if shouldSkip(kind, fp) {
+			continue
+		}
+		yf := yv.Field(i)
+		jf := jv.Field(i)
+		yJSON, _ := json.Marshal(yf.Interface())
+		jJSON, _ := json.Marshal(jf.Interface())
+		if string(yJSON) != string(jJSON) {
+			jsonName := strings.Split(tag, ",")[0]
+			t.Errorf("YAML/JSON mismatch at %s (json:%q): YAML=%s JSON=%s",
+				fp, jsonName, string(yJSON), string(jJSON))
+		}
+	}
+}
+
+// TestFixtureCoversAllResources ensures we don't forget to add a fixture when
+// a new resource kind is added to ParseManifest.
+func TestFixtureCoversAllResources(t *testing.T) {
+	coveredKinds := map[string]bool{
+		"agent":          true,
+		"agentsystem":    true, // covered via AgentSystem in completeness test
+		"tool":           true,
+		"modelendpoint":  true,
+		"mcpserver":      true,
+		"agentpolicy":    true,
+		"agentrole":      true,
+		"toolpermission":  true,
+		"memory":         true,
+		"worker":         true,
+		"task":           true,
+		"taskschedule":   true,
+		"taskwebhook":    true,
+		"toolapproval":   true,
+		"taskapproval":   true,
+		"secret":         true,
+		"sealedsecret":   true, // uses full YAML library, not constrained parser
+		"contextadapter": true, // uses full YAML library, not constrained parser
+	}
+
+	// Probe ParseManifest with every kind it supports.
+	probeKinds := []string{
+		"Agent", "AgentSystem", "ModelEndpoint", "Tool", "Secret",
+		"SealedSecret", "Memory", "AgentPolicy", "AgentRole",
+		"ToolPermission", "ToolApproval", "TaskApproval", "Task",
+		"TaskSchedule", "TaskWebhook", "Worker", "McpServer",
+		"ContextAdapter",
+	}
+	for _, k := range probeKinds {
+		norm := strings.ToLower(k)
+		if !coveredKinds[norm] {
+			t.Errorf("resource kind %q is in ParseManifest but has no completeness test fixture — add one to manifest_parser_completeness_test.go", k)
+		}
+	}
+}

--- a/resources/manifest_parser_ext.go
+++ b/resources/manifest_parser_ext.go
@@ -689,6 +689,8 @@ func ParseToolManifest(data []byte) (Tool, error) {
 			out.Spec.Cli.Output = value
 		case section == "spec" && subsection == "cli" && runtimeSubsection == "" && (key == "working_dir" || key == "workingDir"):
 			out.Spec.Cli.WorkingDir = value
+		case section == "spec" && subsection == "cli" && runtimeSubsection == "" && (key == "image_pull_secret" || key == "imagePullSecret"):
+			out.Spec.Cli.ImagePullSecret = value
 		case section == "spec" && subsection == "cli" && runtimeSubsection == "" && (key == "stdin_from_input" || key == "stdinFromInput"):
 			out.Spec.Cli.StdinFromInput = strings.EqualFold(value, "true")
 		case section == "spec" && subsection == "wasm" && key == "module":
@@ -1119,6 +1121,18 @@ func ParseAgentPolicyManifest(data []byte) (AgentPolicy, error) {
 			out.Spec.MaxTokensPerRun = v
 		case section == "spec" && key == "apply_mode":
 			out.Spec.ApplyMode = value
+		case section == "spec" && (key == "max_child_depth" || key == "maxChildDepth"):
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return AgentPolicy{}, fmt.Errorf("invalid spec.max_child_depth value %q", value)
+			}
+			out.Spec.MaxChildDepth = v
+		case section == "spec" && (key == "max_child_tasks" || key == "maxChildTasks"):
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return AgentPolicy{}, fmt.Errorf("invalid spec.max_child_tasks value %q", value)
+			}
+			out.Spec.MaxChildTasks = v
 		}
 	}
 
@@ -1773,6 +1787,9 @@ func ParseTaskScheduleManifest(data []byte) (TaskSchedule, error) {
 		if section == "metadata" && indent <= 2 && !strings.HasSuffix(trimmed, ":") && !strings.HasPrefix(trimmed, "- ") {
 			subsection = ""
 		}
+		if section == "spec" && strings.HasPrefix(subsection, "task_template_") && indent <= 4 && !strings.HasSuffix(trimmed, ":") {
+			subsection = "task_template"
+		}
 
 		if strings.HasSuffix(trimmed, ":") {
 			switch strings.TrimSuffix(trimmed, ":") {
@@ -1785,6 +1802,25 @@ func ParseTaskScheduleManifest(data []byte) (TaskSchedule, error) {
 			case "labels":
 				if section == "metadata" {
 					subsection = "labels"
+				}
+			case "task_template":
+				if section == "spec" {
+					subsection = "task_template"
+					if out.Spec.TaskTemplate == nil {
+						out.Spec.TaskTemplate = &TaskSpec{}
+					}
+				}
+			case "input":
+				if section == "spec" && strings.HasPrefix(subsection, "task_template") {
+					subsection = "task_template_input"
+				}
+			case "retry":
+				if section == "spec" && strings.HasPrefix(subsection, "task_template") {
+					subsection = "task_template_retry"
+				}
+			case "message_retry":
+				if section == "spec" && strings.HasPrefix(subsection, "task_template") {
+					subsection = "task_template_message_retry"
 				}
 			}
 			continue
@@ -1838,6 +1874,43 @@ func ParseTaskScheduleManifest(data []byte) (TaskSchedule, error) {
 				return TaskSchedule{}, fmt.Errorf("invalid spec.failed_history_limit value %q", value)
 			}
 			out.Spec.FailedHistoryLimit = v
+		case section == "spec" && subsection == "task_template" && key == "system":
+			out.Spec.TaskTemplate.System = value
+		case section == "spec" && subsection == "task_template" && key == "mode":
+			out.Spec.TaskTemplate.Mode = value
+		case section == "spec" && subsection == "task_template" && key == "priority":
+			out.Spec.TaskTemplate.Priority = value
+		case section == "spec" && subsection == "task_template" && (key == "max_turns" || key == "maxTurns"):
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return TaskSchedule{}, fmt.Errorf("invalid spec.task_template.max_turns value %q", value)
+			}
+			out.Spec.TaskTemplate.MaxTurns = v
+		case section == "spec" && subsection == "task_template_input":
+			if out.Spec.TaskTemplate.Input == nil {
+				out.Spec.TaskTemplate.Input = make(map[string]string)
+			}
+			out.Spec.TaskTemplate.Input[key] = value
+		case section == "spec" && subsection == "task_template_retry" && (key == "max_attempts" || key == "maxAttempts"):
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return TaskSchedule{}, fmt.Errorf("invalid spec.task_template.retry.max_attempts value %q", value)
+			}
+			out.Spec.TaskTemplate.Retry.MaxAttempts = v
+		case section == "spec" && subsection == "task_template_retry" && key == "backoff":
+			out.Spec.TaskTemplate.Retry.Backoff = value
+		case section == "spec" && subsection == "task_template_message_retry" && (key == "max_attempts" || key == "maxAttempts"):
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return TaskSchedule{}, fmt.Errorf("invalid spec.task_template.message_retry.max_attempts value %q", value)
+			}
+			out.Spec.TaskTemplate.MessageRetry.MaxAttempts = v
+		case section == "spec" && subsection == "task_template_message_retry" && key == "backoff":
+			out.Spec.TaskTemplate.MessageRetry.Backoff = value
+		case section == "spec" && subsection == "task_template_message_retry" && (key == "max_backoff" || key == "maxBackoff"):
+			out.Spec.TaskTemplate.MessageRetry.MaxBackoff = value
+		case section == "spec" && subsection == "task_template_message_retry" && key == "jitter":
+			out.Spec.TaskTemplate.MessageRetry.Jitter = value
 		}
 	}
 
@@ -1944,6 +2017,8 @@ func ParseTaskWebhookManifest(data []byte) (TaskWebhook, error) {
 			out.Spec.Suspend = strings.EqualFold(value, "true") || value == "1"
 		case section == "spec" && subsection == "task_template" && key == "system":
 			out.Spec.TaskTemplate.System = value
+		case section == "spec" && subsection == "task_template" && key == "mode":
+			out.Spec.TaskTemplate.Mode = value
 		case section == "spec" && subsection == "task_template" && key == "priority":
 			out.Spec.TaskTemplate.Priority = value
 		case section == "spec" && subsection == "task_template" && (key == "max_turns" || key == "maxTurns"):
@@ -1993,6 +2068,22 @@ func ParseTaskWebhookManifest(data []byte) (TaskWebhook, error) {
 				return TaskWebhook{}, fmt.Errorf("invalid spec.auth.max_skew_seconds value %q", value)
 			}
 			out.Spec.Auth.MaxSkewSeconds = v
+		case section == "spec" && subsection == "auth" && key == "algorithm":
+			out.Spec.Auth.Algorithm = value
+		case section == "spec" && subsection == "auth" && (key == "payload_format" || key == "payloadFormat"):
+			out.Spec.Auth.PayloadFormat = value
+		case section == "spec" && subsection == "auth" && (key == "payload_prefix" || key == "payloadPrefix"):
+			out.Spec.Auth.PayloadPrefix = value
+		case section == "spec" && subsection == "auth" && (key == "payload_separator" || key == "payloadSeparator"):
+			out.Spec.Auth.PayloadSeparator = value
+		case section == "spec" && subsection == "auth" && (key == "signature_encoding" || key == "signatureEncoding"):
+			out.Spec.Auth.SignatureEncoding = value
+		case section == "spec" && subsection == "auth" && (key == "header_format" || key == "headerFormat"):
+			out.Spec.Auth.HeaderFormat = value
+		case section == "spec" && subsection == "auth" && (key == "signature_key" || key == "signatureKey"):
+			out.Spec.Auth.SignatureKey = value
+		case section == "spec" && subsection == "auth" && (key == "timestamp_key" || key == "timestampKey"):
+			out.Spec.Auth.TimestampKey = value
 		case section == "spec" && subsection == "idempotency" && (key == "event_id_header" || key == "eventIdHeader"):
 			out.Spec.Idempotency.EventIDHeader = value
 		case section == "spec" && subsection == "idempotency" && (key == "event_id_from_body" || key == "eventIdFromBody"):
@@ -2159,11 +2250,15 @@ func ParseMcpServerManifest(data []byte) (McpServer, error) {
 				if section == "spec" {
 					subsection = "env"
 				}
-			case "auth":
-				if section == "spec" {
-					subsection = "auth"
-				}
-			case "tool_filter", "toolFilter":
+		case "auth":
+			if section == "spec" {
+				subsection = "auth"
+			}
+		case "scopes":
+			if section == "spec" && subsection == "auth" {
+				subsection = "auth_scopes"
+			}
+		case "tool_filter", "toolFilter":
 				if section == "spec" {
 					subsection = "tool_filter"
 				}
@@ -2185,6 +2280,10 @@ func ParseMcpServerManifest(data []byte) (McpServer, error) {
 
 		if section == "spec" && subsection == "args" && strings.HasPrefix(trimmed, "- ") {
 			out.Spec.Args = append(out.Spec.Args, stripQuotes(strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))))
+			continue
+		}
+		if section == "spec" && subsection == "auth_scopes" && strings.HasPrefix(trimmed, "- ") {
+			out.Spec.Auth.Scopes = append(out.Spec.Auth.Scopes, stripQuotes(strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))))
 			continue
 		}
 		if section == "spec" && subsection == "tool_filter_include" && strings.HasPrefix(trimmed, "- ") {
@@ -2231,12 +2330,18 @@ func ParseMcpServerManifest(data []byte) (McpServer, error) {
 			out.Spec.Endpoint = value
 		case section == "spec" && subsection == "" && key == "image":
 			out.Spec.Image = value
+		case section == "spec" && subsection == "" && (key == "image_pull_secret" || key == "imagePullSecret"):
+			out.Spec.ImagePullSecret = value
 		case section == "spec" && subsection == "" && (key == "idle_timeout" || key == "idleTimeout"):
 			out.Spec.IdleTimeout = value
 		case section == "spec" && subsection == "auth" && (key == "secretRef" || key == "secret_ref"):
 			out.Spec.Auth.SecretRef = value
 		case section == "spec" && subsection == "auth" && key == "profile":
 			out.Spec.Auth.Profile = value
+		case section == "spec" && subsection == "auth" && (key == "headerName" || key == "header_name"):
+			out.Spec.Auth.HeaderName = value
+		case section == "spec" && subsection == "auth" && (key == "tokenURL" || key == "token_url"):
+			out.Spec.Auth.TokenURL = value
 		case section == "spec" && subsection == "reconnect" && (key == "max_attempts" || key == "maxAttempts"):
 			v, err := strconv.Atoi(value)
 			if err != nil {

--- a/resources/manifest_parser_model_endpoint.go
+++ b/resources/manifest_parser_model_endpoint.go
@@ -92,6 +92,9 @@ func ParseModelEndpointManifest(data []byte) (ModelEndpoint, error) {
 			out.Spec.Options[strings.ToLower(strings.TrimSpace(key))] = value
 		case section == "spec" && subsection == "auth" && (key == "secretRef" || key == "secret_ref"):
 			out.Spec.Auth.SecretRef = value
+		case section == "spec" && subsection == "" && (key == "allowPrivate" || key == "allow_private"):
+			parsed := strings.EqualFold(value, "true") || value == "1"
+			out.Spec.AllowPrivate = &parsed
 		}
 	}
 

--- a/resources/resource_types.go
+++ b/resources/resource_types.go
@@ -1653,14 +1653,15 @@ type TaskSchedule struct {
 }
 
 type TaskScheduleSpec struct {
-	TaskRef                 string `json:"task_ref,omitempty"`
-	Schedule                string `json:"schedule,omitempty"`
-	TimeZone                string `json:"time_zone,omitempty"`
-	Suspend                 bool   `json:"suspend,omitempty"`
-	StartingDeadlineSeconds int    `json:"starting_deadline_seconds,omitempty"`
-	ConcurrencyPolicy       string `json:"concurrency_policy,omitempty"`
-	SuccessfulHistoryLimit  int    `json:"successful_history_limit,omitempty"`
-	FailedHistoryLimit      int    `json:"failed_history_limit,omitempty"`
+	TaskRef                 string    `json:"task_ref,omitempty"`
+	TaskTemplate            *TaskSpec `json:"task_template,omitempty"`
+	Schedule                string    `json:"schedule,omitempty"`
+	TimeZone                string    `json:"time_zone,omitempty"`
+	Suspend                 bool      `json:"suspend,omitempty"`
+	StartingDeadlineSeconds int       `json:"starting_deadline_seconds,omitempty"`
+	ConcurrencyPolicy       string    `json:"concurrency_policy,omitempty"`
+	SuccessfulHistoryLimit  int       `json:"successful_history_limit,omitempty"`
+	FailedHistoryLimit      int       `json:"failed_history_limit,omitempty"`
 }
 
 type TaskScheduleStatus struct {
@@ -1695,13 +1696,65 @@ func (t *TaskSchedule) Normalize() error {
 	}
 
 	t.Spec.TaskRef = strings.TrimSpace(t.Spec.TaskRef)
-	if t.Spec.TaskRef == "" {
-		return fmt.Errorf("spec.task_ref is required")
+	hasRef := t.Spec.TaskRef != ""
+	hasInline := t.Spec.TaskTemplate != nil
+	if hasRef && hasInline {
+		return fmt.Errorf("spec.task_ref and spec.task_template are mutually exclusive")
 	}
-	if strings.Contains(t.Spec.TaskRef, "/") {
+	if !hasRef && !hasInline {
+		return fmt.Errorf("one of spec.task_ref or spec.task_template is required")
+	}
+	if hasRef && strings.Contains(t.Spec.TaskRef, "/") {
 		parts := strings.SplitN(t.Spec.TaskRef, "/", 2)
 		if strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
 			return fmt.Errorf("invalid spec.task_ref %q: expected name or namespace/name", t.Spec.TaskRef)
+		}
+	}
+	if hasInline {
+		tmpl := t.Spec.TaskTemplate
+		tmpl.System = strings.TrimSpace(tmpl.System)
+		if tmpl.System == "" {
+			return fmt.Errorf("spec.task_template.system is required")
+		}
+		if tmpl.Input == nil {
+			tmpl.Input = make(map[string]string)
+		}
+		if strings.TrimSpace(tmpl.Priority) == "" {
+			tmpl.Priority = "normal"
+		}
+		if tmpl.Retry.MaxAttempts <= 0 {
+			tmpl.Retry.MaxAttempts = 1
+		}
+		if tmpl.Retry.Backoff == "" {
+			tmpl.Retry.Backoff = "0s"
+		}
+		if _, err := time.ParseDuration(tmpl.Retry.Backoff); err != nil {
+			return fmt.Errorf("invalid spec.task_template.retry.backoff %q: %w", tmpl.Retry.Backoff, err)
+		}
+		if tmpl.MessageRetry.MaxAttempts <= 0 {
+			tmpl.MessageRetry.MaxAttempts = tmpl.Retry.MaxAttempts
+		}
+		if strings.TrimSpace(tmpl.MessageRetry.Backoff) == "" {
+			tmpl.MessageRetry.Backoff = tmpl.Retry.Backoff
+		}
+		if _, err := time.ParseDuration(tmpl.MessageRetry.Backoff); err != nil {
+			return fmt.Errorf("invalid spec.task_template.message_retry.backoff %q: %w", tmpl.MessageRetry.Backoff, err)
+		}
+		if strings.TrimSpace(tmpl.MessageRetry.MaxBackoff) == "" {
+			tmpl.MessageRetry.MaxBackoff = "24h"
+		}
+		if _, err := time.ParseDuration(tmpl.MessageRetry.MaxBackoff); err != nil {
+			return fmt.Errorf("invalid spec.task_template.message_retry.max_backoff %q: %w", tmpl.MessageRetry.MaxBackoff, err)
+		}
+		jitter := strings.ToLower(strings.TrimSpace(tmpl.MessageRetry.Jitter))
+		if jitter == "" {
+			jitter = "full"
+		}
+		switch jitter {
+		case "none", "full", "equal":
+			tmpl.MessageRetry.Jitter = jitter
+		default:
+			return fmt.Errorf("invalid spec.task_template.message_retry.jitter %q: expected none, full, or equal", tmpl.MessageRetry.Jitter)
 		}
 	}
 

--- a/resources/task_schedule_test.go
+++ b/resources/task_schedule_test.go
@@ -128,6 +128,142 @@ spec:
 	}
 }
 
+func TestTaskScheduleNormalizeInlineTemplate(t *testing.T) {
+	s := TaskSchedule{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "TaskSchedule",
+		Metadata:   ObjectMeta{Name: "inline-sched"},
+		Spec: TaskScheduleSpec{
+			TaskTemplate: &TaskSpec{
+				System: "my-system",
+			},
+			Schedule: "*/5 * * * *",
+			TimeZone: "UTC",
+		},
+	}
+	if err := s.Normalize(); err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+	if s.Spec.TaskTemplate.Priority != "normal" {
+		t.Fatalf("expected default priority normal, got %q", s.Spec.TaskTemplate.Priority)
+	}
+	if s.Spec.TaskTemplate.Retry.MaxAttempts != 1 {
+		t.Fatalf("expected default retry.max_attempts 1, got %d", s.Spec.TaskTemplate.Retry.MaxAttempts)
+	}
+	if s.Spec.TaskTemplate.Input == nil {
+		t.Fatal("expected input map to be initialized")
+	}
+	if s.Spec.TaskRef != "" {
+		t.Fatalf("expected empty task_ref, got %q", s.Spec.TaskRef)
+	}
+}
+
+func TestTaskScheduleNormalizeMutualExclusivity(t *testing.T) {
+	both := TaskSchedule{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "TaskSchedule",
+		Metadata:   ObjectMeta{Name: "both-set"},
+		Spec: TaskScheduleSpec{
+			TaskRef:      "some-template",
+			TaskTemplate: &TaskSpec{System: "sys"},
+			Schedule:     "* * * * *",
+			TimeZone:     "UTC",
+		},
+	}
+	if err := both.Normalize(); err == nil {
+		t.Fatal("expected error when both task_ref and task_template are set")
+	}
+
+	neither := TaskSchedule{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "TaskSchedule",
+		Metadata:   ObjectMeta{Name: "neither-set"},
+		Spec: TaskScheduleSpec{
+			Schedule: "* * * * *",
+			TimeZone: "UTC",
+		},
+	}
+	if err := neither.Normalize(); err == nil {
+		t.Fatal("expected error when neither task_ref nor task_template is set")
+	}
+}
+
+func TestTaskScheduleNormalizeInlineTemplateMissingSystem(t *testing.T) {
+	s := TaskSchedule{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "TaskSchedule",
+		Metadata:   ObjectMeta{Name: "no-system"},
+		Spec: TaskScheduleSpec{
+			TaskTemplate: &TaskSpec{},
+			Schedule:     "* * * * *",
+			TimeZone:     "UTC",
+		},
+	}
+	if err := s.Normalize(); err == nil {
+		t.Fatal("expected error for inline template missing system")
+	}
+}
+
+func TestParseTaskScheduleManifestYAMLInlineTemplate(t *testing.T) {
+	raw := []byte(`
+apiVersion: orloj.dev/v1
+kind: TaskSchedule
+metadata:
+  name: inline-sched
+spec:
+  task_template:
+    system: report-pipeline
+    priority: high
+    input:
+      topic: weekly
+    retry:
+      max_attempts: 3
+      backoff: 5s
+    message_retry:
+      max_attempts: 2
+      backoff: 1s
+      max_backoff: 10s
+      jitter: full
+  schedule: "0 9 * * 1"
+  time_zone: America/Chicago
+  concurrency_policy: forbid
+`)
+	item, err := ParseTaskScheduleManifest(raw)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if item.Spec.TaskRef != "" {
+		t.Fatalf("expected empty task_ref, got %q", item.Spec.TaskRef)
+	}
+	if item.Spec.TaskTemplate == nil {
+		t.Fatal("expected task_template to be set")
+	}
+	if item.Spec.TaskTemplate.System != "report-pipeline" {
+		t.Fatalf("expected system report-pipeline, got %q", item.Spec.TaskTemplate.System)
+	}
+	if item.Spec.TaskTemplate.Priority != "high" {
+		t.Fatalf("expected priority high, got %q", item.Spec.TaskTemplate.Priority)
+	}
+	if item.Spec.TaskTemplate.Input["topic"] != "weekly" {
+		t.Fatalf("expected input topic=weekly, got %q", item.Spec.TaskTemplate.Input["topic"])
+	}
+	if item.Spec.TaskTemplate.Retry.MaxAttempts != 3 {
+		t.Fatalf("expected retry.max_attempts=3, got %d", item.Spec.TaskTemplate.Retry.MaxAttempts)
+	}
+	if item.Spec.TaskTemplate.Retry.Backoff != "5s" {
+		t.Fatalf("expected retry.backoff=5s, got %q", item.Spec.TaskTemplate.Retry.Backoff)
+	}
+	if item.Spec.TaskTemplate.MessageRetry.MaxAttempts != 2 {
+		t.Fatalf("expected message_retry.max_attempts=2, got %d", item.Spec.TaskTemplate.MessageRetry.MaxAttempts)
+	}
+	if item.Spec.TaskTemplate.MessageRetry.MaxBackoff != "10s" {
+		t.Fatalf("expected message_retry.max_backoff=10s, got %q", item.Spec.TaskTemplate.MessageRetry.MaxBackoff)
+	}
+	if item.Spec.Schedule != "0 9 * * 1" {
+		t.Fatalf("expected schedule 0 9 * * 1, got %q", item.Spec.Schedule)
+	}
+}
+
 func TestTaskWebhookNormalizeDefaultsAndValidation(t *testing.T) {
 	hook := TaskWebhook{
 		APIVersion: "orloj.dev/v1",


### PR DESCRIPTION
The constrained-YAML parser had no case statements for several documented fields, causing them to be silently discarded on apply while JSON manifests worked fine. Add missing field handling for image_pull_secret (Tool CLI, McpServer), fallback_model_refs and allowed_tools (Agent), allowPrivate (ModelEndpoint), max_child_depth and max_child_tasks (AgentPolicy), auth fields (McpServer, TaskWebhook), and task_template.mode (TaskSchedule, TaskWebhook).

Add reflection-based completeness test that fails when a new struct field is added without a corresponding YAML parser case, preventing this class of bug from recurring.


