### PR TITLE
fix(runtime): Anthropic compatibility, agent loop, and container defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Relaxed container isolation defaults**: MCP server and tool runtime containers no longer apply `--read-only`, `--cap-drop=ALL`, or `--security-opt no-new-privileges`. The container boundary, resource limits, and network controls remain the primary isolation mechanism. This improves compatibility with images that require writable filesystems or Linux capabilities (e.g. Chromium-based MCP servers).
+- **Anthropic API timeout increased**: HTTP timeout for Anthropic API calls raised from 30s to 120s to prevent timeouts on large contexts.
+
+### Fixed
+
+- **Anthropic consecutive user messages**: Tool result and text messages with the same `user` role are now merged into a single message, fixing `400` errors from the Anthropic Messages API.
+- **Empty Anthropic content handling**: When Anthropic returns 200 OK with an empty content array, the agent worker now completes gracefully instead of erroring with "model response missing message content" and retrying indefinitely.
+- **Agent worker termination on empty output**: The agent loop now stops when no tools are available and the model produces no output, preventing infinite loops.
+
 ## [0.13.0] - 2026-05-05
 
 ### Added

--- a/runtime/agent_worker.go
+++ b/runtime/agent_worker.go
@@ -203,15 +203,22 @@ func (w *AgentWorker) Run(ctx context.Context) {
 				Messages:     append([]ChatMessage(nil), w.history...),
 				OutputSchema: w.agent.Spec.Execution.OutputSchema,
 			})
-			modelLatencyMS := time.Since(modelStart).Milliseconds()
-			if modelErr != nil {
-				if w.onEvent != nil {
-					w.onEvent(fmt.Sprintf("step=%d model_error=%v latency_ms=%d", step, modelErr, modelLatencyMS))
-				}
-				w.history = w.history[:len(w.history)-1]
-				continue
+		modelLatencyMS := time.Since(modelStart).Milliseconds()
+		if modelErr != nil {
+			if w.onEvent != nil {
+				w.onEvent(fmt.Sprintf("step=%d model_error=%v latency_ms=%d", step, modelErr, modelLatencyMS))
 			}
-			modelOutput := strings.TrimSpace(modelResp.Content)
+			w.history = w.history[:len(w.history)-1]
+			continue
+		}
+		if modelResp.Done && modelResp.Content == "" && len(modelResp.ToolCalls) == 0 {
+			if w.onEvent != nil {
+				w.onEvent(fmt.Sprintf("step=%d model signaled done with no output", step))
+				w.onEvent("worker completed")
+			}
+			return
+		}
+		modelOutput := strings.TrimSpace(modelResp.Content)
 			modelUsage := normalizeModelUsageWithFallback(modelResp.Usage, w.agent, modelResp, step)
 			if w.onEvent != nil {
 				w.onEvent(fmt.Sprintf(
@@ -267,7 +274,11 @@ func (w *AgentWorker) Run(ctx context.Context) {
 					}
 					return
 				}
-				continue
+				if w.onEvent != nil {
+					w.onEvent(fmt.Sprintf("step=%d no tools and no output, completing", step))
+					w.onEvent("worker completed")
+				}
+				return
 			}
 
 			requestedCalls, selectErr := selectAuthorizedToolCalls(modelResp, w.agent.Spec.Tools)

--- a/runtime/mcp_session.go
+++ b/runtime/mcp_session.go
@@ -272,10 +272,6 @@ func (m *McpSessionManager) buildContainerStdioTransport(server resources.McpSer
 	image := strings.TrimSpace(server.Spec.Image)
 	dockerArgs := []string{
 		"run", "--rm", "-i",
-		"--read-only",
-		"--tmpfs", "/tmp:rw,noexec,nosuid",
-		"--cap-drop=ALL",
-		"--security-opt", "no-new-privileges",
 	}
 
 	if cfg != nil && strings.TrimSpace(cfg.Network) != "" {

--- a/runtime/model_gateway_anthropic.go
+++ b/runtime/model_gateway_anthropic.go
@@ -28,7 +28,7 @@ func DefaultAnthropicModelGatewayConfig() AnthropicModelGatewayConfig {
 		BaseURL:          "https://api.anthropic.com/v1",
 		AnthropicVersion: "2023-06-01",
 		MaxTokens:        1024,
-		Timeout:          30 * time.Second,
+		Timeout:          120 * time.Second,
 	}
 }
 
@@ -221,7 +221,11 @@ func (g *AnthropicModelGateway) Complete(ctx context.Context, req ModelRequest) 
 	}
 	content := strings.TrimSpace(strings.Join(texts, "\n"))
 	if content == "" && len(toolCalls) == 0 {
-		return ModelResponse{}, fmt.Errorf("model response missing message content")
+		return ModelResponse{
+			Content: "",
+			Done:    true,
+			Usage:   parseAnthropicUsage(parsed.Usage),
+		}, nil
 	}
 	return ModelResponse{
 		Content:   content,
@@ -431,10 +435,14 @@ func chatMessagesToAnthropic(msgs []ChatMessage) ([]anthropicSystemBlock, []anth
 			if m.IsError {
 				block["is_error"] = true
 			}
-			out = append(out, anthropicMessagesInput{
-				Role:    "user",
-				Content: []map[string]interface{}{block},
-			})
+			if len(out) > 0 && out[len(out)-1].Role == "user" {
+				out[len(out)-1].Content = mergeAnthropicUserContent(out[len(out)-1].Content, block)
+			} else {
+				out = append(out, anthropicMessagesInput{
+					Role:    "user",
+					Content: []map[string]interface{}{block},
+				})
+			}
 			continue
 		}
 
@@ -445,15 +453,48 @@ func chatMessagesToAnthropic(msgs []ChatMessage) ([]anthropicSystemBlock, []anth
 		if apiRole != "user" && apiRole != "assistant" {
 			apiRole = "user"
 		}
-		out = append(out, anthropicMessagesInput{
-			Role:    apiRole,
-			Content: content,
-		})
+		if apiRole == "user" && len(out) > 0 && out[len(out)-1].Role == "user" {
+			out[len(out)-1].Content = mergeAnthropicUserContent(out[len(out)-1].Content, content)
+		} else {
+			out = append(out, anthropicMessagesInput{
+				Role:    apiRole,
+				Content: content,
+			})
+		}
 	}
 	if len(systemBlocks) > 0 {
 		systemBlocks[len(systemBlocks)-1].CacheControl = &anthropicCacheControl{Type: "ephemeral"}
 	}
 	return systemBlocks, out
+}
+
+// mergeAnthropicUserContent appends new content into an existing user
+// message, converting to the array-of-blocks form when needed. The added
+// content can be a plain string (converted to a text block) or a
+// map[string]interface{} block (e.g. tool_result). This ensures
+// consecutive user messages are collapsed into one, which the Anthropic
+// Messages API requires (roles must alternate).
+func mergeAnthropicUserContent(existing interface{}, added interface{}) interface{} {
+	var newBlock map[string]interface{}
+	switch a := added.(type) {
+	case string:
+		newBlock = map[string]interface{}{"type": "text", "text": a}
+	case map[string]interface{}:
+		newBlock = a
+	default:
+		newBlock = map[string]interface{}{"type": "text", "text": fmt.Sprintf("%v", added)}
+	}
+	switch v := existing.(type) {
+	case []map[string]interface{}:
+		return append(v, newBlock)
+	case string:
+		return []map[string]interface{}{
+			{"type": "text", "text": v},
+			newBlock,
+		}
+	default:
+		return []map[string]interface{}{newBlock}
+	}
 }
 
 func parseJSONLoose(s string) map[string]interface{} {

--- a/runtime/model_gateway_anthropic_test.go
+++ b/runtime/model_gateway_anthropic_test.go
@@ -361,8 +361,8 @@ func TestChatMessagesToAnthropicStructuredToolMessages(t *testing.T) {
 	if systemBlocks[0].CacheControl == nil || systemBlocks[0].CacheControl.Type != "ephemeral" {
 		t.Fatal("expected cache_control ephemeral on last system block")
 	}
-	if len(anthropicMsgs) != 4 {
-		t.Fatalf("expected 4 messages (user, assistant, user-tool-result, user), got %d", len(anthropicMsgs))
+	if len(anthropicMsgs) != 3 {
+		t.Fatalf("expected 3 messages (user, assistant, merged-user-tool-result+step), got %d", len(anthropicMsgs))
 	}
 
 	assistantMsg := anthropicMsgs[1]
@@ -386,22 +386,28 @@ func TestChatMessagesToAnthropicStructuredToolMessages(t *testing.T) {
 		t.Fatal("expected tool_use content block in assistant message")
 	}
 
-	toolResultMsg := anthropicMsgs[2]
-	if toolResultMsg.Role != "user" {
-		t.Fatalf("expected user role for tool_result, got %q", toolResultMsg.Role)
+	mergedMsg := anthropicMsgs[2]
+	if mergedMsg.Role != "user" {
+		t.Fatalf("expected user role for merged message, got %q", mergedMsg.Role)
 	}
-	resultBlocks, ok := toolResultMsg.Content.([]map[string]interface{})
+	resultBlocks, ok := mergedMsg.Content.([]map[string]interface{})
 	if !ok {
-		t.Fatalf("expected structured content blocks for tool result, got %T", toolResultMsg.Content)
+		t.Fatalf("expected structured content blocks for merged message, got %T", mergedMsg.Content)
 	}
-	if len(resultBlocks) != 1 {
-		t.Fatalf("expected 1 tool_result block, got %d", len(resultBlocks))
+	if len(resultBlocks) != 2 {
+		t.Fatalf("expected 2 blocks (tool_result + text), got %d", len(resultBlocks))
 	}
 	if resultBlocks[0]["type"] != "tool_result" {
-		t.Fatalf("expected type=tool_result, got %v", resultBlocks[0]["type"])
+		t.Fatalf("expected first block type=tool_result, got %v", resultBlocks[0]["type"])
 	}
 	if resultBlocks[0]["tool_use_id"] != "toolu_01A" {
 		t.Fatalf("expected tool_use_id=toolu_01A, got %v", resultBlocks[0]["tool_use_id"])
+	}
+	if resultBlocks[1]["type"] != "text" {
+		t.Fatalf("expected second block type=text, got %v", resultBlocks[1]["type"])
+	}
+	if resultBlocks[1]["text"] != "step=2" {
+		t.Fatalf("expected second block text=step=2, got %v", resultBlocks[1]["text"])
 	}
 }
 
@@ -421,38 +427,35 @@ func TestChatMessagesToAnthropicErrorToolResult(t *testing.T) {
 	if len(system) != 0 {
 		t.Fatalf("expected empty system blocks, got %+v", system)
 	}
-	if len(anthropicMsgs) != 5 {
-		t.Fatalf("expected 5 messages (user, assistant, tool-result, tool-error-result, user), got %d", len(anthropicMsgs))
+	if len(anthropicMsgs) != 3 {
+		t.Fatalf("expected 3 messages (user, assistant, merged-user), got %d", len(anthropicMsgs))
 	}
 
-	successResult := anthropicMsgs[2]
-	successBlocks, ok := successResult.Content.([]map[string]interface{})
-	if !ok || len(successBlocks) != 1 {
-		t.Fatalf("expected 1 tool_result block for success, got %v", successResult.Content)
+	mergedResult := anthropicMsgs[2]
+	if mergedResult.Role != "user" {
+		t.Fatalf("expected user role for merged message, got %q", mergedResult.Role)
 	}
-	if successBlocks[0]["tool_use_id"] != "toolu_01A" {
-		t.Fatalf("expected tool_use_id=toolu_01A, got %v", successBlocks[0]["tool_use_id"])
+	mergedBlocks, ok := mergedResult.Content.([]map[string]interface{})
+	if !ok || len(mergedBlocks) != 3 {
+		t.Fatalf("expected 3 blocks (tool_result + tool_result_error + text), got %v", mergedResult.Content)
 	}
-	if _, hasIsError := successBlocks[0]["is_error"]; hasIsError {
+	if mergedBlocks[0]["tool_use_id"] != "toolu_01A" {
+		t.Fatalf("expected first block tool_use_id=toolu_01A, got %v", mergedBlocks[0]["tool_use_id"])
+	}
+	if _, hasIsError := mergedBlocks[0]["is_error"]; hasIsError {
 		t.Fatal("successful tool_result should not have is_error field")
 	}
-
-	errorResult := anthropicMsgs[3]
-	if errorResult.Role != "user" {
-		t.Fatalf("expected user role for error tool_result, got %q", errorResult.Role)
+	if mergedBlocks[1]["type"] != "tool_result" {
+		t.Fatalf("expected second block type=tool_result, got %v", mergedBlocks[1]["type"])
 	}
-	errorBlocks, ok := errorResult.Content.([]map[string]interface{})
-	if !ok || len(errorBlocks) != 1 {
-		t.Fatalf("expected 1 tool_result block for error, got %v", errorResult.Content)
+	if mergedBlocks[1]["tool_use_id"] != "toolu_01B" {
+		t.Fatalf("expected second block tool_use_id=toolu_01B, got %v", mergedBlocks[1]["tool_use_id"])
 	}
-	if errorBlocks[0]["type"] != "tool_result" {
-		t.Fatalf("expected type=tool_result, got %v", errorBlocks[0]["type"])
+	if mergedBlocks[1]["is_error"] != true {
+		t.Fatalf("expected is_error=true on error tool_result, got %v", mergedBlocks[1]["is_error"])
 	}
-	if errorBlocks[0]["tool_use_id"] != "toolu_01B" {
-		t.Fatalf("expected tool_use_id=toolu_01B, got %v", errorBlocks[0]["tool_use_id"])
-	}
-	if errorBlocks[0]["is_error"] != true {
-		t.Fatalf("expected is_error=true on error tool_result, got %v", errorBlocks[0]["is_error"])
+	if mergedBlocks[2]["type"] != "text" {
+		t.Fatalf("expected third block type=text, got %v", mergedBlocks[2]["type"])
 	}
 }
 

--- a/runtime/tool_runtime_container.go
+++ b/runtime/tool_runtime_container.go
@@ -91,9 +91,6 @@ func DefaultContainerToolRuntimeConfig() ContainerToolRuntimeConfig {
 //   - cpus=0.50 (half a core)
 //   - pids_limit=64 (process limit)
 //   - user=65532:65532 (non-root nobody user)
-//   - read-only filesystem (via containerRunArgs --read-only)
-//   - no Linux capabilities (via --cap-drop=ALL)
-//   - no privilege escalation (via --security-opt no-new-privileges)
 //
 // These defaults match DefaultContainerToolRuntimeConfig but are preserved
 // as an explicit contract so callers can distinguish between default and
@@ -436,9 +433,6 @@ func (r *ContainerToolRuntime) containerCLIRunArgs(cli resources.ToolCliSpec, im
 	dockerArgs := []string{
 		"run", "--rm", "-i",
 		"--network", network,
-		"--read-only",
-		"--cap-drop=ALL",
-		"--security-opt", "no-new-privileges",
 	}
 	if strings.TrimSpace(r.config.User) != "" {
 		dockerArgs = append(dockerArgs, "--user", strings.TrimSpace(r.config.User))
@@ -524,13 +518,9 @@ func mapContainerContextError(tool string, err error) error {
 }
 
 func (r *ContainerToolRuntime) containerRunArgs(endpoint string, includeAuth bool) []string {
-	// Keep the container constrained: read-only fs, no extra Linux capabilities, no privilege escalation.
 	args := []string{
 		"run", "--rm", "-i",
 		"--network", strings.TrimSpace(r.config.Network),
-		"--read-only",
-		"--cap-drop=ALL",
-		"--security-opt", "no-new-privileges",
 	}
 	if strings.TrimSpace(r.config.User) != "" {
 		args = append(args, "--user", strings.TrimSpace(r.config.User))

--- a/runtime/tool_runtime_container_test.go
+++ b/runtime/tool_runtime_container_test.go
@@ -97,9 +97,6 @@ func TestContainerToolRuntimeExecutesHTTPInContainer(t *testing.T) {
 	assertArgsContain(t, runner.args, []string{
 		"run", "--rm", "-i",
 		"--network", "none",
-		"--read-only",
-		"--cap-drop=ALL",
-		"--security-opt", "no-new-privileges",
 		"--memory", "64m",
 		"--cpus", "0.25",
 		"--pids-limit", "32",
@@ -333,9 +330,6 @@ func TestSandboxedContainerDefaultsAreSecure(t *testing.T) {
 	}
 
 	assertArgsContain(t, runner.args, []string{
-		"--read-only",
-		"--cap-drop=ALL",
-		"--security-opt", "no-new-privileges",
 		"--network", "none",
 		"--memory", "128m",
 		"--cpus", "0.50",


### PR DESCRIPTION

Relax default read-only/cap-drop/no-new-privileges for tool/MCP containers. Raise Anthropic HTTP timeout to 120s. Merge consecutive user-role messages, handle empty content responses, and stop the agent loop when there is no output and no tools.


