### PR TITLE
per-tool and McpServer container resource overrides with optional ceilings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-tool and per-McpServer container resource limits**: Tool manifests now support `spec.cli.resources` and McpServer manifests support `spec.resources` with `memory`, `cpus`, and `pids_limit` fields that override the global `--tool-container-{memory,cpus,pids-limit}` defaults. This allows resource-intensive tools (e.g. Chromium-based MCP servers) to declare their own container limits without raising the global defaults for all tools. Operator-level ceilings (`--tool-container-max-memory`, `--tool-container-max-cpus`, `--tool-container-max-pids-limit`) can optionally cap per-tool overrides; manifests exceeding the ceiling are rejected at apply time.
+
 ## [0.12.1] - 2026-05-03
 
 ### Added

--- a/api/server.go
+++ b/api/server.go
@@ -60,6 +60,7 @@ type ServerOptions struct {
 	SessionTTL         time.Duration
 	UIBasePath         string // URL path prefix for the web console (default "/")
 	TrustedProxies     string // comma-separated CIDRs whose forwarding headers are trusted
+	ContainerResourceCeiling resources.ContainerResourceCeiling
 }
 
 // Server exposes CRUD endpoints for control plane resources.
@@ -79,6 +80,7 @@ type Server struct {
 	requestRateLimiter *rate.Limiter // per-server; avoids test suites sharing one process-global bucket
 	trustedProxies     []*net.IPNet
 	uiBasePath         string
+	containerResourceCeiling resources.ContainerResourceCeiling
 }
 
 func NewServer(stores Stores, runtime *agentruntime.Manager, logger *log.Logger) *Server {
@@ -171,8 +173,9 @@ func NewServerWithOptions(stores Stores, runtime *agentruntime.Manager, logger *
 		// 500 r/s sustained, burst 100 — same as previous package-global limiter, but per Server instance
 		// so concurrent httptest servers in tests do not share one token bucket.
 		requestRateLimiter: rate.NewLimiter(rate.Limit(500), 100),
-		trustedProxies:     trustedProxies,
-		uiBasePath:         uiBase,
+		trustedProxies:             trustedProxies,
+		uiBasePath:                 uiBase,
+		containerResourceCeiling:   opts.ContainerResourceCeiling,
 	}
 	s.routes()
 	return s
@@ -193,6 +196,22 @@ func (s *Server) EventBus() eventbus.Bus {
 // SetMemoryBackends configures the registry used to serve memory entry queries.
 func (s *Server) SetMemoryBackends(registry *agentruntime.PersistentMemoryBackendRegistry) {
 	s.memoryBackends = registry
+}
+
+func (s *Server) validateToolContainerResources(tool resources.Tool) error {
+	res := tool.Spec.Cli.Resources
+	if err := resources.ValidateContainerResources(res, "spec.cli.resources"); err != nil {
+		return err
+	}
+	return resources.EnforceContainerResourceCeiling(res, s.containerResourceCeiling, "tool", tool.Metadata.Name)
+}
+
+func (s *Server) validateMcpServerContainerResources(server resources.McpServer) error {
+	res := server.Spec.Resources
+	if err := resources.ValidateContainerResources(res, "spec.resources"); err != nil {
+		return err
+	}
+	return resources.EnforceContainerResourceCeiling(res, s.containerResourceCeiling, "McpServer", server.Metadata.Name)
 }
 
 // maxRequestBodyBytes is the hard cap on incoming request bodies for all
@@ -1039,6 +1058,10 @@ func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		if err := s.validateToolContainerResources(obj); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		if err := applyRequestNamespace(r, &obj.Metadata); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -1105,6 +1128,10 @@ func (s *Server) handleToolByName(w http.ResponseWriter, r *http.Request) {
 		}
 		obj, err := resources.ParseToolManifest(body)
 		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := s.validateToolContainerResources(obj); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -2953,6 +2980,10 @@ func (s *Server) handleMcpServers(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		if err := s.validateMcpServerContainerResources(obj); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		if err := applyRequestNamespace(r, &obj.Metadata); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -3003,6 +3034,10 @@ func (s *Server) handleMcpServerByName(w http.ResponseWriter, r *http.Request) {
 		}
 		obj, err := resources.ParseMcpServerManifest(body)
 		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := s.validateMcpServerContainerResources(obj); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/cmd/orlojd/main.go
+++ b/cmd/orlojd/main.go
@@ -60,6 +60,9 @@ func main() {
 	toolContainerCPUs := flag.String("tool-container-cpus", env("ORLOJ_TOOL_CONTAINER_CPUS", "0.50"), "container CPU limit for isolated tools")
 	toolContainerPidsLimit := flag.Int("tool-container-pids-limit", 64, "container pids limit for isolated tools")
 	toolContainerUser := flag.String("tool-container-user", env("ORLOJ_TOOL_CONTAINER_USER", "65532:65532"), "container user for isolated tools")
+	toolContainerMaxMemory := flag.String("tool-container-max-memory", env("ORLOJ_TOOL_CONTAINER_MAX_MEMORY", ""), "operator ceiling for per-tool/McpServer resources.memory (empty = unbounded)")
+	toolContainerMaxCPUs := flag.String("tool-container-max-cpus", env("ORLOJ_TOOL_CONTAINER_MAX_CPUS", ""), "operator ceiling for per-tool/McpServer resources.cpus (empty = unbounded)")
+	toolContainerMaxPidsLimit := flag.Int("tool-container-max-pids-limit", envInt("ORLOJ_TOOL_CONTAINER_MAX_PIDS_LIMIT", 0), "operator ceiling for per-tool/McpServer resources.pids_limit (0 = unbounded)")
 	toolSecretEnvPrefix := flag.String("tool-secret-env-prefix", env("ORLOJ_TOOL_SECRET_ENV_PREFIX", "ORLOJ_SECRET_"), "environment variable prefix used to resolve Tool.spec.auth.secretRef")
 	toolWASMModule := flag.String("tool-wasm-module", env("ORLOJ_TOOL_WASM_MODULE", ""), "default wasm module path (per-tool spec.wasm.module takes precedence)")
 	toolWASMEntrypoint := flag.String("tool-wasm-entrypoint", env("ORLOJ_TOOL_WASM_ENTRYPOINT", "run"), "default wasm entrypoint function")
@@ -287,6 +290,11 @@ func main() {
 		SessionTTL:     *authSessionTTL,
 		UIBasePath:     *uiPath,
 		TrustedProxies: *trustedProxies,
+		ContainerResourceCeiling: resources.ContainerResourceCeiling{
+			MaxMemory:    *toolContainerMaxMemory,
+			MaxCPUs:      *toolContainerMaxCPUs,
+			MaxPidsLimit: *toolContainerMaxPidsLimit,
+		},
 	})
 	bus, closeBus := newEventBus(logger, *eventBusBackend, *natsURL, *natsSubjectPrefix)
 	if closeBus != nil {

--- a/docs/pages/concepts/tools/cli-tool.md
+++ b/docs/pages/concepts/tools/cli-tool.md
@@ -125,7 +125,7 @@ CLI tools default to `container` isolation. The operator provides a container im
 - `--cap-drop=ALL`
 - `--security-opt no-new-privileges`
 - `--network bridge` (configurable via `cli.network`)
-- Resource limits from worker config (`--tool-container-memory`, `--tool-container-cpus`, etc.)
+- Resource limits from `cli.resources` (per-tool) or the global worker config (`--tool-container-memory`, `--tool-container-cpus`, `--tool-container-pids-limit`)
 
 Set `cli.network: none` for tools that do not need outbound network access:
 
@@ -135,6 +135,29 @@ cli:
   image: ghcr.io/jqlang/jq:1.7
   network: none
 ```
+
+### Per-tool container resources
+
+Tools that need more resources than the global defaults (e.g. Chromium-based tools) can declare per-tool overrides via `cli.resources`. When set, these take precedence over the global `--tool-container-*` flags:
+
+```yaml
+cli:
+  command: screenshot
+  image: my-chromium:latest
+  network: bridge
+  resources:
+    memory: 1g
+    cpus: "1.0"
+    pids_limit: 256
+```
+
+| Field | Format | Description |
+|-------|--------|-------------|
+| `memory` | Docker memory string (`128m`, `1g`) | Container memory limit. |
+| `cpus` | Decimal string (`0.50`, `1.0`) | Container CPU limit. |
+| `pids_limit` | Integer | Container PID limit. |
+
+Operators can set a ceiling with `--tool-container-max-memory`, `--tool-container-max-cpus`, and `--tool-container-max-pids-limit` on `orlojd`. Manifests exceeding the ceiling are rejected at apply time.
 
 ## Direct execution (no container)
 

--- a/docs/pages/concepts/tools/mcp-server.md
+++ b/docs/pages/concepts/tools/mcp-server.md
@@ -83,6 +83,7 @@ spec:
 | `auth`                | http: authentication configuration (`secretRef` + `profile`).                                             |
 | `tool_filter.include` | Optional allowlist of MCP tool names. When set, only listed tools are generated.                          |
 | `reconnect`           | Reconnection policy: `max_attempts` (default 3) and `backoff` (default 2s).                               |
+| `resources`           | Container resource overrides: `memory`, `cpus`, `pids_limit`. Overrides global `--tool-container-*` flags. Only applies when `image` is set. |
 
 ## How It Works
 
@@ -94,6 +95,26 @@ When an McpServer resource is applied:
 4. The `description` and `input_schema` from the MCP server are propagated to the generated Tool, giving the LLM rich tool definitions.
 
 At invocation time, the `MCPToolRuntime` resolves the server reference, obtains a session from the `McpSessionManager`, and sends a `tools/call` JSON-RPC 2.0 request through the appropriate transport.
+
+## Container Resources
+
+Container-backed MCP servers inherit the global `--tool-container-memory`, `--tool-container-cpus`, and `--tool-container-pids-limit` defaults. For servers that need more resources (e.g. Chromium-based tools like Playwright), override per-server:
+
+```yaml
+apiVersion: orloj.dev/v1
+kind: McpServer
+metadata:
+  name: playwright-mcp
+spec:
+  transport: stdio
+  image: playwright-mcp:latest
+  resources:
+    memory: 1g
+    cpus: "1.0"
+    pids_limit: 512
+```
+
+Operators can enforce an upper bound with `--tool-container-max-memory`, `--tool-container-max-cpus`, and `--tool-container-max-pids-limit` on `orlojd`. Manifests exceeding the ceiling are rejected at apply time.
 
 ## Idle Timeout and Session Lifecycle
 

--- a/docs/pages/reference/server-flags.md
+++ b/docs/pages/reference/server-flags.md
@@ -79,10 +79,13 @@ Model routing (provider, base URL, default model, API key, timeout) is configure
 | `--tool-container-runtime` | `docker` | Container runtime binary. | Container backend; env `ORLOJ_TOOL_CONTAINER_RUNTIME`. |
 | `--tool-container-image` | `curlimages/curl:8.8.0` | Container image for isolated tool calls. | Container backend; env `ORLOJ_TOOL_CONTAINER_IMAGE`. |
 | `--tool-container-network` | `none` | Container network mode. | Container backend; env `ORLOJ_TOOL_CONTAINER_NETWORK`. |
-| `--tool-container-memory` | `128m` | Container memory limit. | Container backend; env `ORLOJ_TOOL_CONTAINER_MEMORY`. |
-| `--tool-container-cpus` | `0.50` | Container CPU limit. | Container backend; env `ORLOJ_TOOL_CONTAINER_CPUS`. |
-| `--tool-container-pids-limit` | `64` | Container PID limit. | Container backend. |
+| `--tool-container-memory` | `128m` | Default container memory limit. Per-tool `spec.cli.resources.memory` and per-McpServer `spec.resources.memory` take precedence when set. | Container backend; env `ORLOJ_TOOL_CONTAINER_MEMORY`. |
+| `--tool-container-cpus` | `0.50` | Default container CPU limit. Per-tool `spec.cli.resources.cpus` and per-McpServer `spec.resources.cpus` take precedence when set. | Container backend; env `ORLOJ_TOOL_CONTAINER_CPUS`. |
+| `--tool-container-pids-limit` | `64` | Default container PID limit. Per-tool `spec.cli.resources.pids_limit` and per-McpServer `spec.resources.pids_limit` take precedence when set. | Container backend; env `ORLOJ_TOOL_CONTAINER_PIDS_LIMIT`. |
 | `--tool-container-user` | `65532:65532` | Container user. | Container backend; env `ORLOJ_TOOL_CONTAINER_USER`. |
+| `--tool-container-max-memory` | empty | Operator ceiling for per-tool/McpServer `resources.memory`. Empty means unbounded. Manifests exceeding this are rejected at apply time. | `orlojd` only; env `ORLOJ_TOOL_CONTAINER_MAX_MEMORY`. |
+| `--tool-container-max-cpus` | empty | Operator ceiling for per-tool/McpServer `resources.cpus`. Empty means unbounded. | `orlojd` only; env `ORLOJ_TOOL_CONTAINER_MAX_CPUS`. |
+| `--tool-container-max-pids-limit` | `0` | Operator ceiling for per-tool/McpServer `resources.pids_limit`. 0 means unbounded. | `orlojd` only; env `ORLOJ_TOOL_CONTAINER_MAX_PIDS_LIMIT`. |
 | `--tool-secret-env-prefix` | `ORLOJ_SECRET_` | Env prefix for tool `secretRef` resolution. | Env fallback: `ORLOJ_TOOL_SECRET_ENV_PREFIX`. |
 | `--tool-wasm-module` | empty | Default WASM module path (per-tool `spec.wasm.module` takes precedence). | Always available; env `ORLOJ_TOOL_WASM_MODULE`. |
 | `--tool-wasm-entrypoint` | `run` | Default WASM entrypoint function. | Always available; env `ORLOJ_TOOL_WASM_ENTRYPOINT`. |
@@ -155,9 +158,9 @@ Model routing (provider, base URL, default model, API key, timeout) is configure
 | `--tool-container-runtime` | `docker` | Container runtime binary. | Container backend; env `ORLOJ_TOOL_CONTAINER_RUNTIME`. |
 | `--tool-container-image` | `curlimages/curl:8.8.0` | Container image for isolated tool calls. | Container backend; env `ORLOJ_TOOL_CONTAINER_IMAGE`. |
 | `--tool-container-network` | `none` | Container network mode. | Container backend; env `ORLOJ_TOOL_CONTAINER_NETWORK`. |
-| `--tool-container-memory` | `128m` | Container memory limit. | Container backend; env `ORLOJ_TOOL_CONTAINER_MEMORY`. |
-| `--tool-container-cpus` | `0.50` | Container CPU limit. | Container backend; env `ORLOJ_TOOL_CONTAINER_CPUS`. |
-| `--tool-container-pids-limit` | `64` | Container PID limit. | Container backend; env `ORLOJ_TOOL_CONTAINER_PIDS_LIMIT`. |
+| `--tool-container-memory` | `128m` | Default container memory limit. Per-tool `spec.cli.resources.memory` takes precedence when set. | Container backend; env `ORLOJ_TOOL_CONTAINER_MEMORY`. |
+| `--tool-container-cpus` | `0.50` | Default container CPU limit. Per-tool `spec.cli.resources.cpus` takes precedence when set. | Container backend; env `ORLOJ_TOOL_CONTAINER_CPUS`. |
+| `--tool-container-pids-limit` | `64` | Default container PID limit. Per-tool `spec.cli.resources.pids_limit` takes precedence when set. | Container backend; env `ORLOJ_TOOL_CONTAINER_PIDS_LIMIT`. |
 | `--tool-container-user` | `65532:65532` | Container user. | Container backend; env `ORLOJ_TOOL_CONTAINER_USER`. |
 | `--tool-secret-env-prefix` | `ORLOJ_SECRET_` | Env prefix for tool `secretRef` resolution. | Env fallback: `ORLOJ_TOOL_SECRET_ENV_PREFIX`. |
 | `--tool-wasm-module` | empty | Default WASM module path (per-tool `spec.wasm.module` takes precedence). | Always available; env `ORLOJ_TOOL_WASM_MODULE`. |

--- a/openapi/schemas/mcp-server.yaml
+++ b/openapi/schemas/mcp-server.yaml
@@ -38,6 +38,7 @@ components:
         auth: { $ref: "tool.yaml#/components/schemas/ToolAuth" }
         tool_filter: { $ref: "#/components/schemas/McpToolFilter" }
         reconnect: { $ref: "#/components/schemas/McpReconnectPolicy" }
+        resources: { $ref: "tool.yaml#/components/schemas/ContainerResources" }
     McpServerStatus:
       type: object
       properties:

--- a/openapi/schemas/tool.yaml
+++ b/openapi/schemas/tool.yaml
@@ -30,6 +30,13 @@ components:
         name: { type: string }
         secretRef: { type: string }
         key: { type: string }
+    ContainerResources:
+      type: object
+      description: "Per-tool or per-McpServer container resource overrides. When set, these take precedence over global --tool-container-{memory,cpus,pids-limit} flags."
+      properties:
+        memory: { type: string, description: "Container memory limit (e.g. 128m, 1g). Overrides --tool-container-memory." }
+        cpus: { type: string, description: "Container CPU limit (e.g. 0.50, 1.0). Overrides --tool-container-cpus." }
+        pids_limit: { type: integer, description: "Container PIDs limit. Overrides --tool-container-pids-limit." }
     ToolCliSpec:
       type: object
       properties:
@@ -49,6 +56,7 @@ components:
         env_from:
           type: array
           items: { $ref: "#/components/schemas/ToolCliEnvRef" }
+        resources: { $ref: "#/components/schemas/ContainerResources" }
     ToolWasmSpec:
       type: object
       properties:

--- a/resources/container_resources.go
+++ b/resources/container_resources.go
@@ -1,0 +1,107 @@
+package resources
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseMemoryBytes converts a Docker-style memory string (e.g. "128m", "1g")
+// to bytes. Accepted suffixes: b, k, m, g (case-insensitive).
+// A bare integer is treated as bytes.
+func ParseMemoryBytes(s string) (int64, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return 0, fmt.Errorf("empty memory value")
+	}
+	multiplier := int64(1)
+	switch {
+	case strings.HasSuffix(s, "g"):
+		multiplier = 1024 * 1024 * 1024
+		s = strings.TrimSuffix(s, "g")
+	case strings.HasSuffix(s, "m"):
+		multiplier = 1024 * 1024
+		s = strings.TrimSuffix(s, "m")
+	case strings.HasSuffix(s, "k"):
+		multiplier = 1024
+		s = strings.TrimSuffix(s, "k")
+	case strings.HasSuffix(s, "b"):
+		s = strings.TrimSuffix(s, "b")
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid memory value %q: %w", s, err)
+	}
+	if v <= 0 {
+		return 0, fmt.Errorf("memory value must be positive, got %d", v)
+	}
+	return v * multiplier, nil
+}
+
+// ValidateContainerResources checks that the fields of a ContainerResources
+// struct are well-formed when set.
+func ValidateContainerResources(res ContainerResources, fieldPrefix string) error {
+	if mem := strings.TrimSpace(res.Memory); mem != "" {
+		if _, err := ParseMemoryBytes(mem); err != nil {
+			return fmt.Errorf("%s.memory: %w", fieldPrefix, err)
+		}
+	}
+	if cpus := strings.TrimSpace(res.CPUs); cpus != "" {
+		v, err := strconv.ParseFloat(cpus, 64)
+		if err != nil {
+			return fmt.Errorf("%s.cpus: invalid value %q: %w", fieldPrefix, cpus, err)
+		}
+		if v <= 0 {
+			return fmt.Errorf("%s.cpus: must be positive, got %s", fieldPrefix, cpus)
+		}
+	}
+	if res.PidsLimit < 0 {
+		return fmt.Errorf("%s.pids_limit: must be non-negative, got %d", fieldPrefix, res.PidsLimit)
+	}
+	return nil
+}
+
+// ContainerResourceCeiling defines operator-level upper bounds for per-tool
+// and per-McpServer container resource overrides. Zero/empty means unbounded.
+type ContainerResourceCeiling struct {
+	MaxMemory   string
+	MaxCPUs     string
+	MaxPidsLimit int
+}
+
+// EnforceContainerResourceCeiling checks that the given resources do not exceed
+// the operator ceiling. Returns a descriptive error when exceeded.
+func EnforceContainerResourceCeiling(res ContainerResources, ceiling ContainerResourceCeiling, resourceKind, resourceName string) error {
+	if mem := strings.TrimSpace(res.Memory); mem != "" && strings.TrimSpace(ceiling.MaxMemory) != "" {
+		requested, err := ParseMemoryBytes(mem)
+		if err != nil {
+			return fmt.Errorf("%s %q resources.memory: %w", resourceKind, resourceName, err)
+		}
+		max, err := ParseMemoryBytes(ceiling.MaxMemory)
+		if err != nil {
+			return fmt.Errorf("operator ceiling max-memory %q: %w", ceiling.MaxMemory, err)
+		}
+		if requested > max {
+			return fmt.Errorf("%s %q resources.memory (%s) exceeds operator limit (%s)", resourceKind, resourceName, mem, ceiling.MaxMemory)
+		}
+	}
+	if cpus := strings.TrimSpace(res.CPUs); cpus != "" && strings.TrimSpace(ceiling.MaxCPUs) != "" {
+		requested, err := strconv.ParseFloat(cpus, 64)
+		if err != nil {
+			return fmt.Errorf("%s %q resources.cpus: invalid value %q", resourceKind, resourceName, cpus)
+		}
+		max, err := strconv.ParseFloat(strings.TrimSpace(ceiling.MaxCPUs), 64)
+		if err != nil {
+			return fmt.Errorf("operator ceiling max-cpus %q: invalid", ceiling.MaxCPUs)
+		}
+		if requested > max {
+			return fmt.Errorf("%s %q resources.cpus (%s) exceeds operator limit (%s)", resourceKind, resourceName, cpus, ceiling.MaxCPUs)
+		}
+	}
+	if res.PidsLimit > 0 && ceiling.MaxPidsLimit > 0 {
+		if res.PidsLimit > ceiling.MaxPidsLimit {
+			return fmt.Errorf("%s %q resources.pids_limit (%d) exceeds operator limit (%d)", resourceKind, resourceName, res.PidsLimit, ceiling.MaxPidsLimit)
+		}
+	}
+	return nil
+}

--- a/resources/container_resources_test.go
+++ b/resources/container_resources_test.go
@@ -1,0 +1,227 @@
+package resources
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseMemoryBytes(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{"128m", 128 * 1024 * 1024, false},
+		{"1g", 1024 * 1024 * 1024, false},
+		{"512k", 512 * 1024, false},
+		{"1024b", 1024, false},
+		{"1024", 1024, false},
+		{"2G", 2 * 1024 * 1024 * 1024, false},
+		{"", 0, true},
+		{"abc", 0, true},
+		{"-1m", 0, true},
+		{"0m", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseMemoryBytes(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %d", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseMemoryBytes(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateContainerResources(t *testing.T) {
+	tests := []struct {
+		name    string
+		res     ContainerResources
+		wantErr string
+	}{
+		{"empty is valid", ContainerResources{}, ""},
+		{"valid memory", ContainerResources{Memory: "1g"}, ""},
+		{"valid cpus", ContainerResources{CPUs: "0.5"}, ""},
+		{"valid pids", ContainerResources{PidsLimit: 128}, ""},
+		{"all valid", ContainerResources{Memory: "256m", CPUs: "2.0", PidsLimit: 64}, ""},
+		{"bad memory", ContainerResources{Memory: "abc"}, "memory"},
+		{"bad cpus", ContainerResources{CPUs: "not-a-number"}, "cpus"},
+		{"zero cpus", ContainerResources{CPUs: "0"}, "cpus"},
+		{"negative cpus", ContainerResources{CPUs: "-1"}, "cpus"},
+		{"negative pids", ContainerResources{PidsLimit: -1}, "pids_limit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateContainerResources(tt.res, "test")
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEnforceContainerResourceCeiling(t *testing.T) {
+	tests := []struct {
+		name    string
+		res     ContainerResources
+		ceiling ContainerResourceCeiling
+		wantErr bool
+	}{
+		{"empty ceiling allows anything", ContainerResources{Memory: "64g"}, ContainerResourceCeiling{}, false},
+		{"within ceiling", ContainerResources{Memory: "512m"}, ContainerResourceCeiling{MaxMemory: "1g"}, false},
+		{"at ceiling", ContainerResources{Memory: "1g"}, ContainerResourceCeiling{MaxMemory: "1g"}, false},
+		{"exceeds memory", ContainerResources{Memory: "2g"}, ContainerResourceCeiling{MaxMemory: "1g"}, true},
+		{"exceeds cpus", ContainerResources{CPUs: "4.0"}, ContainerResourceCeiling{MaxCPUs: "2.0"}, true},
+		{"within cpus", ContainerResources{CPUs: "1.0"}, ContainerResourceCeiling{MaxCPUs: "2.0"}, false},
+		{"exceeds pids", ContainerResources{PidsLimit: 1024}, ContainerResourceCeiling{MaxPidsLimit: 512}, true},
+		{"within pids", ContainerResources{PidsLimit: 256}, ContainerResourceCeiling{MaxPidsLimit: 512}, false},
+		{"no manifest value, ceiling set", ContainerResources{}, ContainerResourceCeiling{MaxMemory: "1g", MaxCPUs: "2.0", MaxPidsLimit: 512}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := EnforceContainerResourceCeiling(tt.res, tt.ceiling, "Tool", "test-tool")
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseToolManifestCLIResources(t *testing.T) {
+	yaml := `apiVersion: orloj.dev/v1
+kind: Tool
+metadata:
+  name: browser-screenshot
+spec:
+  type: cli
+  description: Take a screenshot
+  cli:
+    command: screenshot
+    image: my-chromium:latest
+    network: bridge
+    resources:
+      memory: 1g
+      cpus: "1.0"
+      pids_limit: 256
+`
+	tool, err := ParseToolManifest([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if tool.Spec.Cli.Resources.Memory != "1g" {
+		t.Errorf("memory = %q, want %q", tool.Spec.Cli.Resources.Memory, "1g")
+	}
+	if tool.Spec.Cli.Resources.CPUs != "1.0" {
+		t.Errorf("cpus = %q, want %q", tool.Spec.Cli.Resources.CPUs, "1.0")
+	}
+	if tool.Spec.Cli.Resources.PidsLimit != 256 {
+		t.Errorf("pids_limit = %d, want %d", tool.Spec.Cli.Resources.PidsLimit, 256)
+	}
+}
+
+func TestParseToolManifestCLIResourcesJSON(t *testing.T) {
+	js := `{
+		"apiVersion": "orloj.dev/v1",
+		"kind": "Tool",
+		"metadata": {"name": "browser-screenshot"},
+		"spec": {
+			"type": "cli",
+			"cli": {
+				"command": "screenshot",
+				"image": "my-chromium:latest",
+				"resources": {
+					"memory": "2g",
+					"cpus": "0.75",
+					"pids_limit": 128
+				}
+			}
+		}
+	}`
+	tool, err := ParseToolManifest([]byte(js))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if tool.Spec.Cli.Resources.Memory != "2g" {
+		t.Errorf("memory = %q, want %q", tool.Spec.Cli.Resources.Memory, "2g")
+	}
+	if tool.Spec.Cli.Resources.CPUs != "0.75" {
+		t.Errorf("cpus = %q, want %q", tool.Spec.Cli.Resources.CPUs, "0.75")
+	}
+	if tool.Spec.Cli.Resources.PidsLimit != 128 {
+		t.Errorf("pids_limit = %d, want %d", tool.Spec.Cli.Resources.PidsLimit, 128)
+	}
+}
+
+func TestParseMcpServerManifestResources(t *testing.T) {
+	yaml := `apiVersion: orloj.dev/v1
+kind: McpServer
+metadata:
+  name: playwright-mcp
+spec:
+  transport: stdio
+  image: playwright-mcp:latest
+  resources:
+    memory: 1g
+    cpus: "2.0"
+    pids_limit: 512
+`
+	server, err := ParseMcpServerManifest([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if server.Spec.Resources.Memory != "1g" {
+		t.Errorf("memory = %q, want %q", server.Spec.Resources.Memory, "1g")
+	}
+	if server.Spec.Resources.CPUs != "2.0" {
+		t.Errorf("cpus = %q, want %q", server.Spec.Resources.CPUs, "2.0")
+	}
+	if server.Spec.Resources.PidsLimit != 512 {
+		t.Errorf("pids_limit = %d, want %d", server.Spec.Resources.PidsLimit, 512)
+	}
+}
+
+func TestParseMcpServerManifestResourcesJSON(t *testing.T) {
+	js := `{
+		"apiVersion": "orloj.dev/v1",
+		"kind": "McpServer",
+		"metadata": {"name": "playwright-mcp"},
+		"spec": {
+			"transport": "stdio",
+			"image": "playwright-mcp:latest",
+			"resources": {
+				"memory": "512m",
+				"pids_limit": 256
+			}
+		}
+	}`
+	server, err := ParseMcpServerManifest([]byte(js))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if server.Spec.Resources.Memory != "512m" {
+		t.Errorf("memory = %q, want %q", server.Spec.Resources.Memory, "512m")
+	}
+	if server.Spec.Resources.PidsLimit != 256 {
+		t.Errorf("pids_limit = %d, want %d", server.Spec.Resources.PidsLimit, 256)
+	}
+}

--- a/resources/manifest_parser_completeness_test.go
+++ b/resources/manifest_parser_completeness_test.go
@@ -299,6 +299,10 @@ spec:
       - name: API_KEY
         secretRef: my-secret
         key: api-key
+    resources:
+      memory: 512m
+      cpus: "1.0"
+      pids_limit: 256
 `)
 
 // Tool HTTP fixture — exercises auth and wasm fields.
@@ -413,6 +417,10 @@ spec:
   reconnect:
     max_attempts: 5
     backoff: 2s
+  resources:
+    memory: 1g
+    cpus: "2.0"
+    pids_limit: 512
 `)
 
 var agentPolicyMaximalYAML = []byte(`apiVersion: orloj.dev/v1

--- a/resources/manifest_parser_ext.go
+++ b/resources/manifest_parser_ext.go
@@ -571,6 +571,10 @@ func ParseToolManifest(data []byte) (Tool, error) {
 				if section == "spec" && subsection == "cli" {
 					runtimeSubsection = "env_from"
 				}
+			case "resources":
+				if section == "spec" && subsection == "cli" {
+					runtimeSubsection = "resources"
+				}
 			}
 			continue
 		}
@@ -693,6 +697,16 @@ func ParseToolManifest(data []byte) (Tool, error) {
 			out.Spec.Cli.ImagePullSecret = value
 		case section == "spec" && subsection == "cli" && runtimeSubsection == "" && (key == "stdin_from_input" || key == "stdinFromInput"):
 			out.Spec.Cli.StdinFromInput = strings.EqualFold(value, "true")
+		case section == "spec" && subsection == "cli" && runtimeSubsection == "resources" && key == "memory":
+			out.Spec.Cli.Resources.Memory = value
+		case section == "spec" && subsection == "cli" && runtimeSubsection == "resources" && key == "cpus":
+			out.Spec.Cli.Resources.CPUs = value
+		case section == "spec" && subsection == "cli" && runtimeSubsection == "resources" && (key == "pids_limit" || key == "pidsLimit"):
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return Tool{}, fmt.Errorf("invalid spec.cli.resources.pids_limit value %q", value)
+			}
+			out.Spec.Cli.Resources.PidsLimit = v
 		case section == "spec" && subsection == "wasm" && key == "module":
 			out.Spec.Wasm.Module = value
 		case section == "spec" && subsection == "wasm" && key == "entrypoint":
@@ -2274,6 +2288,10 @@ func ParseMcpServerManifest(data []byte) (McpServer, error) {
 				if section == "spec" {
 					subsection = "reconnect"
 				}
+			case "resources":
+				if section == "spec" {
+					subsection = "resources"
+				}
 			}
 			continue
 		}
@@ -2350,6 +2368,16 @@ func ParseMcpServerManifest(data []byte) (McpServer, error) {
 			out.Spec.Reconnect.MaxAttempts = v
 		case section == "spec" && subsection == "reconnect" && key == "backoff":
 			out.Spec.Reconnect.Backoff = value
+		case section == "spec" && subsection == "resources" && key == "memory":
+			out.Spec.Resources.Memory = value
+		case section == "spec" && subsection == "resources" && key == "cpus":
+			out.Spec.Resources.CPUs = value
+		case section == "spec" && subsection == "resources" && (key == "pids_limit" || key == "pidsLimit"):
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return McpServer{}, fmt.Errorf("invalid spec.resources.pids_limit value %q", value)
+			}
+			out.Spec.Resources.PidsLimit = v
 		case section == "spec" && subsection == "env" && indent >= 6:
 			if len(out.Spec.Env) > 0 {
 				last := &out.Spec.Env[len(out.Spec.Env)-1]

--- a/resources/resource_types.go
+++ b/resources/resource_types.go
@@ -382,18 +382,28 @@ type ToolWasmSpec struct {
 	ImagePullSecret string `json:"image_pull_secret,omitempty"`
 }
 
+// ContainerResources defines per-tool or per-McpServer container resource
+// overrides. When set, these take precedence over the global
+// --tool-container-{memory,cpus,pids-limit} flags.
+type ContainerResources struct {
+	Memory    string `json:"memory,omitempty"`
+	CPUs      string `json:"cpus,omitempty"`
+	PidsLimit int    `json:"pids_limit,omitempty"`
+}
+
 // ToolCliSpec defines the configuration for CLI tool invocations.
 type ToolCliSpec struct {
-	Command        string            `json:"command,omitempty"`
-	Args           []string          `json:"args,omitempty"`
-	Image          string            `json:"image,omitempty"`
-	ImagePullSecret string           `json:"image_pull_secret,omitempty"`
-	Network        string            `json:"network,omitempty"`
-	StdinFromInput bool              `json:"stdin_from_input,omitempty"`
-	Output         string            `json:"output,omitempty"`
-	WorkingDir     string            `json:"working_dir,omitempty"`
-	Env            map[string]string `json:"env,omitempty"`
-	EnvFrom        []ToolCliEnvRef   `json:"env_from,omitempty"`
+	Command         string             `json:"command,omitempty"`
+	Args            []string           `json:"args,omitempty"`
+	Image           string             `json:"image,omitempty"`
+	ImagePullSecret string             `json:"image_pull_secret,omitempty"`
+	Network         string             `json:"network,omitempty"`
+	StdinFromInput  bool               `json:"stdin_from_input,omitempty"`
+	Output          string             `json:"output,omitempty"`
+	WorkingDir      string             `json:"working_dir,omitempty"`
+	Env             map[string]string  `json:"env,omitempty"`
+	EnvFrom         []ToolCliEnvRef    `json:"env_from,omitempty"`
+	Resources       ContainerResources `json:"resources,omitempty"`
 }
 
 // ToolCliEnvRef maps an Orloj secret to a process environment variable.
@@ -2214,6 +2224,7 @@ type McpServerSpec struct {
 	Auth            ToolAuth           `json:"auth,omitempty"`
 	ToolFilter      McpToolFilter      `json:"tool_filter,omitempty"`
 	Reconnect       McpReconnectPolicy `json:"reconnect,omitempty"`
+	Resources       ContainerResources `json:"resources,omitempty"`
 }
 
 type McpServerEnvVar struct {

--- a/runtime/mcp_session.go
+++ b/runtime/mcp_session.go
@@ -283,14 +283,26 @@ func (m *McpSessionManager) buildContainerStdioTransport(server resources.McpSer
 	} else {
 		dockerArgs = append(dockerArgs, "--network", "bridge")
 	}
-	if cfg != nil && strings.TrimSpace(cfg.Memory) != "" {
-		dockerArgs = append(dockerArgs, "--memory", strings.TrimSpace(cfg.Memory))
+	memory := strings.TrimSpace(server.Spec.Resources.Memory)
+	if memory == "" && cfg != nil {
+		memory = strings.TrimSpace(cfg.Memory)
 	}
-	if cfg != nil && strings.TrimSpace(cfg.CPUs) != "" {
-		dockerArgs = append(dockerArgs, "--cpus", strings.TrimSpace(cfg.CPUs))
+	if memory != "" {
+		dockerArgs = append(dockerArgs, "--memory", memory)
 	}
-	if cfg != nil && cfg.PidsLimit > 0 {
-		dockerArgs = append(dockerArgs, "--pids-limit", fmt.Sprintf("%d", cfg.PidsLimit))
+	cpus := strings.TrimSpace(server.Spec.Resources.CPUs)
+	if cpus == "" && cfg != nil {
+		cpus = strings.TrimSpace(cfg.CPUs)
+	}
+	if cpus != "" {
+		dockerArgs = append(dockerArgs, "--cpus", cpus)
+	}
+	pidsLimit := server.Spec.Resources.PidsLimit
+	if pidsLimit <= 0 && cfg != nil {
+		pidsLimit = cfg.PidsLimit
+	}
+	if pidsLimit > 0 {
+		dockerArgs = append(dockerArgs, "--pids-limit", fmt.Sprintf("%d", pidsLimit))
 	}
 
 	var cleanupDir string

--- a/runtime/tool_runtime_container.go
+++ b/runtime/tool_runtime_container.go
@@ -443,14 +443,26 @@ func (r *ContainerToolRuntime) containerCLIRunArgs(cli resources.ToolCliSpec, im
 	if strings.TrimSpace(r.config.User) != "" {
 		dockerArgs = append(dockerArgs, "--user", strings.TrimSpace(r.config.User))
 	}
-	if strings.TrimSpace(r.config.Memory) != "" {
-		dockerArgs = append(dockerArgs, "--memory", strings.TrimSpace(r.config.Memory))
+	memory := strings.TrimSpace(cli.Resources.Memory)
+	if memory == "" {
+		memory = strings.TrimSpace(r.config.Memory)
 	}
-	if strings.TrimSpace(r.config.CPUs) != "" {
-		dockerArgs = append(dockerArgs, "--cpus", strings.TrimSpace(r.config.CPUs))
+	if memory != "" {
+		dockerArgs = append(dockerArgs, "--memory", memory)
 	}
-	if r.config.PidsLimit > 0 {
-		dockerArgs = append(dockerArgs, "--pids-limit", strconv.Itoa(r.config.PidsLimit))
+	cpus := strings.TrimSpace(cli.Resources.CPUs)
+	if cpus == "" {
+		cpus = strings.TrimSpace(r.config.CPUs)
+	}
+	if cpus != "" {
+		dockerArgs = append(dockerArgs, "--cpus", cpus)
+	}
+	pidsLimit := cli.Resources.PidsLimit
+	if pidsLimit <= 0 {
+		pidsLimit = r.config.PidsLimit
+	}
+	if pidsLimit > 0 {
+		dockerArgs = append(dockerArgs, "--pids-limit", strconv.Itoa(pidsLimit))
 	}
 	if strings.TrimSpace(cli.WorkingDir) != "" {
 		dockerArgs = append(dockerArgs, "--workdir", strings.TrimSpace(cli.WorkingDir))

--- a/runtime/tool_runtime_container_test.go
+++ b/runtime/tool_runtime_container_test.go
@@ -427,6 +427,74 @@ func TestContainerToolRuntimeWithNamespaceRebindsAuthSecretResolver(t *testing.T
 	}
 }
 
+func TestContainerCLIRunArgsPerToolResourcesOverrideGlobalConfig(t *testing.T) {
+	globalCfg := ContainerToolRuntimeConfig{
+		RuntimeBinary: "docker",
+		Image:         "default:latest",
+		Network:       "none",
+		Memory:        "128m",
+		CPUs:          "0.50",
+		PidsLimit:     64,
+		User:          "65532:65532",
+	}
+	crt := NewContainerToolRuntimeWithRunner(nil, globalCfg, &captureContainerRunner{stdout: "ok"})
+
+	cli := resources.ToolCliSpec{
+		Command: "screenshot",
+		Image:   "my-chromium:latest",
+		Network: "bridge",
+		Resources: resources.ContainerResources{
+			Memory:    "1g",
+			CPUs:      "2.0",
+			PidsLimit: 256,
+		},
+	}
+	args := crt.containerCLIRunArgs(cli, cli.Image, cli.Command, nil, nil)
+
+	assertArgsContain(t, args, []string{
+		"--memory", "1g",
+		"--cpus", "2.0",
+		"--pids-limit", "256",
+		"--network", "bridge",
+	})
+	for i, arg := range args {
+		if arg == "--memory" && i+1 < len(args) && args[i+1] == "128m" {
+			t.Fatal("per-tool memory should override global 128m")
+		}
+		if arg == "--cpus" && i+1 < len(args) && args[i+1] == "0.50" {
+			t.Fatal("per-tool cpus should override global 0.50")
+		}
+		if arg == "--pids-limit" && i+1 < len(args) && args[i+1] == "64" {
+			t.Fatal("per-tool pids_limit should override global 64")
+		}
+	}
+}
+
+func TestContainerCLIRunArgsFallsBackToGlobalConfig(t *testing.T) {
+	globalCfg := ContainerToolRuntimeConfig{
+		RuntimeBinary: "docker",
+		Image:         "default:latest",
+		Network:       "none",
+		Memory:        "128m",
+		CPUs:          "0.50",
+		PidsLimit:     64,
+		User:          "65532:65532",
+	}
+	crt := NewContainerToolRuntimeWithRunner(nil, globalCfg, &captureContainerRunner{stdout: "ok"})
+
+	cli := resources.ToolCliSpec{
+		Command: "curl",
+		Image:   "curlimages/curl:latest",
+	}
+	args := crt.containerCLIRunArgs(cli, cli.Image, cli.Command, nil, nil)
+
+	assertArgsContain(t, args, []string{
+		"--memory", "128m",
+		"--cpus", "0.50",
+		"--pids-limit", "64",
+	})
+}
+
 func assertArgsContain(t *testing.T, args []string, expected []string) {
 	t.Helper()
 	for i := 0; i < len(expected); i++ {


### PR DESCRIPTION
Add spec.cli.resources and spec.resources (memory, cpus, pids_limit) with CLI defaults as fallback
Prefer manifest values in container CLI + MCP stdio transport
Enforce operator ceilings via --tool-container-max-{memory,cpus,pids-limit} on orlojd at apply time

