### PR TITLE
Add provider-level prompt caching for Anthropic and Bedrock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Per-tool and per-McpServer container resource limits**: Tool manifests now support `spec.cli.resources` and McpServer manifests support `spec.resources` with `memory`, `cpus`, and `pids_limit` fields that override the global `--tool-container-{memory,cpus,pids-limit}` defaults. This allows resource-intensive tools (e.g. Chromium-based MCP servers) to declare their own container limits without raising the global defaults for all tools. Operator-level ceilings (`--tool-container-max-memory`, `--tool-container-max-cpus`, `--tool-container-max-pids-limit`) can optionally cap per-tool overrides; manifests exceeding the ceiling are rejected at apply time.
+- **Provider-level prompt caching for Anthropic and Bedrock**: The Anthropic gateway now sends `cache_control` markers on system messages and tool definitions, enabling Anthropic's server-side prompt caching (up to 90% input token cost reduction on cached prefixes). The Bedrock gateway appends `cachePoint` blocks to system content and tool configurations for equivalent savings when using Claude models via AWS Bedrock. No configuration required — caching hints are sent automatically on all requests.
 
 ## [0.12.1] - 2026-05-03
 

--- a/runtime/model_gateway_anthropic.go
+++ b/runtime/model_gateway_anthropic.go
@@ -127,8 +127,12 @@ func (g *AnthropicModelGateway) Complete(ctx context.Context, req ModelRequest) 
 			Role:    "user",
 			Content: buildOpenAIUserContent(req),
 		}}
-		if strings.TrimSpace(req.Prompt) != "" {
-			body.System = strings.TrimSpace(req.Prompt)
+		if prompt := strings.TrimSpace(req.Prompt); prompt != "" {
+			body.System = []anthropicSystemBlock{{
+				Type:         "text",
+				Text:         prompt,
+				CacheControl: &anthropicCacheControl{Type: "ephemeral"},
+			}}
 		}
 	}
 	toolAliases := make(map[string]string, len(req.Tools))
@@ -240,11 +244,21 @@ func parseAnthropicError(body []byte) string {
 
 type anthropicMessagesRequest struct {
 	Model        string                   `json:"model"`
-	System       string                   `json:"system,omitempty"`
+	System       []anthropicSystemBlock   `json:"system,omitempty"`
 	Messages     []anthropicMessagesInput `json:"messages"`
 	MaxTokens    int                      `json:"max_tokens"`
 	Tools        []anthropicToolSpec      `json:"tools,omitempty"`
 	OutputConfig *anthropicOutputConfig   `json:"output_config,omitempty"`
+}
+
+type anthropicSystemBlock struct {
+	Type         string                 `json:"type"`
+	Text         string                 `json:"text"`
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
+}
+
+type anthropicCacheControl struct {
+	Type string `json:"type"`
 }
 
 type anthropicOutputConfig struct {
@@ -287,9 +301,10 @@ type anthropicMessagesUsage struct {
 }
 
 type anthropicToolSpec struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description,omitempty"`
-	InputSchema map[string]any `json:"input_schema,omitempty"`
+	Name         string                 `json:"name"`
+	Description  string                 `json:"description,omitempty"`
+	InputSchema  map[string]any         `json:"input_schema,omitempty"`
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
 }
 
 func buildAnthropicTools(toolNames []string, schemas map[string]ToolSchemaInfo) ([]anthropicToolSpec, map[string]string) {
@@ -332,6 +347,9 @@ func buildAnthropicTools(toolNames []string, schemas map[string]ToolSchemaInfo) 
 			InputSchema: inputSchema,
 		})
 	}
+	if len(out) > 0 {
+		out[len(out)-1].CacheControl = &anthropicCacheControl{Type: "ephemeral"}
+	}
 	return out, aliases
 }
 
@@ -359,8 +377,8 @@ func parseAnthropicToolUseInput(input map[string]any) string {
 	return strings.TrimSpace(string(encoded))
 }
 
-func chatMessagesToAnthropic(msgs []ChatMessage) (string, []anthropicMessagesInput) {
-	var system string
+func chatMessagesToAnthropic(msgs []ChatMessage) ([]anthropicSystemBlock, []anthropicMessagesInput) {
+	var systemBlocks []anthropicSystemBlock
 	out := make([]anthropicMessagesInput, 0, len(msgs))
 	for _, m := range msgs {
 		role := strings.TrimSpace(m.Role)
@@ -370,11 +388,10 @@ func chatMessagesToAnthropic(msgs []ChatMessage) (string, []anthropicMessagesInp
 			if content == "" {
 				continue
 			}
-			if system == "" {
-				system = content
-			} else {
-				system += "\n" + content
-			}
+			systemBlocks = append(systemBlocks, anthropicSystemBlock{
+				Type: "text",
+				Text: content,
+			})
 			continue
 		}
 
@@ -433,7 +450,10 @@ func chatMessagesToAnthropic(msgs []ChatMessage) (string, []anthropicMessagesInp
 			Content: content,
 		})
 	}
-	return system, out
+	if len(systemBlocks) > 0 {
+		systemBlocks[len(systemBlocks)-1].CacheControl = &anthropicCacheControl{Type: "ephemeral"}
+	}
+	return systemBlocks, out
 }
 
 func parseJSONLoose(s string) map[string]interface{} {

--- a/runtime/model_gateway_anthropic_test.go
+++ b/runtime/model_gateway_anthropic_test.go
@@ -14,8 +14,14 @@ import (
 func TestAnthropicModelGatewayCompleteSuccess(t *testing.T) {
 	type capturedRequest struct {
 		Model     string `json:"model"`
-		System    string `json:"system"`
-		MaxTokens int    `json:"max_tokens"`
+		System    []struct {
+			Type         string `json:"type"`
+			Text         string `json:"text"`
+			CacheControl *struct {
+				Type string `json:"type"`
+			} `json:"cache_control,omitempty"`
+		} `json:"system"`
+		MaxTokens int `json:"max_tokens"`
 		Messages  []struct {
 			Role    string `json:"role"`
 			Content string `json:"content"`
@@ -93,8 +99,11 @@ func TestAnthropicModelGatewayCompleteSuccess(t *testing.T) {
 	if captured.Model != "claude-test" {
 		t.Fatalf("expected model claude-test, got %q", captured.Model)
 	}
-	if captured.System != "You are a planner." {
-		t.Fatalf("expected system prompt, got %q", captured.System)
+	if len(captured.System) != 1 || captured.System[0].Text != "You are a planner." {
+		t.Fatalf("expected system block with text 'You are a planner.', got %+v", captured.System)
+	}
+	if captured.System[0].CacheControl == nil || captured.System[0].CacheControl.Type != "ephemeral" {
+		t.Fatal("expected cache_control ephemeral on system block")
 	}
 	if captured.MaxTokens != 2048 {
 		t.Fatalf("expected max_tokens 2048, got %d", captured.MaxTokens)
@@ -211,7 +220,10 @@ func TestAnthropicModelGatewayCompleteRequestFailure(t *testing.T) {
 func TestAnthropicModelGatewayCompleteToolCallResponse(t *testing.T) {
 	type capturedRequest struct {
 		Tools []struct {
-			Name string `json:"name"`
+			Name         string `json:"name"`
+			CacheControl *struct {
+				Type string `json:"type"`
+			} `json:"cache_control,omitempty"`
 		} `json:"tools"`
 	}
 
@@ -257,6 +269,9 @@ func TestAnthropicModelGatewayCompleteToolCallResponse(t *testing.T) {
 	if len(captured.Tools) != 1 || captured.Tools[0].Name != "web_search" {
 		t.Fatalf("expected request tools payload, got %+v", captured.Tools)
 	}
+	if captured.Tools[0].CacheControl == nil || captured.Tools[0].CacheControl.Type != "ephemeral" {
+		t.Fatal("expected cache_control ephemeral on last tool")
+	}
 	if len(resp.ToolCalls) != 1 {
 		t.Fatalf("expected one tool call, got %d", len(resp.ToolCalls))
 	}
@@ -271,7 +286,10 @@ func TestAnthropicModelGatewayCompleteToolCallResponse(t *testing.T) {
 func TestAnthropicModelGatewayCompleteMapsToolAliasesBackToRuntimeNames(t *testing.T) {
 	type capturedRequest struct {
 		Tools []struct {
-			Name string `json:"name"`
+			Name         string `json:"name"`
+			CacheControl *struct {
+				Type string `json:"type"`
+			} `json:"cache_control,omitempty"`
 		} `json:"tools"`
 	}
 
@@ -336,9 +354,12 @@ func TestChatMessagesToAnthropicStructuredToolMessages(t *testing.T) {
 		{Role: "user", Content: "step=2"},
 	}
 
-	system, anthropicMsgs := chatMessagesToAnthropic(msgs)
-	if system != "be helpful" {
-		t.Fatalf("expected system=be helpful, got %q", system)
+	systemBlocks, anthropicMsgs := chatMessagesToAnthropic(msgs)
+	if len(systemBlocks) != 1 || systemBlocks[0].Text != "be helpful" {
+		t.Fatalf("expected single system block with text 'be helpful', got %+v", systemBlocks)
+	}
+	if systemBlocks[0].CacheControl == nil || systemBlocks[0].CacheControl.Type != "ephemeral" {
+		t.Fatal("expected cache_control ephemeral on last system block")
 	}
 	if len(anthropicMsgs) != 4 {
 		t.Fatalf("expected 4 messages (user, assistant, user-tool-result, user), got %d", len(anthropicMsgs))
@@ -397,8 +418,8 @@ func TestChatMessagesToAnthropicErrorToolResult(t *testing.T) {
 	}
 
 	system, anthropicMsgs := chatMessagesToAnthropic(msgs)
-	if system != "" {
-		t.Fatalf("expected empty system, got %q", system)
+	if len(system) != 0 {
+		t.Fatalf("expected empty system blocks, got %+v", system)
 	}
 	if len(anthropicMsgs) != 5 {
 		t.Fatalf("expected 5 messages (user, assistant, tool-result, tool-error-result, user), got %d", len(anthropicMsgs))

--- a/runtime/model_gateway_bedrock.go
+++ b/runtime/model_gateway_bedrock.go
@@ -134,13 +134,18 @@ func (g *BedrockModelGateway) Complete(ctx context.Context, req ModelRequest) (M
 		},
 	}
 	if len(system) > 0 {
-		input.System = system
+		input.System = append(system, &types.SystemContentBlockMemberCachePoint{
+			Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+		})
 	}
 
 	toolAliases := make(map[string]string, len(req.Tools))
 	if len(req.Tools) > 0 {
 		tools, aliases := buildBedrockTools(req.Tools, req.ToolSchemas)
 		toolAliases = aliases
+		tools = append(tools, &types.ToolMemberCachePoint{
+			Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+		})
 		input.ToolConfig = &types.ToolConfiguration{Tools: tools}
 	}
 

--- a/runtime/model_gateway_bedrock_test.go
+++ b/runtime/model_gateway_bedrock_test.go
@@ -70,12 +70,15 @@ func TestBedrockModelGatewayCompleteBasicText(t *testing.T) {
 	if aws.ToString(capturedInput.ModelId) != "anthropic.claude-3-5-sonnet-20241022-v2:0" {
 		t.Fatalf("unexpected model: %q", aws.ToString(capturedInput.ModelId))
 	}
-	if len(capturedInput.System) != 1 {
-		t.Fatalf("expected 1 system block, got %d", len(capturedInput.System))
+	if len(capturedInput.System) != 2 {
+		t.Fatalf("expected 2 system blocks (text + cache point), got %d", len(capturedInput.System))
 	}
 	sysBlock, ok := capturedInput.System[0].(*types.SystemContentBlockMemberText)
 	if !ok || sysBlock.Value != "You are a planner." {
 		t.Fatalf("unexpected system block: %+v", capturedInput.System[0])
+	}
+	if _, ok := capturedInput.System[1].(*types.SystemContentBlockMemberCachePoint); !ok {
+		t.Fatalf("expected cache point as last system block, got %T", capturedInput.System[1])
 	}
 }
 
@@ -139,8 +142,8 @@ func TestBedrockModelGatewayCompleteMultiTurn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("complete failed: %v", err)
 	}
-	if len(capturedInput.System) != 1 {
-		t.Fatalf("expected 1 system block, got %d", len(capturedInput.System))
+	if len(capturedInput.System) != 2 {
+		t.Fatalf("expected 2 system blocks (text + cache point), got %d", len(capturedInput.System))
 	}
 	if len(capturedInput.Messages) != 3 {
 		t.Fatalf("expected 3 messages (user, assistant, user), got %d", len(capturedInput.Messages))
@@ -184,8 +187,8 @@ func TestBedrockModelGatewayCompleteSystemPromptExtraction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("complete failed: %v", err)
 	}
-	if len(capturedInput.System) != 2 {
-		t.Fatalf("expected 2 system blocks, got %d", len(capturedInput.System))
+	if len(capturedInput.System) != 3 {
+		t.Fatalf("expected 3 system blocks (2 text + cache point), got %d", len(capturedInput.System))
 	}
 	sys0, ok := capturedInput.System[0].(*types.SystemContentBlockMemberText)
 	if !ok || sys0.Value != "first system" {
@@ -194,6 +197,9 @@ func TestBedrockModelGatewayCompleteSystemPromptExtraction(t *testing.T) {
 	sys1, ok := capturedInput.System[1].(*types.SystemContentBlockMemberText)
 	if !ok || sys1.Value != "second system" {
 		t.Fatalf("unexpected second system block")
+	}
+	if _, ok := capturedInput.System[2].(*types.SystemContentBlockMemberCachePoint); !ok {
+		t.Fatalf("expected cache point as last system block, got %T", capturedInput.System[2])
 	}
 	if len(capturedInput.Messages) != 1 {
 		t.Fatalf("expected 1 message (system stripped), got %d", len(capturedInput.Messages))
@@ -239,8 +245,11 @@ func TestBedrockModelGatewayCompleteToolUseResponse(t *testing.T) {
 	if capturedInput.ToolConfig == nil {
 		t.Fatal("expected tool config in request")
 	}
-	if len(capturedInput.ToolConfig.Tools) != 1 {
-		t.Fatalf("expected 1 tool, got %d", len(capturedInput.ToolConfig.Tools))
+	if len(capturedInput.ToolConfig.Tools) != 2 {
+		t.Fatalf("expected 2 tools (spec + cache point), got %d", len(capturedInput.ToolConfig.Tools))
+	}
+	if _, ok := capturedInput.ToolConfig.Tools[1].(*types.ToolMemberCachePoint); !ok {
+		t.Fatalf("expected cache point as last tool, got %T", capturedInput.ToolConfig.Tools[1])
 	}
 	if len(resp.ToolCalls) != 1 {
 		t.Fatalf("expected 1 tool call, got %d", len(resp.ToolCalls))
@@ -262,9 +271,9 @@ func TestBedrockModelGatewayCompleteToolUseResponse(t *testing.T) {
 func TestBedrockModelGatewayCompleteMapsToolAliases(t *testing.T) {
 	mock := &mockBedrockClient{
 		converseFunc: func(_ context.Context, params *bedrockruntime.ConverseInput, _ ...func(*bedrockruntime.Options)) (*bedrockruntime.ConverseOutput, error) {
-			// Verify the tool was sent with the sanitized name
-			if params.ToolConfig == nil || len(params.ToolConfig.Tools) != 1 {
-				return nil, fmt.Errorf("expected 1 tool")
+			// Verify the tool was sent with the sanitized name (first entry before cache point)
+			if params.ToolConfig == nil || len(params.ToolConfig.Tools) < 1 {
+				return nil, fmt.Errorf("expected at least 1 tool")
 			}
 			spec, ok := params.ToolConfig.Tools[0].(*types.ToolMemberToolSpec)
 			if !ok {


### PR DESCRIPTION
Enable server-side prompt caching by sending cache_control markers (Anthropic) and cachePoint blocks (Bedrock) on system messages and tool definitions. This reduces input token costs by up to 90% on cached prefixes in multi-step agent executions with no behavior change.


