### PR TITLE
feat: configurable log level and targeted debug logging for daemons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Global log level for daemons**: `orlojd` and `orlojworker` accept `--log-level`, `--debug`, and `ORLOJ_LOG_LEVEL` so operators can raise or lower verbosity without rebuilding. Operations docs, the server flags reference, and the Helm chart README include examples (including `runtimeConfig.ORLOJ_LOG_LEVEL` for clusters). Telemetry records the effective parsed log level, forwards debug bridge logs when enabled, and routes configured error-level fatals through the error logger so shutdown paths stay consistent with the chosen level.
+- **Targeted debug instrumentation**: additional debug logging around startup/runtime configuration, tool runtime setup, task scheduling and claim/heartbeat loops, worker capacity, and the agent message consumer (receive, skip, retry, ack, and routing decisions) to trace message-driven execution without enabling full trace spam.
+
 ### Changed
 
 - **Relaxed container isolation defaults**: MCP server and tool runtime containers no longer apply `--read-only`, `--cap-drop=ALL`, or `--security-opt no-new-privileges`. The container boundary, resource limits, and network controls remain the primary isolation mechanism. This improves compatibility with images that require writable filesystems or Linux capabilities (e.g. Chromium-based MCP servers).

--- a/charts/orloj/README.md
+++ b/charts/orloj/README.md
@@ -37,6 +37,14 @@ helm uninstall orloj --namespace orloj
 - `runtimeSecret.apiToken`
 - `runtimeConfig.*` (Orloj runtime env vars)
 
+Enable process-wide debug logs during troubleshooting:
+
+```bash
+helm upgrade --install orloj ./charts/orloj \
+  --namespace orloj \
+  --set runtimeConfig.ORLOJ_LOG_LEVEL=debug
+```
+
 ## Notes
 
 - By default, this chart deploys a single Postgres replica with a PVC and a single NATS replica.

--- a/charts/orloj/values.yaml
+++ b/charts/orloj/values.yaml
@@ -20,6 +20,8 @@ runtimeSecret:
   modelGatewayApiKey: ""
   apiToken: ""
 
+# Shared non-secret runtime environment variables for orlojd and orlojworker.
+# Example: set ORLOJ_LOG_LEVEL: debug while investigating scheduling/runtime behavior.
 runtimeConfig: {}
 
 postgres:

--- a/cmd/orlojd/main.go
+++ b/cmd/orlojd/main.go
@@ -34,6 +34,8 @@ func main() {
 	envUint64 := startup.EnvUint64OrDefault
 
 	showVersion := flag.Bool("version", false, "print version and exit")
+	logLevelRaw := flag.String("log-level", env("ORLOJ_LOG_LEVEL", "info"), "minimum log level: debug|info|warn|error (env: ORLOJ_LOG_LEVEL)")
+	debugLogs := flag.Bool("debug", false, "enable debug logging (equivalent to --log-level=debug)")
 	addr := flag.String("addr", ":8080", "server listen address")
 	uiPath := flag.String("ui-path", env("ORLOJ_UI_PATH", "/"), "base URL path for the web console (env: ORLOJ_UI_PATH)")
 	apiKey := flag.String("api-key", env("ORLOJ_API_TOKEN", ""), "API key for bearer token auth (empty disables auth; env fallback: ORLOJ_API_TOKEN or ORLOJ_API_TOKENS)")
@@ -95,14 +97,49 @@ func main() {
 		os.Exit(0)
 	}
 
-	authMode, authModeErr := parseAuthMode(*authModeRaw)
-	if authModeErr != nil {
-		logger := telemetry.NewBridgeLogger(telemetry.NewLogger("orlojd"))
-		logger.Fatalf("%v", authModeErr)
+	resolvedLogLevel := *logLevelRaw
+	if *debugLogs {
+		resolvedLogLevel = "debug"
+	}
+	parsedLogLevel, logLevelErr := telemetry.ResolveLogLevel(*logLevelRaw, *debugLogs)
+	if logLevelErr != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", logLevelErr)
+		os.Exit(2)
 	}
 
-	slogger := telemetry.NewLogger("orlojd")
+	slogger := telemetry.NewLoggerWithLevel("orlojd", parsedLogLevel)
 	logger := telemetry.NewBridgeLogger(slogger)
+	debugLogger := telemetry.NewDebugBridgeLogger(slogger)
+	fatalLogger := telemetry.NewErrorBridgeLogger(slogger)
+	resolvedLogLevelLabel := strings.ToLower(strings.TrimSpace(resolvedLogLevel))
+	if resolvedLogLevelLabel == "" {
+		resolvedLogLevelLabel = "info"
+	}
+
+	authMode, authModeErr := parseAuthMode(*authModeRaw)
+	if authModeErr != nil {
+		fatalLogger.Fatalf("%v", authModeErr)
+	}
+
+	debugLogger.Printf(
+		"startup config addr=%s ui_path=%s log_level=%s auth_mode=%s api_token_configured=%t trusted_proxies_configured=%t storage_backend=%s postgres_dsn_configured=%t task_execution_mode=%s embedded_worker=%t event_bus_backend=%s agent_message_bus_backend=%s tool_isolation_backend=%s tool_container_runtime=%s tool_container_network=%s wasm_module_configured=%t",
+		*addr,
+		*uiPath,
+		resolvedLogLevelLabel,
+		*authModeRaw,
+		strings.TrimSpace(*apiKey) != "",
+		strings.TrimSpace(*trustedProxies) != "",
+		*storageBackend,
+		strings.TrimSpace(*postgresDSN) != "",
+		*taskExecutionMode,
+		*runTaskWorker || *embeddedWorker,
+		*eventBusBackend,
+		*agentMessageBusBackend,
+		*toolIsolationBackend,
+		*toolContainerRuntime,
+		*toolContainerNetwork,
+		strings.TrimSpace(*toolWASMModule) != "",
+	)
 
 	if authMode == api.AuthModeNative && strings.TrimSpace(os.Getenv("ORLOJ_SETUP_TOKEN")) == "" {
 		logger.Printf("WARNING: auth mode is native but ORLOJ_SETUP_TOKEN is not set; the first POST to /v1/auth/setup will create the admin account without a setup secret")
@@ -123,7 +160,7 @@ func main() {
 
 	secretEncryptionKey, err := startup.ParseSecretEncryptionKey(*secretEncryptionKeyRaw)
 	if err != nil {
-		logger.Fatalf("%v", err)
+		fatalLogger.Fatalf("%v", err)
 	}
 	startup.LogSecretEncryption(logger, secretEncryptionKey)
 
@@ -138,7 +175,7 @@ func main() {
 		IncludeScheduleStores: true,
 	}, logger)
 	if err != nil {
-		logger.Fatalf("%v", err)
+		fatalLogger.Fatalf("%v", err)
 	}
 	defer stores.Close()
 	if len(secretEncryptionKey) > 0 {
@@ -153,7 +190,7 @@ func main() {
 	}
 	if strings.TrimSpace(*authResetAdminPassword) != "" {
 		if err := runLocalAdminPasswordReset(stores, strings.TrimSpace(*authResetAdminUsername), strings.TrimSpace(*authResetAdminPassword)); err != nil {
-			logger.Fatalf("admin password reset failed: %v", err)
+			fatalLogger.Fatalf("admin password reset failed: %v", err)
 		}
 		logger.Printf("admin password reset completed")
 		return
@@ -196,6 +233,7 @@ func main() {
 		stores.Tasks, stores.AgentSystems, stores.Agents, stores.Tools,
 		stores.Memories, stores.Policies, stores.Workers, logger, *reconcile,
 	)
+	taskController.SetDebugLogger(debugLogger)
 	taskSchedulerController := controllers.NewTaskSchedulerController(stores.Tasks, stores.Workers, logger, *reconcile, 20*time.Second)
 	taskScheduleController := controllers.NewTaskScheduleController(stores.TaskSchedules, stores.Tasks, logger, *reconcile)
 	workerController := controllers.NewWorkerController(stores.Workers, logger, *reconcile, 20*time.Second)
@@ -231,11 +269,11 @@ func main() {
 		Secrets:          stores.Secrets,
 	}, logger)
 	if err != nil {
-		logger.Fatalf("failed to configure isolated tool runtime: %v", err)
+		fatalLogger.Fatalf("failed to configure isolated tool runtime: %v", err)
 	}
 	wasmToolRuntime, closeWasm, err := startup.NewWASMToolRuntime(wasmRuntimeCfg, logger)
 	if err != nil {
-		logger.Fatalf("failed to configure wasm tool runtime: %v", err)
+		fatalLogger.Fatalf("failed to configure wasm tool runtime: %v", err)
 	}
 	if closeWasm != nil {
 		defer closeWasm()
@@ -251,6 +289,25 @@ func main() {
 		AllowedCommands: startup.ParseCSV(*cliToolAllowedCommands),
 		MaxArgvLength:   *cliToolMaxArgvLength,
 	}, cliSecretResolver)
+	debugLogger.Printf(
+		"tool runtime config isolation_backend=%s container_runtime=%s container_image=%s container_network=%s container_memory=%s container_cpus=%s container_pids_limit=%d container_user=%s cli_allowed_commands=%d cli_max_argv_length=%d wasm_entrypoint=%s wasm_memory_bytes=%d wasm_fuel=%d wasm_wasi=%t wasm_cache_configured=%t mcp_container_network=%s",
+		*toolIsolationBackend,
+		*toolContainerRuntime,
+		*toolContainerImage,
+		*toolContainerNetwork,
+		*toolContainerMemory,
+		*toolContainerCPUs,
+		*toolContainerPidsLimit,
+		*toolContainerUser,
+		len(startup.ParseCSV(*cliToolAllowedCommands)),
+		*cliToolMaxArgvLength,
+		*toolWASMEntrypoint,
+		*toolWASMMemoryBytes,
+		*toolWASMFuel,
+		*toolWASMWASI,
+		strings.TrimSpace(*toolWASMCacheDir) != "",
+		"bridge",
+	)
 
 	var requestAuthorizer api.RequestAuthorizer
 	if strings.TrimSpace(*apiKey) != "" {
@@ -293,7 +350,7 @@ func main() {
 			MaxPidsLimit: *toolContainerMaxPidsLimit,
 		},
 	})
-	bus, closeBus := newEventBus(logger, *eventBusBackend, *natsURL, *natsSubjectPrefix)
+	bus, closeBus := newEventBus(logger, fatalLogger, *eventBusBackend, *natsURL, *natsSubjectPrefix)
 	if closeBus != nil {
 		defer closeBus()
 	}
@@ -301,6 +358,7 @@ func main() {
 		logger, *agentMessageBusBackend, *agentMessageNATSURL,
 		*agentMessageSubjectPrefix, *agentMessageStreamName,
 		*agentMessageHistoryMax, *agentMessageDedupeWindow,
+		fatalLogger,
 	)
 	if closeAgentMessageBus != nil {
 		defer closeAgentMessageBus()
@@ -391,6 +449,7 @@ func main() {
 						TaskApprovals:       stores.TaskApprovals,
 						Policies:            stores.Policies,
 						ContextAdapters:     stores.ContextAdapters,
+						DebugLogger:         debugLogger,
 						OnStepEvent: func(taskName, namespace string, evt agentruntime.AgentStepEvent) {
 							if bus != nil {
 								bus.Publish(eventbus.Event{
@@ -433,7 +492,7 @@ func main() {
 
 	logger.Printf("API server listening on %s", *addr)
 	if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		logger.Fatalf("server error: %v", err)
+		fatalLogger.Fatalf("server error: %v", err)
 	}
 	wg.Wait()
 }
@@ -504,7 +563,7 @@ func parseAuthMode(raw string) (api.AuthMode, error) {
 	}
 }
 
-func newEventBus(logger *log.Logger, backend, natsURL, subjectPrefix string) (eventbus.Bus, func()) {
+func newEventBus(logger *log.Logger, fatalLogger *log.Logger, backend, natsURL, subjectPrefix string) (eventbus.Bus, func()) {
 	mode := strings.ToLower(strings.TrimSpace(backend))
 	switch mode {
 	case "", "memory":
@@ -515,14 +574,14 @@ func newEventBus(logger *log.Logger, backend, natsURL, subjectPrefix string) (ev
 	case "nats":
 		bus, err := eventbus.NewNATSBus(natsURL, subjectPrefix, 8192, logger)
 		if err != nil {
-			if logger != nil {
-				logger.Fatalf("failed to initialize nats event bus: %v", err)
+			if fatalLogger != nil {
+				fatalLogger.Fatalf("failed to initialize nats event bus: %v", err)
 			}
 		}
 		return bus, func() { _ = bus.Close() }
 	default:
-		if logger != nil {
-			logger.Fatalf("unsupported event bus backend %q; expected memory or nats", backend)
+		if fatalLogger != nil {
+			fatalLogger.Fatalf("unsupported event bus backend %q; expected memory or nats", backend)
 		}
 		return eventbus.NewMemoryBus(8192), nil
 	}

--- a/cmd/orlojworker/main.go
+++ b/cmd/orlojworker/main.go
@@ -28,6 +28,8 @@ func main() {
 	envUint64 := startup.EnvUint64OrDefault
 
 	showVersion := flag.Bool("version", false, "print version and exit")
+	logLevelRaw := flag.String("log-level", env("ORLOJ_LOG_LEVEL", "info"), "minimum log level: debug|info|warn|error (env: ORLOJ_LOG_LEVEL)")
+	debugLogs := flag.Bool("debug", false, "enable debug logging (equivalent to --log-level=debug)")
 	workerID := flag.String("worker-id", "worker-1", "task worker identity")
 	healthzAddr := flag.String("healthz-addr", env("ORLOJ_WORKER_HEALTHZ_ADDR", ""), "optional address for the /healthz liveness probe endpoint (e.g. :8081); empty disables it")
 	reconcile := flag.Duration("reconcile-interval", 1*time.Second, "claim/reconcile interval")
@@ -80,8 +82,45 @@ func main() {
 		os.Exit(0)
 	}
 
-	slogger := telemetry.NewLogger("orlojworker")
+	resolvedLogLevel := *logLevelRaw
+	if *debugLogs {
+		resolvedLogLevel = "debug"
+	}
+	parsedLogLevel, logLevelErr := telemetry.ResolveLogLevel(*logLevelRaw, *debugLogs)
+	if logLevelErr != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", logLevelErr)
+		os.Exit(2)
+	}
+
+	slogger := telemetry.NewLoggerWithLevel("orlojworker", parsedLogLevel)
 	logger := telemetry.NewBridgeLogger(slogger)
+	debugLogger := telemetry.NewDebugBridgeLogger(slogger)
+	fatalLogger := telemetry.NewErrorBridgeLogger(slogger)
+	resolvedLogLevelLabel := strings.ToLower(strings.TrimSpace(resolvedLogLevel))
+	if resolvedLogLevelLabel == "" {
+		resolvedLogLevelLabel = "info"
+	}
+
+	debugLogger.Printf(
+		"startup config worker_id=%s log_level=%s healthz_enabled=%t region=%s gpu=%t supported_models=%d max_concurrent_tasks=%d storage_backend=%s postgres_dsn_configured=%t task_execution_mode=%s agent_message_consume=%t agent_message_bus_backend=%s agent_message_consumer_namespace=%q tool_isolation_backend=%s tool_container_runtime=%s tool_container_network=%s wasm_module_configured=%t",
+		*workerID,
+		resolvedLogLevelLabel,
+		strings.TrimSpace(*healthzAddr) != "",
+		*region,
+		*gpu,
+		len(startup.ParseCSV(*supportedModels)),
+		*maxConcurrentTasks,
+		*storageBackend,
+		strings.TrimSpace(*postgresDSN) != "",
+		*taskExecutionMode,
+		*agentMessageConsume,
+		*agentMessageBusBackend,
+		strings.TrimSpace(*agentMessageConsumerNamespace),
+		*toolIsolationBackend,
+		*toolContainerRuntime,
+		*toolContainerNetwork,
+		strings.TrimSpace(*toolWASMModule) != "",
+	)
 
 	otelShutdown, otelErr := telemetry.Init(context.Background(), telemetry.Config{
 		ServiceName: "orlojworker",
@@ -98,7 +137,7 @@ func main() {
 
 	secretEncryptionKey, err := startup.ParseSecretEncryptionKey(*secretEncryptionKeyRaw)
 	if err != nil {
-		logger.Fatalf("%v", err)
+		fatalLogger.Fatalf("%v", err)
 	}
 	startup.LogSecretEncryption(logger, secretEncryptionKey)
 
@@ -113,7 +152,7 @@ func main() {
 		IncludeScheduleStores: false,
 	}, logger)
 	if err != nil {
-		logger.Fatalf("%v", err)
+		fatalLogger.Fatalf("%v", err)
 	}
 	defer stores.Close()
 
@@ -130,6 +169,7 @@ func main() {
 		stores.Tasks, stores.AgentSystems, stores.Agents, stores.Tools,
 		stores.Memories, stores.Policies, stores.Workers, logger, *reconcile,
 	)
+	taskController.SetDebugLogger(debugLogger)
 	taskController.ConfigureWorker(*workerID, *leaseDuration, *heartbeatInterval)
 	taskController.SetExecutionMode(*taskExecutionMode)
 	taskController.SetGovernanceStores(stores.Roles, stores.ToolPerms)
@@ -161,11 +201,11 @@ func main() {
 		Secrets:          stores.Secrets,
 	}, logger)
 	if err != nil {
-		logger.Fatalf("failed to configure isolated tool runtime: %v", err)
+		fatalLogger.Fatalf("failed to configure isolated tool runtime: %v", err)
 	}
 	wasmToolRuntime, closeWasm, err := startup.NewWASMToolRuntime(wasmRuntimeCfg, logger)
 	if err != nil {
-		logger.Fatalf("failed to configure wasm tool runtime: %v", err)
+		fatalLogger.Fatalf("failed to configure wasm tool runtime: %v", err)
 	}
 	if closeWasm != nil {
 		defer closeWasm()
@@ -193,11 +233,31 @@ func main() {
 	}
 	taskController.SetCliToolRuntime(cliConfig, toolSecretResolver)
 	taskController.SetContextAdapterStore(stores.ContextAdapters)
+	debugLogger.Printf(
+		"tool runtime config isolation_backend=%s container_runtime=%s container_image=%s container_network=%s container_memory=%s container_cpus=%s container_pids_limit=%d container_user=%s cli_allowed_commands=%d cli_max_argv_length=%d wasm_entrypoint=%s wasm_memory_bytes=%d wasm_fuel=%d wasm_wasi=%t wasm_cache_configured=%t mcp_container_network=%s",
+		*toolIsolationBackend,
+		*toolContainerRuntime,
+		*toolContainerImage,
+		*toolContainerNetwork,
+		*toolContainerMemory,
+		*toolContainerCPUs,
+		*toolContainerPidsLimit,
+		*toolContainerUser,
+		len(cliConfig.AllowedCommands),
+		cliConfig.MaxArgvLength,
+		*toolWASMEntrypoint,
+		*toolWASMMemoryBytes,
+		*toolWASMFuel,
+		*toolWASMWASI,
+		strings.TrimSpace(*toolWASMCacheDir) != "",
+		"bridge",
+	)
 
 	agentMessageBus, closeAgentMessageBus := startup.NewAgentMessageBus(
 		logger, *agentMessageBusBackend, *agentMessageNATSURL,
 		*agentMessageSubjectPrefix, *agentMessageStreamName,
 		*agentMessageHistoryMax, *agentMessageDedupeWindow,
+		fatalLogger,
 	)
 	if closeAgentMessageBus != nil {
 		defer closeAgentMessageBus()
@@ -254,6 +314,7 @@ func main() {
 					TaskApprovals:       stores.TaskApprovals,
 					Policies:            stores.Policies,
 					ContextAdapters:     stores.ContextAdapters,
+					DebugLogger:         debugLogger,
 				},
 			)
 			go consumer.Start(ctx)

--- a/controllers/task_controller.go
+++ b/controllers/task_controller.go
@@ -25,35 +25,36 @@ var traceStepIDPattern = regexp.MustCompile(`^a([0-9]+)\.s([0-9]+)$`) //nolint:g
 
 // TaskController reconciles Task resources.
 type TaskController struct {
-	taskStore         *store.TaskStore
-	agentSystemStore  *store.AgentSystemStore
-	agentStore        *store.AgentStore
-	toolStore         *store.ToolStore
-	memoryStore       *store.MemoryStore
-	policyStore       *store.AgentPolicyStore
-	modelEPStore      *store.ModelEndpointStore
-	roleStore         *store.AgentRoleStore
-	toolPermStore     *store.ToolPermissionStore
-	toolApprovalStore *store.ToolApprovalStore
-	taskApprovalStore *store.TaskApprovalStore
-	workerStore       *store.WorkerStore
-	executor          *agentruntime.TaskExecutor
-	reconcileEvery    time.Duration
-	leaseDuration     time.Duration
-	heartbeatEvery    time.Duration
-	workerID          string
-	logger            *log.Logger
-	eventBus          eventbus.Bus
-	agentMessageBus   agentruntime.AgentMessageBus
-	executionMode     string
-	isolatedTools     agentruntime.ToolRuntime
-	wasmTools         agentruntime.ToolRuntime
-	cliToolConfig     agentruntime.CLIToolRuntimeConfig
-	cliSecretResolver agentruntime.SecretResolver
-	mcpSessionMgr     *agentruntime.McpSessionManager
-	mcpServerStore    *store.McpServerStore
+	taskStore           *store.TaskStore
+	agentSystemStore    *store.AgentSystemStore
+	agentStore          *store.AgentStore
+	toolStore           *store.ToolStore
+	memoryStore         *store.MemoryStore
+	policyStore         *store.AgentPolicyStore
+	modelEPStore        *store.ModelEndpointStore
+	roleStore           *store.AgentRoleStore
+	toolPermStore       *store.ToolPermissionStore
+	toolApprovalStore   *store.ToolApprovalStore
+	taskApprovalStore   *store.TaskApprovalStore
+	workerStore         *store.WorkerStore
+	executor            *agentruntime.TaskExecutor
+	reconcileEvery      time.Duration
+	leaseDuration       time.Duration
+	heartbeatEvery      time.Duration
+	workerID            string
+	logger              *log.Logger
+	debugLogger         *log.Logger
+	eventBus            eventbus.Bus
+	agentMessageBus     agentruntime.AgentMessageBus
+	executionMode       string
+	isolatedTools       agentruntime.ToolRuntime
+	wasmTools           agentruntime.ToolRuntime
+	cliToolConfig       agentruntime.CLIToolRuntimeConfig
+	cliSecretResolver   agentruntime.SecretResolver
+	mcpSessionMgr       *agentruntime.McpSessionManager
+	mcpServerStore      *store.McpServerStore
 	contextAdapterStore *store.ContextAdapterStore
-	extensions        agentruntime.Extensions
+	extensions          agentruntime.Extensions
 }
 
 func NewTaskController(
@@ -86,6 +87,16 @@ func NewTaskController(
 		logger:           logger,
 		executionMode:    "sequential",
 		extensions:       agentruntime.DefaultExtensions(),
+	}
+}
+
+func (c *TaskController) SetDebugLogger(logger *log.Logger) {
+	c.debugLogger = logger
+}
+
+func (c *TaskController) debugf(format string, args ...any) {
+	if c != nil && c.debugLogger != nil {
+		c.debugLogger.Printf(format, args...)
 	}
 }
 
@@ -228,6 +239,7 @@ func (c *TaskController) ReconcileOnce(ctx context.Context) error {
 				return err
 			}
 			if !acquired {
+				c.debugf("task scheduler idle worker=%s reason=worker_slot_unavailable", c.workerID)
 				return nil
 			}
 			slotAcquired = true
@@ -242,11 +254,14 @@ func (c *TaskController) ReconcileOnce(ctx context.Context) error {
 		if !claimed {
 			if slotAcquired {
 				_ = c.workerStore.ReleaseSlot(ctx, c.workerID)
+				c.debugf("worker=%s released empty claim slot", c.workerID)
 			}
+			c.debugf("task scheduler idle worker=%s reason=no_due_matching_task", c.workerID)
 			return nil
 		}
 
 		taskKey := taskScopedName(task)
+		c.debugf("task claimed task=%s worker=%s phase=%s attempt=%d lease=%s execution_mode=%s", taskKey, c.workerID, task.Status.Phase, task.Status.Attempts, c.leaseDuration.String(), c.executionMode)
 		stopHeartbeat := c.startHeartbeat(ctx, taskKey)
 		c.appendTaskLog(taskKey, fmt.Sprintf("task claimed by worker=%s lease=%s", c.workerID, c.leaseDuration))
 		c.appendTaskHistory(&task, "claim", fmt.Sprintf("task claimed by worker=%s lease=%s", c.workerID, c.leaseDuration))
@@ -276,8 +291,12 @@ func (c *TaskController) ReconcileOnce(ctx context.Context) error {
 		reconcileErr := c.reconcileTask(ctx, task)
 		stopHeartbeat()
 		if slotAcquired {
-			if err := c.workerStore.ReleaseSlot(ctx, c.workerID); err != nil && c.logger != nil {
-				c.logger.Printf("worker=%s release slot failed: %v", c.workerID, err)
+			if err := c.workerStore.ReleaseSlot(ctx, c.workerID); err != nil {
+				if c.logger != nil {
+					c.logger.Printf("worker=%s release slot failed: %v", c.workerID, err)
+				}
+			} else {
+				c.debugf("worker=%s released task slot task=%s", c.workerID, taskKey)
 			}
 		}
 		if reconcileErr != nil {
@@ -2636,42 +2655,53 @@ func taskScopedName(task resources.Task) string {
 }
 
 func (c *TaskController) taskMatchesWorker(task resources.Task) bool {
+	taskKey := taskScopedName(task)
 	if strings.EqualFold(strings.TrimSpace(task.Spec.Mode), "template") {
+		c.debugf("task scheduling skipped task=%s worker=%s reason=template_mode", taskKey, c.workerID)
 		return false
 	}
 	phase := strings.ToLower(strings.TrimSpace(task.Status.Phase))
 	assigned := strings.TrimSpace(task.Status.AssignedWorker)
 	// Assignment is a pending-task placement hint. Running tasks may fail over on lease expiry.
 	if phase != "running" && assigned != "" && !strings.EqualFold(assigned, c.workerID) {
+		c.debugf("task scheduling skipped task=%s worker=%s reason=assigned_to_other assigned_worker=%s phase=%s", taskKey, c.workerID, assigned, phase)
 		return false
 	}
 	if c.workerStore == nil {
+		c.debugf("task scheduling matched task=%s worker=%s reason=no_worker_store", taskKey, c.workerID)
 		return true
 	}
 	worker, ok, err := c.workerStore.Get(context.Background(), c.workerID)
 	if err != nil {
+		c.debugf("task scheduling skipped task=%s worker=%s reason=worker_lookup_error error=%v", taskKey, c.workerID, err)
 		return false
 	}
 	if !ok {
 		// Allow scheduling when worker registration is not present (for embedded/single-process use).
+		c.debugf("task scheduling matched task=%s worker=%s reason=worker_registration_missing", taskKey, c.workerID)
 		return true
 	}
 	if !strings.EqualFold(strings.TrimSpace(worker.Status.Phase), "ready") &&
 		!strings.EqualFold(strings.TrimSpace(worker.Status.Phase), "pending") {
+		c.debugf("task scheduling skipped task=%s worker=%s reason=worker_not_ready worker_phase=%s", taskKey, c.workerID, worker.Status.Phase)
 		return false
 	}
 
 	req := task.Spec.Requirements
 	if strings.TrimSpace(req.Region) != "" && !strings.EqualFold(strings.TrimSpace(req.Region), strings.TrimSpace(worker.Spec.Region)) {
+		c.debugf("task scheduling skipped task=%s worker=%s reason=region_mismatch required_region=%s worker_region=%s", taskKey, c.workerID, req.Region, worker.Spec.Region)
 		return false
 	}
 	if req.GPU && !worker.Spec.Capabilities.GPU {
+		c.debugf("task scheduling skipped task=%s worker=%s reason=gpu_required", taskKey, c.workerID)
 		return false
 	}
 	if strings.TrimSpace(req.Model) != "" && len(worker.Spec.Capabilities.SupportedModels) > 0 &&
 		!containsFold(worker.Spec.Capabilities.SupportedModels, req.Model) {
+		c.debugf("task scheduling skipped task=%s worker=%s reason=model_unsupported required_model=%s supported_models=%s", taskKey, c.workerID, req.Model, strings.Join(worker.Spec.Capabilities.SupportedModels, ","))
 		return false
 	}
+	c.debugf("task scheduling matched task=%s worker=%s worker_region=%s worker_phase=%s", taskKey, c.workerID, worker.Spec.Region, worker.Status.Phase)
 	return true
 }
 
@@ -2681,11 +2711,14 @@ func (c *TaskController) workerClaimHints() store.WorkerClaimHints {
 	}
 	worker, ok, err := c.workerStore.Get(context.Background(), c.workerID)
 	if err != nil {
+		c.debugf("worker claim hints unavailable worker=%s reason=lookup_error error=%v", c.workerID, err)
 		return store.WorkerClaimHints{}
 	}
 	if !ok {
+		c.debugf("worker claim hints unavailable worker=%s reason=worker_registration_missing", c.workerID)
 		return store.WorkerClaimHints{}
 	}
+	c.debugf("worker claim hints worker=%s region=%s supported_models=%s", c.workerID, worker.Spec.Region, strings.Join(worker.Spec.Capabilities.SupportedModels, ","))
 	return store.WorkerClaimHints{
 		AssignedWorker:  c.workerID,
 		Region:          strings.TrimSpace(worker.Spec.Region),
@@ -2700,6 +2733,7 @@ func (c *TaskController) tryAcquireWorkerSlot(ctx context.Context) (bool, error)
 	}
 	if !acquired && worker.Metadata.Name == "" {
 		// Embedded/single-process worker can run without explicit Worker registration.
+		c.debugf("worker=%s slot acquired reason=worker_registration_missing", c.workerID)
 		return true, nil
 	}
 	if !acquired {
@@ -2710,8 +2744,10 @@ func (c *TaskController) tryAcquireWorkerSlot(ctx context.Context) (bool, error)
 			}
 			c.logger.Printf("worker=%s at capacity current=%d max=%d", c.workerID, worker.Status.CurrentTasks, maxConcurrent)
 		}
+		c.debugf("worker=%s slot unavailable current=%d max=%d worker_phase=%s", c.workerID, worker.Status.CurrentTasks, worker.Spec.MaxConcurrentTasks, worker.Status.Phase)
 		return false, nil
 	}
+	c.debugf("worker=%s slot acquired current=%d max=%d worker_phase=%s", c.workerID, worker.Status.CurrentTasks, worker.Spec.MaxConcurrentTasks, worker.Status.Phase)
 	return true, nil
 }
 
@@ -3056,6 +3092,7 @@ func (c *TaskController) startHeartbeat(ctx context.Context, taskName string) fu
 					}
 					return
 				}
+				c.debugf("task=%s lease heartbeat renewed worker=%s lease=%s", taskName, c.workerID, c.leaseDuration.String())
 			}
 		}
 	}()

--- a/docs/pages/operations/configuration.md
+++ b/docs/pages/operations/configuration.md
@@ -64,6 +64,7 @@ Example:
 | `ORLOJCTL_API_TOKEN` | `orlojctl` | `--api-token` | Bearer token for CLI API calls. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `orlojd`, `orlojworker` | none | OTLP gRPC endpoint for OpenTelemetry traces. Empty disables export. |
 | `OTEL_EXPORTER_OTLP_INSECURE` | `orlojd`, `orlojworker` | none | Set `true` for non-TLS OTLP in development. |
+| `ORLOJ_LOG_LEVEL` | `orlojd`, `orlojworker` | `--log-level`, `--debug` | Minimum log level: `debug`, `info` (default), `warn`, or `error`. `--debug` is equivalent to `--log-level=debug` and takes precedence. |
 | `ORLOJ_LOG_FORMAT` | `orlojd`, `orlojworker` | none | Log format: `json` (default) or `text`. |
 
 ## Server and Worker Flags

--- a/docs/pages/operations/observability.md
+++ b/docs/pages/operations/observability.md
@@ -145,13 +145,27 @@ histogram_quantile(0.95, sum by (le, agent) (rate(orloj_agent_step_duration_seco
 
 ## Structured Logging
 
-Both `orlojd` and `orlojworker` emit structured JSON logs by default. Log output can be configured via the `ORLOJ_LOG_FORMAT` environment variable.
+Both `orlojd` and `orlojworker` emit structured JSON logs by default. Log output can be configured via the `ORLOJ_LOG_FORMAT` environment variable, and log verbosity can be configured with `ORLOJ_LOG_LEVEL`, `--log-level`, or the `--debug` shortcut.
 
 ### Configuration
 
 | Variable | Values | Default | Description |
 |---|---|---|---|
+| `ORLOJ_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `info` | Minimum log level. Use `debug` when investigating scheduling, worker, message bus, and runtime decisions. |
 | `ORLOJ_LOG_FORMAT` | `json`, `text` | `json` | Log output format. Use `text` for local development. |
+
+Local debugging example:
+
+```bash
+ORLOJ_LOG_FORMAT=text go run ./cmd/orlojd --debug --storage-backend=memory --embedded-worker
+```
+
+Kubernetes/Helm deployments should usually set the environment variable instead:
+
+```yaml
+runtimeConfig:
+  ORLOJ_LOG_LEVEL: debug
+```
 
 ### Log Fields
 

--- a/docs/pages/reference/server-flags.md
+++ b/docs/pages/reference/server-flags.md
@@ -19,6 +19,8 @@ go run ./cmd/orlojd -h
 | Flag | Default | Description | Condition / Notes |
 |---|---|---|---|
 | `--version` | `false` | Print version and exit. | n/a |
+| `--log-level` | `info` | Minimum log level. | `debug|info|warn|error`; env `ORLOJ_LOG_LEVEL`. |
+| `--debug` | `false` | Enable debug logging. | Equivalent to `--log-level=debug`; takes precedence over `--log-level`. |
 | `--addr` | `:8080` | Server listen address. | n/a |
 | `--ui-path` | `/` | Base URL path for the web console. | Env fallback: `ORLOJ_UI_PATH`. Set to a subpath (e.g. `/console/`) when sharing a hostname via reverse proxy. |
 | `--api-key` | empty | Bearer token auth key. | Env fallback: `ORLOJ_API_TOKEN`; see also `ORLOJ_API_TOKENS`. |
@@ -109,6 +111,8 @@ go run ./cmd/orlojworker -h
 | Flag | Default | Description | Condition / Notes |
 |---|---|---|---|
 | `--version` | `false` | Print version and exit. | n/a |
+| `--log-level` | `info` | Minimum log level. | `debug|info|warn|error`; env `ORLOJ_LOG_LEVEL`. |
+| `--debug` | `false` | Enable debug logging. | Equivalent to `--log-level=debug`; takes precedence over `--log-level`. |
 | `--worker-id` | `worker-1` | Worker identity. | n/a |
 | `--healthz-addr` | empty | Optional `/healthz` listener address. | Empty disables; env `ORLOJ_WORKER_HEALTHZ_ADDR`. |
 | `--region` | `default` | Worker region. | n/a |

--- a/runtime/agent_message_consumer.go
+++ b/runtime/agent_message_consumer.go
@@ -81,6 +81,7 @@ type AgentMessageConsumerOptions struct {
 	Policies            AgentPolicyLookup
 	ContextAdapters     ContextAdapterGetter
 	OnStepEvent         func(taskName, namespace string, evt AgentStepEvent)
+	DebugLogger         *log.Logger
 }
 
 // ToolApprovalUpserter persists ToolApproval resources when a governed tool requires approval.
@@ -96,41 +97,42 @@ type TaskApprovalUpserter interface {
 
 // AgentMessageConsumerManager watches agents and consumes runtime inbox messages per agent.
 type AgentMessageConsumerManager struct {
-	bus            AgentMessageBus
-	agents         AgentRegistry
-	systems        AgentSystemRegistry
-	tasks          TaskStateStore
-	tools          ToolResourceLookup
-	roles          AgentRoleLookup
-	toolPerms      ToolPermissionLookup
-	isolated       ToolRuntime
-	wasmRT         ToolRuntime
-	cliConfig      CLIToolRuntimeConfig
-	secretResolver SecretResolver
-	mcpSessionMgr  *McpSessionManager
-	mcpServerStore McpServerLookup
-	executor       *TaskExecutor
-	logger         *log.Logger
-	workerID       string
-	namespace      string
-	refresh        time.Duration
-	dedupeTTL      time.Duration
-	retryDelay     time.Duration
-	leaseExtend    time.Duration
-	extensions     Extensions
-	memories       MemoryResourceLookup
-	memBackends    *PersistentMemoryBackendRegistry
-	modelEPs       resources.ModelEndpointLookup
-	toolApprovals  ToolApprovalUpserter
-	taskApprovals  TaskApprovalUpserter
-	policies       AgentPolicyLookup
+	bus             AgentMessageBus
+	agents          AgentRegistry
+	systems         AgentSystemRegistry
+	tasks           TaskStateStore
+	tools           ToolResourceLookup
+	roles           AgentRoleLookup
+	toolPerms       ToolPermissionLookup
+	isolated        ToolRuntime
+	wasmRT          ToolRuntime
+	cliConfig       CLIToolRuntimeConfig
+	secretResolver  SecretResolver
+	mcpSessionMgr   *McpSessionManager
+	mcpServerStore  McpServerLookup
+	executor        *TaskExecutor
+	logger          *log.Logger
+	debugLogger     *log.Logger
+	workerID        string
+	namespace       string
+	refresh         time.Duration
+	dedupeTTL       time.Duration
+	retryDelay      time.Duration
+	leaseExtend     time.Duration
+	extensions      Extensions
+	memories        MemoryResourceLookup
+	memBackends     *PersistentMemoryBackendRegistry
+	modelEPs        resources.ModelEndpointLookup
+	toolApprovals   ToolApprovalUpserter
+	taskApprovals   TaskApprovalUpserter
+	policies        AgentPolicyLookup
 	contextAdapters ContextAdapterGetter
-	onStepEvent    func(taskName, namespace string, evt AgentStepEvent)
-	mu             sync.Mutex
-	consumers      map[string]context.CancelFunc
-	seenMessage    map[string]time.Time
-	taskMemory     map[string]*SharedMemoryStore
-	taskMemoryMu   sync.Mutex
+	onStepEvent     func(taskName, namespace string, evt AgentStepEvent)
+	mu              sync.Mutex
+	consumers       map[string]context.CancelFunc
+	seenMessage     map[string]time.Time
+	taskMemory      map[string]*SharedMemoryStore
+	taskMemoryMu    sync.Mutex
 }
 
 func NewAgentMessageConsumerManager(
@@ -162,39 +164,46 @@ func NewAgentMessageConsumerManager(
 		executor = NewTaskExecutor(logger)
 	}
 	return &AgentMessageConsumerManager{
-		bus:            bus,
-		agents:         agents,
-		systems:        systems,
-		tasks:          tasks,
-		tools:          opts.Tools,
-		roles:          opts.Roles,
-		toolPerms:      opts.ToolPermissions,
-		isolated:       opts.IsolatedToolRuntime,
-		wasmRT:         opts.WasmToolRuntime,
-		cliConfig:      opts.CliToolConfig,
-		secretResolver: opts.SecretResolver,
-		mcpSessionMgr:  opts.McpSessionManager,
-		mcpServerStore: opts.McpServerStore,
-		executor:       executor,
-		logger:         logger,
-		workerID:       strings.TrimSpace(opts.WorkerID),
-		namespace:      strings.TrimSpace(opts.Namespace),
-		refresh:        refresh,
-		dedupeTTL:      dedupe,
-		retryDelay:     retry,
-		leaseExtend:    lease,
-		memories:       opts.Memories,
-		memBackends:    opts.MemoryBackends,
-		modelEPs:       opts.ModelEndpoints,
-		toolApprovals:  opts.ToolApprovals,
-		taskApprovals:  opts.TaskApprovals,
-		policies:       opts.Policies,
+		bus:             bus,
+		agents:          agents,
+		systems:         systems,
+		tasks:           tasks,
+		tools:           opts.Tools,
+		roles:           opts.Roles,
+		toolPerms:       opts.ToolPermissions,
+		isolated:        opts.IsolatedToolRuntime,
+		wasmRT:          opts.WasmToolRuntime,
+		cliConfig:       opts.CliToolConfig,
+		secretResolver:  opts.SecretResolver,
+		mcpSessionMgr:   opts.McpSessionManager,
+		mcpServerStore:  opts.McpServerStore,
+		executor:        executor,
+		logger:          logger,
+		debugLogger:     opts.DebugLogger,
+		workerID:        strings.TrimSpace(opts.WorkerID),
+		namespace:       strings.TrimSpace(opts.Namespace),
+		refresh:         refresh,
+		dedupeTTL:       dedupe,
+		retryDelay:      retry,
+		leaseExtend:     lease,
+		memories:        opts.Memories,
+		memBackends:     opts.MemoryBackends,
+		modelEPs:        opts.ModelEndpoints,
+		toolApprovals:   opts.ToolApprovals,
+		taskApprovals:   opts.TaskApprovals,
+		policies:        opts.Policies,
 		contextAdapters: opts.ContextAdapters,
-		onStepEvent:    opts.OnStepEvent,
-		extensions:     NormalizeExtensions(opts.Extensions),
-		consumers:      make(map[string]context.CancelFunc),
-		seenMessage:    make(map[string]time.Time),
-		taskMemory:     make(map[string]*SharedMemoryStore),
+		onStepEvent:     opts.OnStepEvent,
+		extensions:      NormalizeExtensions(opts.Extensions),
+		consumers:       make(map[string]context.CancelFunc),
+		seenMessage:     make(map[string]time.Time),
+		taskMemory:      make(map[string]*SharedMemoryStore),
+	}
+}
+
+func (m *AgentMessageConsumerManager) debugf(format string, args ...any) {
+	if m != nil && m.debugLogger != nil {
+		m.debugLogger.Printf(format, args...)
 	}
 }
 
@@ -203,6 +212,7 @@ func (m *AgentMessageConsumerManager) Start(ctx context.Context) {
 		return
 	}
 
+	m.debugf("agent message consumer manager starting worker=%s namespace=%q refresh=%s dedupe_window=%s retry_delay=%s lease_extend=%s", m.workerID, m.namespace, m.refresh, m.dedupeTTL, m.retryDelay, m.leaseExtend)
 	m.reconcileConsumers(ctx)
 	ticker := time.NewTicker(m.refresh)
 	defer ticker.Stop()
@@ -243,6 +253,7 @@ func (m *AgentMessageConsumerManager) reconcileConsumers(ctx context.Context) {
 			Durable:   durableName(m.workerID, namespace, name),
 		}
 	}
+	m.debugf("agent message consumer reconcile worker=%s desired=%d namespace_filter=%q", m.workerID, len(desired), m.namespace)
 
 	type pendingStart struct {
 		key string
@@ -295,7 +306,18 @@ func (m *AgentMessageConsumerManager) stopAllConsumers() {
 func (m *AgentMessageConsumerManager) consumeLoop(ctx context.Context, key string, sub AgentMessageSubscription) {
 	for {
 		err := m.bus.Consume(ctx, sub, func(ctx context.Context, delivery AgentMessageDelivery) error {
-			return m.handleDelivery(ctx, key, delivery)
+			msg := delivery.Message()
+			err := m.handleDelivery(ctx, key, delivery)
+			if err != nil {
+				if delay, ok := retryDelayFromError(err); ok {
+					m.debugf("agent message delivery retry requested agent=%s message_id=%s task_id=%s delay=%s error=%v", key, msg.MessageID, msg.TaskID, delay, err)
+				} else {
+					m.debugf("agent message delivery nack requested agent=%s message_id=%s task_id=%s error=%v", key, msg.MessageID, msg.TaskID, err)
+				}
+			} else {
+				m.debugf("agent message delivery acked agent=%s message_id=%s task_id=%s", key, msg.MessageID, msg.TaskID)
+			}
+			return err
 		})
 		if err != nil && ctx.Err() == nil && m.logger != nil {
 			m.logger.Printf("agent message consumer error agent=%s: %v", key, err)
@@ -318,6 +340,7 @@ func (m *AgentMessageConsumerManager) handleDelivery(ctx context.Context, _ stri
 		}
 		return nil
 	}
+	m.debugf("agent message received task=%s message_id=%s from=%s to=%s type=%s attempt=%d branch_id=%s", taskKey, msg.MessageID, msg.FromAgent, msg.ToAgent, msg.Type, msg.Attempt, msg.BranchID)
 
 	task, ok, err := m.tasks.Get(ctx, taskKey)
 	if err != nil {
@@ -330,12 +353,15 @@ func (m *AgentMessageConsumerManager) handleDelivery(ctx context.Context, _ stri
 		return nil
 	}
 	if isTerminalTaskPhase(task.Status.Phase) {
+		m.debugf("agent message skipped task=%s message_id=%s reason=terminal_task_phase phase=%s", taskKey, msg.MessageID, task.Status.Phase)
 		return nil
 	}
 	if strings.EqualFold(strings.TrimSpace(task.Status.Phase), "waitingapproval") {
+		m.debugf("agent message retry deferred task=%s message_id=%s reason=task_waiting_approval", taskKey, msg.MessageID)
 		return RetryAfter(2*time.Second, nil)
 	}
 	if isMessageProcessed(task.Status.Trace, msg.MessageID) {
+		m.debugf("agent message skipped task=%s message_id=%s reason=trace_already_processed", taskKey, msg.MessageID)
 		return nil
 	}
 
@@ -358,9 +384,11 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 		return err
 	}
 	if skip {
+		m.debugf("agent message skipped task=%s message_id=%s reason=begin_attempt_skip", taskKey, msg.MessageID)
 		return nil
 	}
 	if retryAfter > 0 {
+		m.debugf("agent message attempt deferred task=%s message_id=%s delay=%s", taskKey, msg.MessageID, retryAfter.String())
 		return RetryAfter(retryAfter, nil)
 	}
 
@@ -380,12 +408,14 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 		}
 		return nil
 	}
+	m.debugf("agent message processing task=%s message_id=%s system=%s to_agent=%s", taskKey, msg.MessageID, system.Metadata.Name, msg.ToAgent)
 
 	joinDecision, err := m.applyJoinGate(ctx, taskKey, msg, system)
 	if err != nil {
 		return err
 	}
 	if joinDecision.SkipExecution {
+		m.debugf("agent message skipped task=%s message_id=%s reason=join_gate_waiting mode=%s required=%d received=%d", taskKey, msg.MessageID, joinDecision.JoinMode, joinDecision.Required, len(joinDecision.Sources))
 		return nil
 	}
 
@@ -394,6 +424,7 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 		return err
 	}
 	if delegationDecision.SkipExecution {
+		m.debugf("agent message skipped task=%s message_id=%s reason=delegation_gate_waiting mode=%s required=%d received=%d", taskKey, msg.MessageID, delegationDecision.DelegationMode, delegationDecision.Required, len(delegationDecision.Sources))
 		return nil
 	}
 
@@ -424,6 +455,7 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 		return nil
 	}
 	agent.Spec.Model = effectiveModel
+	m.debugf("agent message resolved agent task=%s message_id=%s agent=%s model=%s", taskKey, msg.MessageID, agent.Metadata.Name, effectiveModel)
 
 	var matchedPolicies []resources.AgentPolicy
 	if m.policies != nil {
@@ -524,6 +556,7 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 		input["inbox.delegation.sources"] = delegationDecision.SourceAgents()
 		input["inbox.delegation.payloads"] = delegationDecision.SourcePayloads()
 	}
+	m.debugf("agent message execution input prepared task=%s message_id=%s agent=%s join_mode=%s delegation_mode=%s memory_ref_configured=%t tools=%d", taskKey, msg.MessageID, agent.Metadata.Name, joinDecision.JoinMode, delegationDecision.DelegationMode, strings.TrimSpace(agent.Spec.Memory.Ref) != "", len(agent.Spec.Tools))
 
 	var approvalCtx *GovernedToolApprovalContext
 	if m.toolApprovals != nil {
@@ -757,6 +790,7 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 			}
 			return nil
 		}
+		m.debugf("agent message published downstream task=%s from=%s to=%s message_id=%s parent_message_id=%s branch_id=%s kind=%s", taskKey, result.Agent, nextMessage.ToAgent, nextMessage.MessageID, msg.MessageID, nextMessage.BranchID, downstreamLogKind)
 	}
 	if err := m.recordForward(ctx, taskKey, msg, record, result, downstreamMessages); err != nil {
 		return err
@@ -1441,24 +1475,30 @@ func (m *AgentMessageConsumerManager) beginMessageAttempt(ctx context.Context, t
 			continue
 		}
 		if !ok {
+			m.debugf("agent message begin skipped task=%s message_id=%s reason=task_not_found", taskKey, msg.MessageID)
 			return resources.Task{}, resources.TaskMessage{}, true, 0, nil
 		}
 		if isTerminalTaskPhase(task.Status.Phase) {
+			m.debugf("agent message begin skipped task=%s message_id=%s reason=terminal_task_phase phase=%s", taskKey, msg.MessageID, task.Status.Phase)
 			return task, resources.TaskMessage{}, true, 0, nil
 		}
 		index := ensureTaskMessageRecord(&task, msg)
 		record := task.Status.Messages[index]
 		if isMessageIdempotent(task.Status.MessageIdempotency, messageIdempotencyKey(msg)) {
+			m.debugf("agent message begin skipped task=%s message_id=%s reason=idempotency_seen key=%s", taskKey, msg.MessageID, messageIdempotencyKey(msg))
 			return task, record, true, 0, nil
 		}
 		if isTerminalMessagePhase(record.Phase) {
+			m.debugf("agent message begin skipped task=%s message_id=%s reason=terminal_message_phase phase=%s", taskKey, msg.MessageID, record.Phase)
 			return task, record, true, 0, nil
 		}
 		if isMessageProcessed(task.Status.Trace, msg.MessageID) {
+			m.debugf("agent message begin skipped task=%s message_id=%s reason=trace_processed", taskKey, msg.MessageID)
 			return task, record, true, 0, nil
 		}
 		owned, ownershipRetryAfter, ownershipChanged, takeover := m.acquireMessageOwnership(&task, msg)
 		if !owned {
+			m.debugf("agent message ownership deferred task=%s message_id=%s worker=%s delay=%s ownership_changed=%t", taskKey, msg.MessageID, m.workerID, ownershipRetryAfter.String(), ownershipChanged)
 			return task, record, false, ownershipRetryAfter, nil
 		}
 		if strings.EqualFold(strings.TrimSpace(record.Phase), "retrypending") {
@@ -1477,6 +1517,7 @@ func (m *AgentMessageConsumerManager) beginMessageAttempt(ctx context.Context, t
 						_ = m.tasks.AppendLog(ctx, taskKey, fmt.Sprintf("agent message lease takeover: message_id=%s worker=%s", msg.MessageID, m.workerID))
 					}
 				}
+				m.debugf("agent message retry wait active task=%s message_id=%s worker=%s delay=%s takeover=%t", taskKey, msg.MessageID, m.workerID, wait.String(), takeover)
 				return task, record, false, wait, nil
 			}
 		}
@@ -1504,6 +1545,7 @@ func (m *AgentMessageConsumerManager) beginMessageAttempt(ctx context.Context, t
 			_ = m.tasks.AppendLog(ctx, taskKey, fmt.Sprintf("agent message lease takeover: message_id=%s worker=%s", msg.MessageID, m.workerID))
 		}
 		_ = m.tasks.AppendLog(ctx, taskKey, fmt.Sprintf("agent message attempt started: id=%s attempt=%d/%d", msg.MessageID, record.Attempts, record.MaxAttempts))
+		m.debugf("agent message attempt started task=%s message_id=%s worker=%s attempt=%d max_attempts=%d takeover=%t", taskKey, msg.MessageID, m.workerID, record.Attempts, record.MaxAttempts, takeover)
 		namespace, taskName := splitTaskKey(taskKey)
 		m.emitMetering(ctx, MeteringEvent{
 			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
@@ -1609,6 +1651,7 @@ func (m *AgentMessageConsumerManager) recordRetryOrDeadLetter(ctx context.Contex
 				continue
 			}
 			_ = m.tasks.AppendLog(ctx, taskKey, fmt.Sprintf("agent message retry scheduled: id=%s attempt=%d/%d delay=%s error=%s", msg.MessageID, current.Attempts, current.MaxAttempts, delay.String(), current.LastError))
+			m.debugf("agent message retry scheduled task=%s message_id=%s worker=%s attempt=%d max_attempts=%d delay=%s retry_reason=%s", taskKey, msg.MessageID, m.workerID, current.Attempts, current.MaxAttempts, delay.String(), retryClass.Reason)
 			telemetry.RecordRetry(strings.TrimSpace(msg.ToAgent))
 			telemetry.RecordMessagePhase("retrypending", strings.TrimSpace(msg.ToAgent))
 			namespace, taskName := splitTaskKey(taskKey)
@@ -1687,6 +1730,7 @@ func (m *AgentMessageConsumerManager) recordRetryOrDeadLetter(ctx context.Contex
 		}
 		m.deleteTaskSharedMemory(taskKey)
 		_ = m.tasks.AppendLog(ctx, taskKey, fmt.Sprintf("agent message dead-lettered: id=%s attempts=%d error=%s", msg.MessageID, current.Attempts, current.LastError))
+		m.debugf("agent message dead-lettered task=%s message_id=%s worker=%s attempts=%d retryable=%t reason=%s", taskKey, msg.MessageID, m.workerID, current.Attempts, retryClass.Retryable, retryClass.Reason)
 		telemetry.RecordDeadLetter(strings.TrimSpace(msg.ToAgent))
 		telemetry.RecordMessagePhase("deadletter", strings.TrimSpace(msg.ToAgent))
 		namespace, taskName := splitTaskKey(taskKey)
@@ -1724,7 +1768,6 @@ func (m *AgentMessageConsumerManager) recordRetryOrDeadLetter(ctx context.Contex
 	}
 	return false, 0, lastErr
 }
-
 
 func ensureTaskMessageRecord(task *resources.Task, msg AgentMessage) int {
 	if task == nil {
@@ -2005,7 +2048,6 @@ func extendWorkerLease(task *resources.Task, workerID string, duration time.Dura
 	task.Status.LastHeartbeat = now.Format(time.RFC3339Nano)
 	task.Status.LeaseUntil = now.Add(duration).Format(time.RFC3339Nano)
 }
-
 
 func hasTraceMarker(trace []resources.TaskTraceEvent, eventType, messageID string) bool {
 	messageID = strings.TrimSpace(messageID)

--- a/startup/runtime.go
+++ b/startup/runtime.go
@@ -152,7 +152,12 @@ func NewAgentMessageBus(
 	streamName string,
 	historyMax int,
 	dedupeWindow time.Duration,
+	fatalLoggers ...*log.Logger,
 ) (agentruntime.AgentMessageBus, func()) {
+	fatalLogger := logger
+	if len(fatalLoggers) > 0 && fatalLoggers[0] != nil {
+		fatalLogger = fatalLoggers[0]
+	}
 	mode := strings.ToLower(strings.TrimSpace(backend))
 	switch mode {
 	case "", "none":
@@ -169,13 +174,13 @@ func NewAgentMessageBus(
 		return bus, func() { _ = bus.Close() }
 	case "nats", "nats-jetstream":
 		bus, err := agentruntime.NewNATSJetStreamAgentMessageBus(natsURL, subjectPrefix, streamName, logger)
-		if err != nil && logger != nil {
-			logger.Fatalf("failed to initialize runtime agent message bus: %v", err)
+		if err != nil && fatalLogger != nil {
+			fatalLogger.Fatalf("failed to initialize runtime agent message bus: %v", err)
 		}
 		return bus, func() { _ = bus.Close() }
 	default:
-		if logger != nil {
-			logger.Fatalf("unsupported runtime agent message bus backend %q; expected none, memory, or nats-jetstream", backend)
+		if fatalLogger != nil {
+			fatalLogger.Fatalf("unsupported runtime agent message bus backend %q; expected none, memory, or nats-jetstream", backend)
 		}
 		return nil, nil
 	}

--- a/telemetry/logging.go
+++ b/telemetry/logging.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"log"
 	"log/slog"
@@ -20,17 +21,59 @@ const requestIDKey contextKey = "request_id"
 
 // NewLogger creates a *slog.Logger with a JSON handler for production
 // or a text handler for development. The environment variable ORLOJ_LOG_FORMAT
-// controls the output: "json" (default) or "text".
+// controls the output: "json" (default) or "text". ORLOJ_LOG_LEVEL controls
+// filtering: "debug", "info" (default), "warn", or "error".
 func NewLogger(serviceName string) *slog.Logger {
+	level, err := LogLevelFromEnv()
+	if err != nil {
+		level = slog.LevelInfo
+	}
+	return NewLoggerWithLevel(serviceName, level)
+}
+
+// NewLoggerWithLevel creates a *slog.Logger with the supplied minimum level.
+func NewLoggerWithLevel(serviceName string, level slog.Level) *slog.Logger {
+	return slog.New(newLogHandler(os.Stdout, level)).With("service", serviceName)
+}
+
+// ParseLogLevel parses an Orloj log level.
+func ParseLogLevel(raw string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("invalid log level %q; expected debug, info, warn, or error", raw)
+	}
+}
+
+// ResolveLogLevel applies the process-wide debug shortcut before parsing raw.
+func ResolveLogLevel(raw string, debug bool) (slog.Level, error) {
+	if debug {
+		return slog.LevelDebug, nil
+	}
+	return ParseLogLevel(raw)
+}
+
+// LogLevelFromEnv parses ORLOJ_LOG_LEVEL, defaulting to info when unset.
+func LogLevelFromEnv() (slog.Level, error) {
+	return ParseLogLevel(os.Getenv("ORLOJ_LOG_LEVEL"))
+}
+
+func newLogHandler(w io.Writer, level slog.Level) slog.Handler {
 	format := strings.ToLower(strings.TrimSpace(os.Getenv("ORLOJ_LOG_FORMAT")))
-	var handler slog.Handler
+	opts := &slog.HandlerOptions{Level: level}
 	switch format {
 	case "text":
-		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
+		return slog.NewTextHandler(w, opts)
 	default:
-		handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
+		return slog.NewJSONHandler(w, opts)
 	}
-	return slog.New(handler).With("service", serviceName)
 }
 
 // NewBridgeLogger creates a *log.Logger that writes through slog.
@@ -38,16 +81,32 @@ func NewLogger(serviceName string) *slog.Logger {
 // log entries. Use this to maintain backward compatibility with code
 // that expects *log.Logger while gaining structured output.
 func NewBridgeLogger(sl *slog.Logger) *log.Logger {
-	return log.New(&slogWriter{sl: sl}, "", 0)
+	return NewBridgeLoggerAtLevel(sl, slog.LevelInfo)
+}
+
+// NewDebugBridgeLogger creates a *log.Logger that writes debug-level records.
+func NewDebugBridgeLogger(sl *slog.Logger) *log.Logger {
+	return NewBridgeLoggerAtLevel(sl, slog.LevelDebug)
+}
+
+// NewErrorBridgeLogger creates a *log.Logger that writes error-level records.
+func NewErrorBridgeLogger(sl *slog.Logger) *log.Logger {
+	return NewBridgeLoggerAtLevel(sl, slog.LevelError)
+}
+
+// NewBridgeLoggerAtLevel creates a *log.Logger that writes at the supplied slog level.
+func NewBridgeLoggerAtLevel(sl *slog.Logger, level slog.Level) *log.Logger {
+	return log.New(&slogWriter{sl: sl, level: level}, "", 0)
 }
 
 type slogWriter struct {
-	sl *slog.Logger
+	sl    *slog.Logger
+	level slog.Level
 }
 
 func (w *slogWriter) Write(p []byte) (int, error) {
 	msg := strings.TrimRight(string(p), "\n")
-	w.sl.Info(msg)
+	w.sl.Log(context.Background(), w.level, msg)
 	return len(p), nil
 }
 

--- a/telemetry/logging_test.go
+++ b/telemetry/logging_test.go
@@ -1,0 +1,97 @@
+package telemetry
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want slog.Level
+	}{
+		{name: "default", raw: "", want: slog.LevelInfo},
+		{name: "debug", raw: "debug", want: slog.LevelDebug},
+		{name: "info", raw: "INFO", want: slog.LevelInfo},
+		{name: "warn", raw: "warn", want: slog.LevelWarn},
+		{name: "warning", raw: "warning", want: slog.LevelWarn},
+		{name: "error", raw: "error", want: slog.LevelError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseLogLevel(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseLogLevel(%q): %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseLogLevel(%q)=%v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseLogLevelInvalid(t *testing.T) {
+	if _, err := ParseLogLevel("trace"); err == nil {
+		t.Fatal("expected invalid log level error")
+	}
+}
+
+func TestResolveLogLevelDebugPrecedence(t *testing.T) {
+	got, err := ResolveLogLevel("error", true)
+	if err != nil {
+		t.Fatalf("ResolveLogLevel: %v", err)
+	}
+	if got != slog.LevelDebug {
+		t.Fatalf("ResolveLogLevel with debug flag=%v, want %v", got, slog.LevelDebug)
+	}
+}
+
+func TestDebugBridgeLoggerFilteredAtInfo(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	NewDebugBridgeLogger(logger).Printf("hidden")
+	NewBridgeLogger(logger).Printf("visible")
+
+	out := buf.String()
+	if strings.Contains(out, "hidden") {
+		t.Fatalf("debug bridge log was not filtered: %s", out)
+	}
+	if !strings.Contains(out, "visible") {
+		t.Fatalf("info bridge log missing: %s", out)
+	}
+}
+
+func TestDebugBridgeLoggerEmitsAtDebug(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	NewDebugBridgeLogger(logger).Printf("visible debug")
+
+	out := buf.String()
+	if !strings.Contains(out, `"level":"DEBUG"`) {
+		t.Fatalf("debug level missing: %s", out)
+	}
+	if !strings.Contains(out, "visible debug") {
+		t.Fatalf("debug message missing: %s", out)
+	}
+}
+
+func TestErrorBridgeLoggerEmitsAtError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	NewErrorBridgeLogger(logger).Printf("visible error")
+
+	out := buf.String()
+	if !strings.Contains(out, `"level":"ERROR"`) {
+		t.Fatalf("error level missing: %s", out)
+	}
+	if !strings.Contains(out, "visible error") {
+		t.Fatalf("error message missing: %s", out)
+	}
+}


### PR DESCRIPTION
Add --log-level, --debug, and ORLOJ_LOG_LEVEL to orlojd and orlojworker. Wire telemetry to the parsed level, debug bridge logs, and error-level fatals. Add debug logs for startup config, tool runtime setup, task scheduling/claim/heartbeat, worker capacity, and the agent message consumer. Document flags and ORLOJ_LOG_LEVEL in ops/config, observability, server-flags, and Helm (runtimeConfig example).

