### PR TITLE
fix: harden resources, runtime, and crypto against data corruption, ReDoS, overflow, and silent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Global log level for daemons**: `orlojd` and `orlojworker` accept `--log-level`, `--debug`, and `ORLOJ_LOG_LEVEL` so operators can raise or lower verbosity without rebuilding. Operations docs, the server flags reference, and the Helm chart README include examples (including `runtimeConfig.ORLOJ_LOG_LEVEL` for clusters). Telemetry records the effective parsed log level, forwards debug bridge logs when enabled, and routes configured error-level fatals through the error logger so shutdown paths stay consistent with the chosen level.
 - **Targeted debug instrumentation**: additional debug logging around startup/runtime configuration, tool runtime setup, task scheduling and claim/heartbeat loops, worker capacity, and the agent message consumer (receive, skip, retry, ack, and routing decisions) to trace message-driven execution without enabling full trace spam.
+- **Kubernetes-style memory suffixes**: `ParseMemoryBytes` now accepts `Gi`, `Mi`, `Ki` suffixes (IEC binary, 1024-based) alongside Docker-style `g`, `m`, `k`.
+- **`Agent.ResolvedModel()` accessor**: provides a clear read path for the runtime-resolved model ID, discouraging direct field access on the `json:"-"` tagged `Spec.Model`.
 
 ### Changed
 
@@ -19,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **DeepCopy BlockedOn pointer isolation**: `Task.DeepCopy()` now deep-copies the `BlockedOn` pointer, preventing shared mutable state across task copies during concurrent reconciliation.
+- **Regex ReDoS protection + caching**: Edge condition `output_matches` patterns are length-limited (512 chars) at normalization time and compiled regexes are cached, eliminating per-evaluation re-compilation and catastrophic backtracking vectors.
+- **Integer overflow in `ParseMemoryBytes`**: Memory values that overflow int64 when multiplied by their unit (e.g. `"9999999999g"`) now return an error instead of a negative result passed to Docker resource flags.
+- **OutputSchema validation**: Agent `output_schema` is now validated during normalization — requires a root `"type"` key, caps nesting at 10 levels, and limits serialized size to 64 KB.
+- **YAML multi-document rejection**: All manifest parsers now reject `---` document separators with a descriptive error, preventing silent field corruption from multi-document streams.
+- **NormalizeGraphJoin rejects invalid values**: Unknown `join.mode` or `join.on_failure` values now return errors instead of being silently replaced with defaults.
+- **Task.Normalize requires system for run mode**: A Task with `mode: run` and empty `spec.system` is now rejected at normalization time rather than failing at runtime.
+- **EncodeTaskApprovalResumeContext error propagation**: The function now returns errors instead of silently returning empty maps on marshal/unmarshal failure.
+- **Memory ingest content size limit**: `memory.ingest` now rejects payloads exceeding 10 MB, preventing OOM from unbounded content ingestion.
+- **Deterministic memory search results**: `SharedMemoryStore.Search` now sorts results by key before truncating to `topK`, producing consistent results across calls.
+- **Sealed secret AAD includes algorithm version**: GCM additional authenticated data now includes `AES-256-GCM-v1` as a prefix, with backward-compatible fallback to the legacy AAD format during unseal.
+- **YAML inline array quoted commas**: The manifest parser's flow array split now respects quoted strings, so values like `["hello, world", b]` parse correctly instead of splitting on the embedded comma.
 - **Standalone `orlojworker` MCP execution parity**: standalone workers now build and own an `McpSessionManager`, configure MCP execution on the task controller, pass MCP dependencies into message-driven agent consumers, start the idle reaper, and close MCP sessions on shutdown. This brings standalone `orlojworker` behavior in line with embedded `orlojd` workers so generated `type=mcp` tools can execute in both task-controller and message-driven flows.
 - **Provider-safe tool names across model gateways**: OpenAI-compatible/OpenAI, Azure OpenAI, Anthropic, Bedrock, and Ollama now share consistent tool-name aliasing. Runtime tool names such as `memory.write` are sanitized for provider requests, parsed responses map back to runtime names, and multi-turn assistant tool-call history is re-aliased through the current request's tool alias map so history names match the provider `tools` array. This fixes follow-up turn failures for MCP-style names and built-ins with dots.
 - **Trusted local model endpoints under `allowPrivate`**: `ModelEndpoint.spec.allowPrivate: true` now permits trusted local/private model gateways, including loopback Ollama and local OpenAI-compatible servers, while still blocking cloud metadata, link-local, and unspecified addresses. Generic tool and MCP egress protections remain unchanged.

--- a/controllers/task_controller.go
+++ b/controllers/task_controller.go
@@ -895,7 +895,7 @@ func (c *TaskController) maybeCreateCompletionReviewFromTaskApproval(ctx context
 			ReviewCycle:         1,
 			Output:              copyStringMap(task.Status.Output),
 			OutputFormat:        "json",
-			ResumeContext:       resources.EncodeTaskApprovalResumeContext(nextResume),
+			ResumeContext:       mustEncodeTaskApprovalResumeContext(nextResume),
 		},
 		Status: resources.TaskApprovalStatus{Phase: "Pending"},
 	}
@@ -1712,7 +1712,7 @@ func (c *TaskController) createTaskApprovalForCheckpoint(
 			Supersedes:          strings.TrimSpace(supersedes),
 			Output:              outputSnapshot,
 			OutputFormat:        strings.TrimSpace(outputFormat),
-			ResumeContext:       resources.EncodeTaskApprovalResumeContext(resume),
+			ResumeContext:       mustEncodeTaskApprovalResumeContext(resume),
 		},
 		Status: resources.TaskApprovalStatus{Phase: "Pending"},
 	}
@@ -2646,6 +2646,14 @@ func copyStringMap(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 	for k, v := range in {
 		out[k] = v
+	}
+	return out
+}
+
+func mustEncodeTaskApprovalResumeContext(ctx resources.TaskApprovalResumeContext) map[string]any {
+	out, err := resources.EncodeTaskApprovalResumeContext(ctx)
+	if err != nil {
+		return map[string]any{}
 	}
 	return out
 }

--- a/controllers/task_scheduler_controller_test.go
+++ b/controllers/task_scheduler_controller_test.go
@@ -73,6 +73,7 @@ func TestTaskSchedulerAssignsTasksByRequirementsAndCapacity(t *testing.T) {
 			Kind:       "Task",
 			Metadata:   resources.ObjectMeta{Name: "task-west-gpu-1"},
 			Spec: resources.TaskSpec{
+				System:       "test-system",
 				Requirements: resources.TaskRequirements{Region: "us-west", GPU: true, Model: "gpt-4o"},
 			},
 		},
@@ -81,6 +82,7 @@ func TestTaskSchedulerAssignsTasksByRequirementsAndCapacity(t *testing.T) {
 			Kind:       "Task",
 			Metadata:   resources.ObjectMeta{Name: "task-east"},
 			Spec: resources.TaskSpec{
+				System:       "test-system",
 				Requirements: resources.TaskRequirements{Region: "us-east", Model: "gpt-4o"},
 			},
 		},
@@ -89,6 +91,7 @@ func TestTaskSchedulerAssignsTasksByRequirementsAndCapacity(t *testing.T) {
 			Kind:       "Task",
 			Metadata:   resources.ObjectMeta{Name: "task-west-gpu-2"},
 			Spec: resources.TaskSpec{
+				System:       "test-system",
 				Requirements: resources.TaskRequirements{Region: "us-west", GPU: true, Model: "gpt-4o"},
 			},
 		},
@@ -97,6 +100,7 @@ func TestTaskSchedulerAssignsTasksByRequirementsAndCapacity(t *testing.T) {
 			Kind:       "Task",
 			Metadata:   resources.ObjectMeta{Name: "task-no-match"},
 			Spec: resources.TaskSpec{
+				System:       "test-system",
 				Requirements: resources.TaskRequirements{Region: "eu-central", GPU: true, Model: "gpt-4o"},
 			},
 		},
@@ -172,6 +176,7 @@ func TestTaskSchedulerClearsAndReassignsInvalidAssignment(t *testing.T) {
 		Kind:       "Task",
 		Metadata:   resources.ObjectMeta{Name: "task-1"},
 		Spec: resources.TaskSpec{
+			System:       "test-system",
 			Requirements: resources.TaskRequirements{Model: "gpt-4o"},
 		},
 		Status: resources.TaskStatus{AssignedWorker: "worker-stale"},

--- a/controllers/task_task_approval_reconcile_test.go
+++ b/controllers/task_task_approval_reconcile_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/OrlojHQ/orloj/store"
 )
 
+func testEncodeResumeContext(ctx resources.TaskApprovalResumeContext) map[string]any {
+	out, _ := resources.EncodeTaskApprovalResumeContext(ctx)
+	return out
+}
+
 func TestReconcileWaitingTaskApprovalSequentialRequestChangesCreatesNextReviewCycle(t *testing.T) {
 	controller, stores := newTaskControllerHarness()
 	approvals := store.NewTaskApprovalStore()
@@ -620,7 +625,7 @@ func TestReconcileWaitingTaskApprovalMessageDrivenRequestChangesPublishesReviewM
 			ReviewCycle:         1,
 			Output:              "draft v1",
 			OutputFormat:        "text",
-			ResumeContext:       resources.EncodeTaskApprovalResumeContext(resumeContext),
+			ResumeContext:       testEncodeResumeContext(resumeContext),
 		},
 		Status: resources.TaskApprovalStatus{
 			Phase:     "ChangesRequested",
@@ -779,7 +784,7 @@ func TestReconcileWaitingTaskApprovalMessageDrivenApproveUsesFrozenResumeContext
 			ReviewCycle:    1,
 			Output:         "draft v1",
 			OutputFormat:   "text",
-			ResumeContext: resources.EncodeTaskApprovalResumeContext(resources.TaskApprovalResumeContext{
+			ResumeContext: testEncodeResumeContext(resources.TaskApprovalResumeContext{
 				Mode:           "message-driven",
 				Action:         "message_forward",
 				System:         "frozen-message-system",
@@ -898,7 +903,7 @@ func TestReconcileWaitingTaskApprovalMessageDrivenCompletionReviewApproveSucceed
 				"final_report": "approved final output",
 			},
 			OutputFormat: "json",
-			ResumeContext: resources.EncodeTaskApprovalResumeContext(resources.TaskApprovalResumeContext{
+			ResumeContext: testEncodeResumeContext(resources.TaskApprovalResumeContext{
 				Mode:           "message-driven",
 				Action:         "message_complete",
 				System:         "message-review-system",
@@ -1004,7 +1009,7 @@ func TestReconcileWaitingTaskApprovalMessageDrivenChangesRequestedDisabledFailsC
 			ReviewCycle:         1,
 			Output:              "draft v1",
 			OutputFormat:        "text",
-			ResumeContext: resources.EncodeTaskApprovalResumeContext(resources.TaskApprovalResumeContext{
+			ResumeContext: testEncodeResumeContext(resources.TaskApprovalResumeContext{
 				Mode:           "message-driven",
 				Action:         "message_complete",
 				System:         "message-review-system",

--- a/resources/agent.go
+++ b/resources/agent.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -73,32 +74,39 @@ type ListMeta struct {
 
 // Agent represents the desired and observed state for a single agent runtime.
 type Agent struct {
-	APIVersion string      `json:"apiVersion"`
-	Kind       string      `json:"kind"`
-	Metadata   ObjectMeta  `json:"metadata"`
-	Spec       AgentSpec   `json:"spec"`
-	Status     AgentStatus `json:"status,omitempty"`
+	APIVersion string      `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string      `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta  `json:"metadata" yaml:"metadata"`
+	Spec       AgentSpec   `json:"spec" yaml:"spec"`
+	Status     AgentStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
+
+// ResolvedModel returns the runtime-resolved model ID. This is populated
+// after model ref resolution and should be used instead of reading Spec.Model directly.
+func (a *Agent) ResolvedModel() string { return a.Spec.Model }
 
 // AgentList is returned by list API calls.
 type AgentList struct {
-	ListMeta `json:",inline"`
-	Items    []Agent `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []Agent `json:"items" yaml:"items"`
 }
 
 // AgentSpec defines desired runtime behavior.
 type AgentSpec struct {
-	// Model stores the resolved model id for runtime execution and is not part of the external Agent API.
-	Model             string             `json:"-"`
-	ModelRef          string             `json:"model_ref,omitempty"`
-	FallbackModelRefs []string           `json:"fallback_model_refs,omitempty"`
-	Prompt            string             `json:"prompt"`
-	Tools        []string           `json:"tools,omitempty"`
-	AllowedTools []string           `json:"allowed_tools,omitempty"`
-	Roles        []string           `json:"roles,omitempty"`
-	Memory       MemorySpec         `json:"memory,omitempty"`
-	Execution    AgentExecutionSpec `json:"execution,omitempty"`
-	Limits       AgentLimits        `json:"limits,omitempty"`
+	// Model stores the resolved model id for runtime execution.
+	// WARNING: This field is NOT part of the external Agent API (tagged json:"-").
+	// It is populated at runtime from ModelRef resolution. Do not set directly
+	// in struct literals — use ModelRef instead. Read via Agent.ResolvedModel().
+	Model             string             `json:"-" yaml:"-"`
+	ModelRef          string             `json:"model_ref,omitempty" yaml:"model_ref,omitempty"`
+	FallbackModelRefs []string           `json:"fallback_model_refs,omitempty" yaml:"fallback_model_refs,omitempty"`
+	Prompt            string             `json:"prompt" yaml:"prompt"`
+	Tools        []string           `json:"tools,omitempty" yaml:"tools,omitempty"`
+	AllowedTools []string           `json:"allowed_tools,omitempty" yaml:"allowed_tools,omitempty"`
+	Roles        []string           `json:"roles,omitempty" yaml:"roles,omitempty"`
+	Memory       MemorySpec         `json:"memory,omitempty" yaml:"memory,omitempty"`
+	Execution    AgentExecutionSpec `json:"execution,omitempty" yaml:"execution,omitempty"`
+	Limits       AgentLimits        `json:"limits,omitempty" yaml:"limits,omitempty"`
 }
 
 const (
@@ -117,34 +125,34 @@ const (
 
 // AgentExecutionSpec configures optional per-agent execution contracts.
 type AgentExecutionSpec struct {
-	Profile                 string         `json:"profile,omitempty"`
-	ToolSequence            []string       `json:"tool_sequence,omitempty"`
-	RequiredOutputMarkers   []string       `json:"required_output_markers,omitempty"`
-	DuplicateToolCallPolicy string         `json:"duplicate_tool_call_policy,omitempty"`
-	OnContractViolation     string         `json:"on_contract_violation,omitempty"`
-	ToolUseBehavior         string         `json:"tool_use_behavior,omitempty"`
-	OutputSchema            map[string]any `json:"output_schema,omitempty"`
+	Profile                 string         `json:"profile,omitempty" yaml:"profile,omitempty"`
+	ToolSequence            []string       `json:"tool_sequence,omitempty" yaml:"tool_sequence,omitempty"`
+	RequiredOutputMarkers   []string       `json:"required_output_markers,omitempty" yaml:"required_output_markers,omitempty"`
+	DuplicateToolCallPolicy string         `json:"duplicate_tool_call_policy,omitempty" yaml:"duplicate_tool_call_policy,omitempty"`
+	OnContractViolation     string         `json:"on_contract_violation,omitempty" yaml:"on_contract_violation,omitempty"`
+	ToolUseBehavior         string         `json:"tool_use_behavior,omitempty" yaml:"tool_use_behavior,omitempty"`
+	OutputSchema            map[string]any `json:"output_schema,omitempty" yaml:"output_schema,omitempty"`
 }
 
 // MemorySpec configures runtime memory backend.
 type MemorySpec struct {
-	Ref      string   `json:"ref,omitempty"`
-	Type     string   `json:"type,omitempty"`
-	Provider string   `json:"provider,omitempty"`
-	Allow    []string `json:"allow,omitempty"`
+	Ref      string   `json:"ref,omitempty" yaml:"ref,omitempty"`
+	Type     string   `json:"type,omitempty" yaml:"type,omitempty"`
+	Provider string   `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Allow    []string `json:"allow,omitempty" yaml:"allow,omitempty"`
 }
 
 // AgentLimits configures execution safety bounds.
 type AgentLimits struct {
-	MaxSteps int    `json:"max_steps,omitempty"`
-	Timeout  string `json:"timeout,omitempty"`
+	MaxSteps int    `json:"max_steps,omitempty" yaml:"max_steps,omitempty"`
+	Timeout  string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
 // AgentStatus represents current runtime state.
 type AgentStatus struct {
-	Phase              string `json:"phase,omitempty"`
-	LastError          string `json:"lastError,omitempty"`
-	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
+	Phase              string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 // Normalize applies defaults and validates the resource.
@@ -295,6 +303,9 @@ func (a *Agent) Normalize() error {
 	if a.Spec.Execution.Profile == AgentExecutionProfileContract && len(a.Spec.Execution.ToolSequence) == 0 {
 		return fmt.Errorf("spec.execution.tool_sequence is required when spec.execution.profile=contract")
 	}
+	if err := validateOutputSchema(a.Spec.Execution.OutputSchema); err != nil {
+		return fmt.Errorf("spec.execution.output_schema: %w", err)
+	}
 	if a.Spec.Limits.MaxSteps <= 0 {
 		a.Spec.Limits.MaxSteps = 10
 	}
@@ -302,4 +313,42 @@ func (a *Agent) Normalize() error {
 		a.Status.Phase = "Pending"
 	}
 	return nil
+}
+
+const (
+	maxOutputSchemaDepth = 10
+	maxOutputSchemaSize  = 64 * 1024
+)
+
+func validateOutputSchema(schema map[string]any) error {
+	if len(schema) == 0 {
+		return nil
+	}
+	if _, ok := schema["type"]; !ok {
+		return fmt.Errorf("root level must contain a \"type\" key")
+	}
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		return fmt.Errorf("cannot serialize: %w", err)
+	}
+	if len(raw) > maxOutputSchemaSize {
+		return fmt.Errorf("serialized size %d exceeds limit of %d bytes", len(raw), maxOutputSchemaSize)
+	}
+	if depth := mapDepth(schema, 0); depth > maxOutputSchemaDepth {
+		return fmt.Errorf("nesting depth %d exceeds limit of %d", depth, maxOutputSchemaDepth)
+	}
+	return nil
+}
+
+func mapDepth(m map[string]any, current int) int {
+	max := current + 1
+	for _, v := range m {
+		switch child := v.(type) {
+		case map[string]any:
+			if d := mapDepth(child, current+1); d > max {
+				max = d
+			}
+		}
+	}
+	return max
 }

--- a/resources/container_resources.go
+++ b/resources/container_resources.go
@@ -2,12 +2,14 @@ package resources
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 )
 
-// ParseMemoryBytes converts a Docker-style memory string (e.g. "128m", "1g")
-// to bytes. Accepted suffixes: b, k, m, g (case-insensitive).
+// ParseMemoryBytes converts a memory string to bytes.
+// Accepted suffixes (case-insensitive): gi, mi, ki (IEC binary),
+// g, m, k (Docker-style, also 1024-based), b (bytes).
 // A bare integer is treated as bytes.
 func ParseMemoryBytes(s string) (int64, error) {
 	s = strings.TrimSpace(strings.ToLower(s))
@@ -16,6 +18,15 @@ func ParseMemoryBytes(s string) (int64, error) {
 	}
 	multiplier := int64(1)
 	switch {
+	case strings.HasSuffix(s, "gi"):
+		multiplier = 1024 * 1024 * 1024
+		s = strings.TrimSuffix(s, "gi")
+	case strings.HasSuffix(s, "mi"):
+		multiplier = 1024 * 1024
+		s = strings.TrimSuffix(s, "mi")
+	case strings.HasSuffix(s, "ki"):
+		multiplier = 1024
+		s = strings.TrimSuffix(s, "ki")
 	case strings.HasSuffix(s, "g"):
 		multiplier = 1024 * 1024 * 1024
 		s = strings.TrimSuffix(s, "g")
@@ -34,6 +45,9 @@ func ParseMemoryBytes(s string) (int64, error) {
 	}
 	if v <= 0 {
 		return 0, fmt.Errorf("memory value must be positive, got %d", v)
+	}
+	if multiplier > 1 && v > math.MaxInt64/multiplier {
+		return 0, fmt.Errorf("memory value overflows int64")
 	}
 	return v * multiplier, nil
 }

--- a/resources/container_resources_test.go
+++ b/resources/container_resources_test.go
@@ -41,6 +41,49 @@ func TestParseMemoryBytes(t *testing.T) {
 	}
 }
 
+func TestParseMemoryBytes_Overflow(t *testing.T) {
+	overflowCases := []string{
+		"9999999999g",
+		"9999999999999m",
+		"9223372036854775807k",
+	}
+	for _, input := range overflowCases {
+		t.Run(input, func(t *testing.T) {
+			_, err := ParseMemoryBytes(input)
+			if err == nil {
+				t.Fatalf("expected overflow error for %q", input)
+			}
+			if !strings.Contains(err.Error(), "overflow") {
+				t.Fatalf("expected overflow in error message, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseMemoryBytes_KubernetesStyle(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"1Gi", 1024 * 1024 * 1024},
+		{"128Mi", 128 * 1024 * 1024},
+		{"512Ki", 512 * 1024},
+		{"2gi", 2 * 1024 * 1024 * 1024},
+		{"256mi", 256 * 1024 * 1024},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseMemoryBytes(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseMemoryBytes(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateContainerResources(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/resources/graph.go
+++ b/resources/graph.go
@@ -112,9 +112,13 @@ func edgeConditionMatches(c *EdgeCondition, output, outputLower string) bool {
 		}
 	}
 	if c.OutputMatches != "" {
-		re, err := regexp.Compile(c.OutputMatches)
-		if err != nil {
-			return false
+		re := c.CompiledOutputMatches
+		if re == nil {
+			var err error
+			re, err = regexp.Compile(c.OutputMatches)
+			if err != nil {
+				return false
+			}
 		}
 		if !re.MatchString(output) {
 			return false
@@ -261,8 +265,8 @@ func jsonValueContains(val any, target string) bool {
 	}
 }
 
-// NormalizeGraphJoin applies defaults and clamps unsupported values.
-func NormalizeGraphJoin(join GraphJoin) GraphJoin {
+// NormalizeGraphJoin applies defaults and validates join configuration.
+func NormalizeGraphJoin(join GraphJoin) (GraphJoin, error) {
 	mode := strings.ToLower(strings.TrimSpace(join.Mode))
 	switch mode {
 	case "", "wait_for_all":
@@ -270,7 +274,7 @@ func NormalizeGraphJoin(join GraphJoin) GraphJoin {
 	case "quorum":
 		join.Mode = "quorum"
 	default:
-		join.Mode = "wait_for_all"
+		return join, fmt.Errorf("invalid join.mode %q: expected wait_for_all or quorum", join.Mode)
 	}
 
 	if join.QuorumCount < 0 {
@@ -292,7 +296,7 @@ func NormalizeGraphJoin(join GraphJoin) GraphJoin {
 	case "continue_partial":
 		join.OnFailure = "continue_partial"
 	default:
-		join.OnFailure = "deadletter"
+		return join, fmt.Errorf("invalid join.on_failure %q: expected deadletter, skip, or continue_partial", join.OnFailure)
 	}
-	return join
+	return join, nil
 }

--- a/resources/graph_test.go
+++ b/resources/graph_test.go
@@ -954,7 +954,7 @@ spec:
 	if len(mgr.Delegates) != 3 {
 		t.Fatalf("expected 3 delegates, got %d", len(mgr.Delegates))
 	}
-	join := NormalizeGraphJoin(mgr.DelegateJoin)
+	join, _ := NormalizeGraphJoin(mgr.DelegateJoin)
 	if join.Mode != "quorum" {
 		t.Fatalf("expected quorum mode, got %q", join.Mode)
 	}
@@ -969,4 +969,48 @@ func routeNames(routes []GraphRoute) []string {
 		names[i] = r.To
 	}
 	return names
+}
+
+func TestNormalizeGraphJoin_InvalidMode(t *testing.T) {
+	_, err := NormalizeGraphJoin(GraphJoin{Mode: "quorom"})
+	if err == nil {
+		t.Fatal("expected error for invalid mode 'quorom'")
+	}
+}
+
+func TestNormalizeGraphJoin_InvalidOnFailure(t *testing.T) {
+	_, err := NormalizeGraphJoin(GraphJoin{Mode: "wait_for_all", OnFailure: "bogus"})
+	if err == nil {
+		t.Fatal("expected error for invalid on_failure 'bogus'")
+	}
+}
+
+func TestNormalizeGraphJoin_ValidModes(t *testing.T) {
+	join, err := NormalizeGraphJoin(GraphJoin{Mode: "quorum", OnFailure: "skip"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if join.Mode != "quorum" {
+		t.Fatalf("expected quorum, got %q", join.Mode)
+	}
+	if join.OnFailure != "skip" {
+		t.Fatalf("expected skip, got %q", join.OnFailure)
+	}
+}
+
+func TestEdgeConditionRegexLengthLimit(t *testing.T) {
+	longPattern := make([]byte, 600)
+	for i := range longPattern {
+		longPattern[i] = 'a'
+	}
+	routes := []GraphRoute{{
+		To: "next",
+		Condition: &EdgeCondition{
+			OutputMatches: string(longPattern),
+		},
+	}}
+	_, err := normalizeGraphRoutes(routes, "test", "edges")
+	if err == nil {
+		t.Fatal("expected error for regex exceeding 512 chars")
+	}
 }

--- a/resources/manifest_parser.go
+++ b/resources/manifest_parser.go
@@ -7,6 +7,18 @@ import (
 	"strings"
 )
 
+// rejectMultiDocumentYAML returns an error if the input contains a YAML
+// document separator (`---` on its own line). Multi-document streams are not
+// supported; each resource must be applied individually.
+func rejectMultiDocumentYAML(data []byte) error {
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "---" {
+			return fmt.Errorf("multi-document YAML is not supported; split documents and apply individually")
+		}
+	}
+	return nil
+}
+
 // yamlScalarToTyped converts a bare YAML scalar string to its natural Go type:
 // "true"/"false" → bool, integer strings → int64, float strings → float64,
 // inline arrays "[a, b, c]" → []any of typed elements,
@@ -31,7 +43,7 @@ func yamlScalarToTyped(s string) any {
 		if inner == "" {
 			return []any{}
 		}
-		parts := strings.Split(inner, ",")
+		parts := splitFlowArray(inner)
 		arr := make([]any, 0, len(parts))
 		for _, p := range parts {
 			arr = append(arr, yamlScalarToTyped(stripQuotes(strings.TrimSpace(p))))
@@ -41,8 +53,38 @@ func yamlScalarToTyped(s string) any {
 	return s
 }
 
+// splitFlowArray splits a YAML flow sequence body on commas, respecting
+// quoted strings so that commas inside quotes are not treated as separators.
+func splitFlowArray(inner string) []string {
+	var parts []string
+	var current strings.Builder
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(inner); i++ {
+		ch := inner[i]
+		switch {
+		case ch == '\'' && !inDouble:
+			inSingle = !inSingle
+			current.WriteByte(ch)
+		case ch == '"' && !inSingle:
+			inDouble = !inDouble
+			current.WriteByte(ch)
+		case ch == ',' && !inSingle && !inDouble:
+			parts = append(parts, current.String())
+			current.Reset()
+		default:
+			current.WriteByte(ch)
+		}
+	}
+	parts = append(parts, current.String())
+	return parts
+}
+
 // ParseAgentManifest accepts either JSON or a constrained YAML subset for Agent resources.
 func ParseAgentManifest(data []byte) (Agent, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return Agent{}, err
+	}
 	var agent Agent
 
 	if json.Valid(data) {

--- a/resources/manifest_parser_context_adapter.go
+++ b/resources/manifest_parser_context_adapter.go
@@ -9,6 +9,9 @@ import (
 
 // ParseContextAdapterManifest parses ContextAdapter resources from JSON or YAML (Kubernetes-style).
 func ParseContextAdapterManifest(data []byte) (ContextAdapter, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return ContextAdapter{}, err
+	}
 	var out ContextAdapter
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {

--- a/resources/manifest_parser_ext.go
+++ b/resources/manifest_parser_ext.go
@@ -45,6 +45,9 @@ func DetectKind(data []byte) (string, error) {
 
 // ParseAgentSystemManifest parses AgentSystem resources from JSON or constrained YAML.
 func ParseAgentSystemManifest(data []byte) (AgentSystem, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return AgentSystem{}, err
+	}
 	var out AgentSystem
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -462,6 +465,9 @@ func applyReviewCheckpointField(spec *ReviewCheckpointSpec, key, value string) e
 
 // ParseToolManifest parses Tool resources from JSON or constrained YAML.
 func ParseToolManifest(data []byte) (Tool, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return Tool{}, err
+	}
 	var out Tool
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -932,6 +938,9 @@ func parseSecretManifestWithoutNormalize(data []byte) (Secret, error) {
 
 // ParseSecretManifest parses Secret resources from JSON or constrained YAML.
 func ParseSecretManifest(data []byte) (Secret, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return Secret{}, err
+	}
 	out, err := parseSecretManifestWithoutNormalize(data)
 	if err != nil {
 		return Secret{}, err
@@ -944,6 +953,9 @@ func ParseSecretManifest(data []byte) (Secret, error) {
 
 // ParseMemoryManifest parses Memory resources from JSON or constrained YAML.
 func ParseMemoryManifest(data []byte) (Memory, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return Memory{}, err
+	}
 	var out Memory
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -1027,6 +1039,9 @@ func ParseMemoryManifest(data []byte) (Memory, error) {
 
 // ParseAgentPolicyManifest parses AgentPolicy resources from JSON or constrained YAML.
 func ParseAgentPolicyManifest(data []byte) (AgentPolicy, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return AgentPolicy{}, err
+	}
 	var out AgentPolicy
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -1158,6 +1173,9 @@ func ParseAgentPolicyManifest(data []byte) (AgentPolicy, error) {
 
 // ParseAgentRoleManifest parses AgentRole resources from JSON or constrained YAML.
 func ParseAgentRoleManifest(data []byte) (AgentRole, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return AgentRole{}, err
+	}
 	var out AgentRole
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -1239,6 +1257,9 @@ func ParseAgentRoleManifest(data []byte) (AgentRole, error) {
 
 // ParseToolPermissionManifest parses ToolPermission resources from JSON or constrained YAML.
 func ParseToolPermissionManifest(data []byte) (ToolPermission, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return ToolPermission{}, err
+	}
 	var out ToolPermission
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -1364,6 +1385,9 @@ func ParseToolPermissionManifest(data []byte) (ToolPermission, error) {
 
 // ParseToolApprovalManifest parses ToolApproval resources from JSON or constrained YAML.
 func ParseToolApprovalManifest(data []byte) (ToolApproval, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return ToolApproval{}, err
+	}
 	var out ToolApproval
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -1460,6 +1484,9 @@ func ParseToolApprovalManifest(data []byte) (ToolApproval, error) {
 
 // ParseTaskApprovalManifest parses TaskApproval resources from JSON or constrained YAML.
 func ParseTaskApprovalManifest(data []byte) (TaskApproval, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return TaskApproval{}, err
+	}
 	var out TaskApproval
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -1633,6 +1660,9 @@ func ParseTaskApprovalManifest(data []byte) (TaskApproval, error) {
 
 // ParseTaskManifest parses Task resources from JSON or constrained YAML.
 func ParseTaskManifest(data []byte) (Task, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return Task{}, err
+	}
 	var out Task
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -1775,6 +1805,9 @@ func ParseTaskManifest(data []byte) (Task, error) {
 
 // ParseTaskScheduleManifest parses TaskSchedule resources from JSON or constrained YAML.
 func ParseTaskScheduleManifest(data []byte) (TaskSchedule, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return TaskSchedule{}, err
+	}
 	var out TaskSchedule
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -1936,6 +1969,9 @@ func ParseTaskScheduleManifest(data []byte) (TaskSchedule, error) {
 
 // ParseTaskWebhookManifest parses TaskWebhook resources from JSON or constrained YAML.
 func ParseTaskWebhookManifest(data []byte) (TaskWebhook, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return TaskWebhook{}, err
+	}
 	var out TaskWebhook
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -2123,6 +2159,9 @@ func ParseTaskWebhookManifest(data []byte) (TaskWebhook, error) {
 
 // ParseWorkerManifest parses Worker resources from JSON or constrained YAML.
 func ParseWorkerManifest(data []byte) (Worker, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return Worker{}, err
+	}
 	var out Worker
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {
@@ -2220,6 +2259,9 @@ func ParseWorkerManifest(data []byte) (Worker, error) {
 
 // ParseMcpServerManifest parses McpServer resources from JSON or constrained YAML.
 func ParseMcpServerManifest(data []byte) (McpServer, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return McpServer{}, err
+	}
 	var out McpServer
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {

--- a/resources/manifest_parser_model_endpoint.go
+++ b/resources/manifest_parser_model_endpoint.go
@@ -8,6 +8,9 @@ import (
 
 // ParseModelEndpointManifest parses ModelEndpoint resources from JSON or constrained YAML.
 func ParseModelEndpointManifest(data []byte) (ModelEndpoint, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return ModelEndpoint{}, err
+	}
 	var out ModelEndpoint
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {

--- a/resources/manifest_parser_sealed_secret.go
+++ b/resources/manifest_parser_sealed_secret.go
@@ -7,6 +7,9 @@ import (
 )
 
 func ParseSealedSecretManifest(data []byte) (SealedSecret, error) {
+	if err := rejectMultiDocumentYAML(data); err != nil {
+		return SealedSecret{}, err
+	}
 	var out SealedSecret
 	if json.Valid(data) {
 		if err := json.Unmarshal(data, &out); err != nil {

--- a/resources/parse_manifest_test.go
+++ b/resources/parse_manifest_test.go
@@ -60,3 +60,132 @@ spec:
 		t.Fatalf("name: got %q", name)
 	}
 }
+
+func TestParseAgentManifest_MultiDocument(t *testing.T) {
+	raw := []byte(`apiVersion: orloj.dev/v1
+kind: Agent
+metadata:
+  name: first
+spec:
+  model_ref: mep
+  prompt: hello
+---
+apiVersion: orloj.dev/v1
+kind: Agent
+metadata:
+  name: second
+spec:
+  model_ref: mep
+  prompt: world
+`)
+	_, err := ParseAgentManifest(raw)
+	if err == nil {
+		t.Fatal("expected error for multi-document YAML")
+	}
+	if !strings.Contains(err.Error(), "multi-document") {
+		t.Fatalf("expected multi-document error, got: %v", err)
+	}
+}
+
+func TestAgentNormalize_OutputSchemaDepthLimit(t *testing.T) {
+	schema := map[string]any{"type": "object"}
+	current := schema
+	for i := 0; i < 20; i++ {
+		child := map[string]any{"type": "object"}
+		current["properties"] = child
+		current = child
+	}
+	agent := Agent{
+		Metadata: ObjectMeta{Name: "deep-schema"},
+		Spec: AgentSpec{
+			ModelRef:  "mep",
+			Prompt:    "test",
+			Execution: AgentExecutionSpec{OutputSchema: schema},
+		},
+	}
+	err := agent.Normalize()
+	if err == nil {
+		t.Fatal("expected error for deeply nested output schema")
+	}
+	if !strings.Contains(err.Error(), "nesting depth") {
+		t.Fatalf("expected nesting depth error, got: %v", err)
+	}
+}
+
+func TestAgentNormalize_OutputSchemaRequiresType(t *testing.T) {
+	agent := Agent{
+		Metadata: ObjectMeta{Name: "no-type"},
+		Spec: AgentSpec{
+			ModelRef:  "mep",
+			Prompt:    "test",
+			Execution: AgentExecutionSpec{OutputSchema: map[string]any{"description": "foo"}},
+		},
+	}
+	err := agent.Normalize()
+	if err == nil {
+		t.Fatal("expected error for schema without type key")
+	}
+}
+
+func TestTaskNormalize_RunModeRequiresSystem(t *testing.T) {
+	task := Task{
+		Metadata: ObjectMeta{Name: "no-system"},
+		Spec: TaskSpec{
+			Mode: "run",
+		},
+	}
+	err := task.Normalize()
+	if err == nil {
+		t.Fatal("expected error when spec.system is empty in run mode")
+	}
+	if !strings.Contains(err.Error(), "spec.system is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTaskNormalize_TemplateModeNoSystemOK(t *testing.T) {
+	task := Task{
+		Metadata: ObjectMeta{Name: "template-task"},
+		Spec: TaskSpec{
+			Mode: "template",
+		},
+	}
+	err := task.Normalize()
+	if err != nil {
+		t.Fatalf("template mode should not require system: %v", err)
+	}
+}
+
+func TestYamlScalarToTyped_QuotedCommas(t *testing.T) {
+	result := yamlScalarToTyped(`[a, "hello, world", b]`)
+	arr, ok := result.([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", result)
+	}
+	if len(arr) != 3 {
+		t.Fatalf("expected 3 elements, got %d: %v", len(arr), arr)
+	}
+	if arr[0] != "a" {
+		t.Fatalf("arr[0] = %q, want %q", arr[0], "a")
+	}
+	if arr[1] != "hello, world" {
+		t.Fatalf("arr[1] = %q, want %q", arr[1], "hello, world")
+	}
+	if arr[2] != "b" {
+		t.Fatalf("arr[2] = %q, want %q", arr[2], "b")
+	}
+}
+
+func TestYamlScalarToTyped_SingleQuotedCommas(t *testing.T) {
+	result := yamlScalarToTyped(`['one, two', three]`)
+	arr, ok := result.([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", result)
+	}
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 elements, got %d: %v", len(arr), arr)
+	}
+	if arr[0] != "one, two" {
+		t.Fatalf("arr[0] = %q, want %q", arr[0], "one, two")
+	}
+}

--- a/resources/resource_types.go
+++ b/resources/resource_types.go
@@ -29,44 +29,44 @@ func normalizeGovernanceConfigPhase(phase *string) {
 
 // AgentSystem defines a multi-agent architecture and execution graph.
 type AgentSystem struct {
-	APIVersion string            `json:"apiVersion"`
-	Kind       string            `json:"kind"`
-	Metadata   ObjectMeta        `json:"metadata"`
-	Spec       AgentSystemSpec   `json:"spec"`
-	Status     AgentSystemStatus `json:"status,omitempty"`
+	APIVersion string            `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string            `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta        `json:"metadata" yaml:"metadata"`
+	Spec       AgentSystemSpec   `json:"spec" yaml:"spec"`
+	Status     AgentSystemStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type AgentSystemSpec struct {
-	Agents           []string              `json:"agents,omitempty"`
-	Graph            map[string]GraphEdge  `json:"graph,omitempty"`
-	CompletionReview *ReviewCheckpointSpec `json:"completion_review,omitempty"`
-	ContextAdapter   string                `json:"context_adapter,omitempty"`
+	Agents           []string              `json:"agents,omitempty" yaml:"agents,omitempty"`
+	Graph            map[string]GraphEdge  `json:"graph,omitempty" yaml:"graph,omitempty"`
+	CompletionReview *ReviewCheckpointSpec `json:"completion_review,omitempty" yaml:"completion_review,omitempty"`
+	ContextAdapter   string                `json:"context_adapter,omitempty" yaml:"context_adapter,omitempty"`
 }
 
 type GraphEdge struct {
 	// Legacy single-hop edge. Preserved for backward compatibility.
-	Next string `json:"next,omitempty"`
+	Next string `json:"next,omitempty" yaml:"next,omitempty"`
 	// Rich edge list for fan-out and per-edge metadata.
-	Edges []GraphRoute `json:"edges,omitempty"`
+	Edges []GraphRoute `json:"edges,omitempty" yaml:"edges,omitempty"`
 	// Join semantics for this downstream node.
-	Join GraphJoin `json:"join,omitempty"`
+	Join GraphJoin `json:"join,omitempty" yaml:"join,omitempty"`
 	// Delegates dispatched after the node's first execution. Reports
 	// flow back and trigger a review re-execution before edges fire.
-	Delegates []GraphRoute `json:"delegates,omitempty"`
+	Delegates []GraphRoute `json:"delegates,omitempty" yaml:"delegates,omitempty"`
 	// DelegateJoin controls how delegate returns are collected.
-	DelegateJoin GraphJoin `json:"delegate_join,omitempty"`
+	DelegateJoin GraphJoin `json:"delegate_join,omitempty" yaml:"delegate_join,omitempty"`
 	// Review gates this node's output behind a human approval checkpoint.
-	Review *ReviewCheckpointSpec `json:"review,omitempty"`
+	Review *ReviewCheckpointSpec `json:"review,omitempty" yaml:"review,omitempty"`
 }
 
 type GraphRoute struct {
-	To string `json:"to,omitempty"`
+	To string `json:"to,omitempty" yaml:"to,omitempty"`
 	// Optional labels used by routing/observability layers.
-	Labels map[string]string `json:"labels,omitempty"`
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// Optional policy key/value bag for edge-level controls.
-	Policy map[string]string `json:"policy,omitempty"`
+	Policy map[string]string `json:"policy,omitempty" yaml:"policy,omitempty"`
 	// Optional condition that must match the completing agent's output for this edge to fire.
-	Condition *EdgeCondition `json:"condition,omitempty"`
+	Condition *EdgeCondition `json:"condition,omitempty" yaml:"condition,omitempty"`
 }
 
 // EdgeCondition defines a predicate evaluated against the completing agent's output
@@ -74,59 +74,61 @@ type GraphRoute struct {
 // (logical AND). Use Default to mark a fallback edge.
 type EdgeCondition struct {
 	// OutputContains matches if the output contains this string (case-insensitive).
-	OutputContains string `json:"output_contains,omitempty"`
+	OutputContains string `json:"output_contains,omitempty" yaml:"output_contains,omitempty"`
 	// OutputNotContains matches if the output does NOT contain this string (case-insensitive).
-	OutputNotContains string `json:"output_not_contains,omitempty"`
+	OutputNotContains string `json:"output_not_contains,omitempty" yaml:"output_not_contains,omitempty"`
 	// OutputMatches matches if the output matches this regex pattern.
-	OutputMatches string `json:"output_matches,omitempty"`
+	OutputMatches string `json:"output_matches,omitempty" yaml:"output_matches,omitempty"`
+	// CompiledOutputMatches is the pre-compiled regex from OutputMatches, populated during normalization.
+	CompiledOutputMatches *regexp.Regexp `json:"-" yaml:"-"`
 	// Default marks this edge as the fallback when no conditional edge matches.
-	Default bool `json:"default,omitempty"`
+	Default bool `json:"default,omitempty" yaml:"default,omitempty"`
 
 	// OutputJSONPath extracts a value from JSON output using dot-notation (e.g. "$.route").
 	// When set, one of the comparison operators (Equals, NotEquals, Contains, GreaterThan,
 	// LessThan) must also be set.
-	OutputJSONPath string `json:"output_json_path,omitempty"`
+	OutputJSONPath string `json:"output_json_path,omitempty" yaml:"output_json_path,omitempty"`
 	// Equals matches when the extracted JSON value equals this string.
-	Equals string `json:"equals,omitempty"`
+	Equals string `json:"equals,omitempty" yaml:"equals,omitempty"`
 	// NotEquals matches when the extracted JSON value does NOT equal this string.
-	NotEquals string `json:"not_equals,omitempty"`
+	NotEquals string `json:"not_equals,omitempty" yaml:"not_equals,omitempty"`
 	// Contains matches when the extracted JSON value (string or array) contains this value.
-	Contains string `json:"contains,omitempty"`
+	Contains string `json:"contains,omitempty" yaml:"contains,omitempty"`
 	// GreaterThan matches when the extracted numeric JSON value is greater than this threshold.
-	GreaterThan string `json:"greater_than,omitempty"`
+	GreaterThan string `json:"greater_than,omitempty" yaml:"greater_than,omitempty"`
 	// LessThan matches when the extracted numeric JSON value is less than this threshold.
-	LessThan string `json:"less_than,omitempty"`
+	LessThan string `json:"less_than,omitempty" yaml:"less_than,omitempty"`
 }
 
 type GraphJoin struct {
 	// Mode: wait_for_all | quorum.
-	Mode string `json:"mode,omitempty"`
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"`
 	// QuorumCount is an absolute minimum number of upstream branches.
-	QuorumCount int `json:"quorum_count,omitempty"`
+	QuorumCount int `json:"quorum_count,omitempty" yaml:"quorum_count,omitempty"`
 	// QuorumPercent is percentage-based minimum of expected branches (0-100).
-	QuorumPercent int `json:"quorum_percent,omitempty"`
+	QuorumPercent int `json:"quorum_percent,omitempty" yaml:"quorum_percent,omitempty"`
 	// OnFailure: deadletter | skip | continue_partial.
-	OnFailure string `json:"on_failure,omitempty"`
+	OnFailure string `json:"on_failure,omitempty" yaml:"on_failure,omitempty"`
 }
 
 type ReviewCheckpointSpec struct {
-	CheckpointID        string `json:"checkpoint_id,omitempty"`
-	DisplayName         string `json:"display_name,omitempty"`
-	Reason              string `json:"reason,omitempty"`
-	TTL                 string `json:"ttl,omitempty"`
-	AllowRequestChanges *bool  `json:"allow_request_changes,omitempty"`
-	MaxReviewCycles     int    `json:"max_review_cycles,omitempty"`
+	CheckpointID        string `json:"checkpoint_id,omitempty" yaml:"checkpoint_id,omitempty"`
+	DisplayName         string `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Reason              string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	TTL                 string `json:"ttl,omitempty" yaml:"ttl,omitempty"`
+	AllowRequestChanges *bool  `json:"allow_request_changes,omitempty" yaml:"allow_request_changes,omitempty"`
+	MaxReviewCycles     int    `json:"max_review_cycles,omitempty" yaml:"max_review_cycles,omitempty"`
 }
 
 type AgentSystemStatus struct {
-	Phase              string `json:"phase,omitempty"`
-	LastError          string `json:"lastError,omitempty"`
-	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
+	Phase              string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type AgentSystemList struct {
-	ListMeta `json:",inline"`
-	Items    []AgentSystem `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []AgentSystem `json:"items" yaml:"items"`
 }
 
 func normalizeGraphRoutes(routes []GraphRoute, node, field string) ([]GraphRoute, error) {
@@ -148,9 +150,14 @@ func normalizeGraphRoutes(routes []GraphRoute, node, field string) ([]GraphRoute
 			route.Condition.GreaterThan = strings.TrimSpace(route.Condition.GreaterThan)
 			route.Condition.LessThan = strings.TrimSpace(route.Condition.LessThan)
 			if route.Condition.OutputMatches != "" {
-				if _, err := regexp.Compile(route.Condition.OutputMatches); err != nil {
+				if len(route.Condition.OutputMatches) > 512 {
+					return nil, fmt.Errorf("spec.graph.%s.%s[%s].condition.output_matches: pattern exceeds 512 chars", node, field, route.To)
+				}
+				compiled, err := regexp.Compile(route.Condition.OutputMatches)
+				if err != nil {
 					return nil, fmt.Errorf("spec.graph.%s.%s[%s].condition.output_matches: invalid regex %q: %w", node, field, route.To, route.Condition.OutputMatches, err)
 				}
+				route.Condition.CompiledOutputMatches = compiled
 			}
 			hasJSONOp := route.Condition.Equals != "" || route.Condition.NotEquals != "" ||
 				route.Condition.Contains != "" || route.Condition.GreaterThan != "" || route.Condition.LessThan != ""
@@ -235,6 +242,16 @@ func (a *AgentSystem) Normalize() error {
 			}
 			seenCheckpoints[checkpointKey] = fmt.Sprintf("spec.graph.%s.review", name)
 		}
+		normalizedJoin, err := NormalizeGraphJoin(node.Join)
+		if err != nil {
+			return fmt.Errorf("spec.graph.%s.join: %w", name, err)
+		}
+		node.Join = normalizedJoin
+		normalizedDelegateJoin, err := NormalizeGraphJoin(node.DelegateJoin)
+		if err != nil {
+			return fmt.Errorf("spec.graph.%s.delegate_join: %w", name, err)
+		}
+		node.DelegateJoin = normalizedDelegateJoin
 		a.Spec.Graph[name] = node
 	}
 	if a.Spec.CompletionReview != nil {
@@ -348,127 +365,127 @@ func normalizeReviewCheckpoint(spec *ReviewCheckpointSpec, path string) error {
 
 // Tool defines an external capability that agents can call.
 type Tool struct {
-	APIVersion string     `json:"apiVersion"`
-	Kind       string     `json:"kind"`
-	Metadata   ObjectMeta `json:"metadata"`
-	Spec       ToolSpec   `json:"spec"`
-	Status     ToolStatus `json:"status,omitempty"`
+	APIVersion string     `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string     `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta `json:"metadata" yaml:"metadata"`
+	Spec       ToolSpec   `json:"spec" yaml:"spec"`
+	Status     ToolStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type ToolSpec struct {
-	Type             string            `json:"type,omitempty"`
-	Endpoint         string            `json:"endpoint,omitempty"`
-	Description      string            `json:"description,omitempty"`
-	InputSchema      map[string]any    `json:"input_schema,omitempty"`
-	McpServerRef     string            `json:"mcp_server_ref,omitempty"`
-	McpToolName      string            `json:"mcp_tool_name,omitempty"`
-	Cli              ToolCliSpec       `json:"cli,omitempty"`
-	Wasm             ToolWasmSpec      `json:"wasm,omitempty"`
-	Capabilities     []string          `json:"capabilities,omitempty"`
-	OperationClasses []string          `json:"operation_classes,omitempty"`
-	RiskLevel        string            `json:"risk_level,omitempty"`
-	Runtime          ToolRuntimePolicy `json:"runtime,omitempty"`
-	Auth             ToolAuth          `json:"auth,omitempty"`
+	Type             string            `json:"type,omitempty" yaml:"type,omitempty"`
+	Endpoint         string            `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Description      string            `json:"description,omitempty" yaml:"description,omitempty"`
+	InputSchema      map[string]any    `json:"input_schema,omitempty" yaml:"input_schema,omitempty"`
+	McpServerRef     string            `json:"mcp_server_ref,omitempty" yaml:"mcp_server_ref,omitempty"`
+	McpToolName      string            `json:"mcp_tool_name,omitempty" yaml:"mcp_tool_name,omitempty"`
+	Cli              ToolCliSpec       `json:"cli,omitempty" yaml:"cli,omitempty"`
+	Wasm             ToolWasmSpec      `json:"wasm,omitempty" yaml:"wasm,omitempty"`
+	Capabilities     []string          `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	OperationClasses []string          `json:"operation_classes,omitempty" yaml:"operation_classes,omitempty"`
+	RiskLevel        string            `json:"risk_level,omitempty" yaml:"risk_level,omitempty"`
+	Runtime          ToolRuntimePolicy `json:"runtime,omitempty" yaml:"runtime,omitempty"`
+	Auth             ToolAuth          `json:"auth,omitempty" yaml:"auth,omitempty"`
 }
 
 // ToolWasmSpec configures per-tool WASM module execution.
 // Module may be a local path, HTTPS URL, or OCI artifact reference (oci://...).
 type ToolWasmSpec struct {
-	Module          string `json:"module,omitempty"`
-	Entrypoint      string `json:"entrypoint,omitempty"`
-	MaxMemoryBytes  int64  `json:"max_memory_bytes,omitempty"`
-	Fuel            uint64 `json:"fuel,omitempty"`
-	EnableWASI      bool   `json:"enable_wasi"`
-	ImagePullSecret string `json:"image_pull_secret,omitempty"`
+	Module          string `json:"module,omitempty" yaml:"module,omitempty"`
+	Entrypoint      string `json:"entrypoint,omitempty" yaml:"entrypoint,omitempty"`
+	MaxMemoryBytes  int64  `json:"max_memory_bytes,omitempty" yaml:"max_memory_bytes,omitempty"`
+	Fuel            uint64 `json:"fuel,omitempty" yaml:"fuel,omitempty"`
+	EnableWASI      bool   `json:"enable_wasi" yaml:"enable_wasi"`
+	ImagePullSecret string `json:"image_pull_secret,omitempty" yaml:"image_pull_secret,omitempty"`
 }
 
 // ContainerResources defines per-tool or per-McpServer container resource
 // overrides. When set, these take precedence over the global
 // --tool-container-{memory,cpus,pids-limit} flags.
 type ContainerResources struct {
-	Memory    string `json:"memory,omitempty"`
-	CPUs      string `json:"cpus,omitempty"`
-	PidsLimit int    `json:"pids_limit,omitempty"`
+	Memory    string `json:"memory,omitempty" yaml:"memory,omitempty"`
+	CPUs      string `json:"cpus,omitempty" yaml:"cpus,omitempty"`
+	PidsLimit int    `json:"pids_limit,omitempty" yaml:"pids_limit,omitempty"`
 }
 
 // ToolCliSpec defines the configuration for CLI tool invocations.
 type ToolCliSpec struct {
-	Command         string             `json:"command,omitempty"`
-	Args            []string           `json:"args,omitempty"`
-	Image           string             `json:"image,omitempty"`
-	ImagePullSecret string             `json:"image_pull_secret,omitempty"`
-	Network         string             `json:"network,omitempty"`
-	StdinFromInput  bool               `json:"stdin_from_input,omitempty"`
-	Output          string             `json:"output,omitempty"`
-	WorkingDir      string             `json:"working_dir,omitempty"`
-	Env             map[string]string  `json:"env,omitempty"`
-	EnvFrom         []ToolCliEnvRef    `json:"env_from,omitempty"`
-	Resources       ContainerResources `json:"resources,omitempty"`
+	Command         string             `json:"command,omitempty" yaml:"command,omitempty"`
+	Args            []string           `json:"args,omitempty" yaml:"args,omitempty"`
+	Image           string             `json:"image,omitempty" yaml:"image,omitempty"`
+	ImagePullSecret string             `json:"image_pull_secret,omitempty" yaml:"image_pull_secret,omitempty"`
+	Network         string             `json:"network,omitempty" yaml:"network,omitempty"`
+	StdinFromInput  bool               `json:"stdin_from_input,omitempty" yaml:"stdin_from_input,omitempty"`
+	Output          string             `json:"output,omitempty" yaml:"output,omitempty"`
+	WorkingDir      string             `json:"working_dir,omitempty" yaml:"working_dir,omitempty"`
+	Env             map[string]string  `json:"env,omitempty" yaml:"env,omitempty"`
+	EnvFrom         []ToolCliEnvRef    `json:"env_from,omitempty" yaml:"env_from,omitempty"`
+	Resources       ContainerResources `json:"resources,omitempty" yaml:"resources,omitempty"`
 }
 
 // ToolCliEnvRef maps an Orloj secret to a process environment variable.
 type ToolCliEnvRef struct {
-	Name      string `json:"name"`
-	SecretRef string `json:"secretRef"`
-	Key       string `json:"key,omitempty"`
+	Name      string `json:"name" yaml:"name"`
+	SecretRef string `json:"secretRef" yaml:"secretRef"`
+	Key       string `json:"key,omitempty" yaml:"key,omitempty"`
 }
 
 type ToolAuth struct {
-	Profile    string   `json:"profile,omitempty"`
-	SecretRef  string   `json:"secretRef,omitempty"`
-	HeaderName string   `json:"headerName,omitempty"`
-	TokenURL   string   `json:"tokenURL,omitempty"`
-	Scopes     []string `json:"scopes,omitempty"`
+	Profile    string   `json:"profile,omitempty" yaml:"profile,omitempty"`
+	SecretRef  string   `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	HeaderName string   `json:"headerName,omitempty" yaml:"headerName,omitempty"`
+	TokenURL   string   `json:"tokenURL,omitempty" yaml:"tokenURL,omitempty"`
+	Scopes     []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 }
 
 // Secret stores sensitive values for runtime tool auth.
 // Data values are base64-encoded (Kubernetes style).
 type Secret struct {
-	APIVersion string       `json:"apiVersion"`
-	Kind       string       `json:"kind"`
-	Metadata   ObjectMeta   `json:"metadata"`
-	Spec       SecretSpec   `json:"spec"`
-	Status     SecretStatus `json:"status,omitempty"`
+	APIVersion string       `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string       `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta   `json:"metadata" yaml:"metadata"`
+	Spec       SecretSpec   `json:"spec" yaml:"spec"`
+	Status     SecretStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type SecretSpec struct {
-	Data       map[string]string `json:"data,omitempty"`
-	StringData map[string]string `json:"stringData,omitempty"`
+	Data       map[string]string `json:"data,omitempty" yaml:"data,omitempty"`
+	StringData map[string]string `json:"stringData,omitempty" yaml:"stringData,omitempty"`
 }
 
 type SecretStatus struct {
-	Phase              string `json:"phase,omitempty"`
-	LastError          string `json:"lastError,omitempty"`
-	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
+	Phase              string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type SecretList struct {
-	ListMeta `json:",inline"`
-	Items    []Secret `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []Secret `json:"items" yaml:"items"`
 }
 
 type ToolRuntimePolicy struct {
-	Timeout       string          `json:"timeout,omitempty"`
-	IsolationMode string          `json:"isolation_mode,omitempty"`
-	Retry         ToolRetryPolicy `json:"retry,omitempty"`
+	Timeout       string          `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	IsolationMode string          `json:"isolation_mode,omitempty" yaml:"isolation_mode,omitempty"`
+	Retry         ToolRetryPolicy `json:"retry,omitempty" yaml:"retry,omitempty"`
 }
 
 type ToolRetryPolicy struct {
-	MaxAttempts int    `json:"max_attempts,omitempty"`
-	Backoff     string `json:"backoff,omitempty"`
-	MaxBackoff  string `json:"max_backoff,omitempty"`
-	Jitter      string `json:"jitter,omitempty"`
+	MaxAttempts int    `json:"max_attempts,omitempty" yaml:"max_attempts,omitempty"`
+	Backoff     string `json:"backoff,omitempty" yaml:"backoff,omitempty"`
+	MaxBackoff  string `json:"max_backoff,omitempty" yaml:"max_backoff,omitempty"`
+	Jitter      string `json:"jitter,omitempty" yaml:"jitter,omitempty"`
 }
 
 type ToolStatus struct {
-	Phase              string `json:"phase,omitempty"`
-	LastError          string `json:"lastError,omitempty"`
-	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
+	Phase              string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type ToolList struct {
-	ListMeta `json:",inline"`
-	Items    []Tool `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []Tool `json:"items" yaml:"items"`
 }
 
 func (t *Tool) Normalize() error {
@@ -758,35 +775,35 @@ func (s *Secret) Normalize() error {
 
 // Memory defines persistent storage configuration for agents.
 type Memory struct {
-	APIVersion string       `json:"apiVersion"`
-	Kind       string       `json:"kind"`
-	Metadata   ObjectMeta   `json:"metadata"`
-	Spec       MemoryConfig `json:"spec"`
-	Status     MemoryStatus `json:"status,omitempty"`
+	APIVersion string       `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string       `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta   `json:"metadata" yaml:"metadata"`
+	Spec       MemoryConfig `json:"spec" yaml:"spec"`
+	Status     MemoryStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type MemoryConfig struct {
-	Type              string           `json:"type,omitempty"`
-	Provider          string           `json:"provider,omitempty"`
-	EmbeddingModel    string           `json:"embedding_model,omitempty"`
-	Endpoint          string           `json:"endpoint,omitempty"`
-	EndpointSecretRef string           `json:"endpoint_secret_ref,omitempty"`
-	Auth              MemoryAuthConfig `json:"auth,omitempty"`
+	Type              string           `json:"type,omitempty" yaml:"type,omitempty"`
+	Provider          string           `json:"provider,omitempty" yaml:"provider,omitempty"`
+	EmbeddingModel    string           `json:"embedding_model,omitempty" yaml:"embedding_model,omitempty"`
+	Endpoint          string           `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	EndpointSecretRef string           `json:"endpoint_secret_ref,omitempty" yaml:"endpoint_secret_ref,omitempty"`
+	Auth              MemoryAuthConfig `json:"auth,omitempty" yaml:"auth,omitempty"`
 }
 
 type MemoryAuthConfig struct {
-	SecretRef string `json:"secretRef,omitempty"`
+	SecretRef string `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
 }
 
 type MemoryStatus struct {
-	Phase              string `json:"phase,omitempty"`
-	LastError          string `json:"lastError,omitempty"`
-	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
+	Phase              string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type MemoryList struct {
-	ListMeta `json:",inline"`
-	Items    []Memory `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []Memory `json:"items" yaml:"items"`
 }
 
 func (m *Memory) Normalize() error {
@@ -811,34 +828,34 @@ func (m *Memory) Normalize() error {
 
 // AgentPolicy defines governance limits for runtime behavior.
 type AgentPolicy struct {
-	APIVersion string          `json:"apiVersion"`
-	Kind       string          `json:"kind"`
-	Metadata   ObjectMeta      `json:"metadata"`
-	Spec       AgentPolicySpec `json:"spec"`
-	Status     PolicyStatus    `json:"status,omitempty"`
+	APIVersion string          `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string          `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta      `json:"metadata" yaml:"metadata"`
+	Spec       AgentPolicySpec `json:"spec" yaml:"spec"`
+	Status     PolicyStatus    `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type AgentPolicySpec struct {
-	MaxTokensPerRun int      `json:"max_tokens_per_run,omitempty"`
-	AllowedModels   []string `json:"allowed_models,omitempty"`
-	BlockedTools    []string `json:"blocked_tools,omitempty"`
-	ApplyMode       string   `json:"apply_mode,omitempty"`
-	TargetSystems   []string `json:"target_systems,omitempty"`
-	TargetTasks     []string `json:"target_tasks,omitempty"`
-	TargetAgents    []string `json:"target_agents,omitempty"`
-	MaxChildDepth   int      `json:"max_child_depth,omitempty"`
-	MaxChildTasks   int      `json:"max_child_tasks,omitempty"`
+	MaxTokensPerRun int      `json:"max_tokens_per_run,omitempty" yaml:"max_tokens_per_run,omitempty"`
+	AllowedModels   []string `json:"allowed_models,omitempty" yaml:"allowed_models,omitempty"`
+	BlockedTools    []string `json:"blocked_tools,omitempty" yaml:"blocked_tools,omitempty"`
+	ApplyMode       string   `json:"apply_mode,omitempty" yaml:"apply_mode,omitempty"`
+	TargetSystems   []string `json:"target_systems,omitempty" yaml:"target_systems,omitempty"`
+	TargetTasks     []string `json:"target_tasks,omitempty" yaml:"target_tasks,omitempty"`
+	TargetAgents    []string `json:"target_agents,omitempty" yaml:"target_agents,omitempty"`
+	MaxChildDepth   int      `json:"max_child_depth,omitempty" yaml:"max_child_depth,omitempty"`
+	MaxChildTasks   int      `json:"max_child_tasks,omitempty" yaml:"max_child_tasks,omitempty"`
 }
 
 type PolicyStatus struct {
-	Phase              string `json:"phase,omitempty"`
-	LastError          string `json:"lastError,omitempty"`
-	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
+	Phase              string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type AgentPolicyList struct {
-	ListMeta `json:",inline"`
-	Items    []AgentPolicy `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []AgentPolicy `json:"items" yaml:"items"`
 }
 
 func (p *AgentPolicy) Normalize() error {
@@ -869,27 +886,27 @@ func (p *AgentPolicy) Normalize() error {
 
 // AgentRole defines reusable permission grants that can be bound to agents.
 type AgentRole struct {
-	APIVersion string          `json:"apiVersion"`
-	Kind       string          `json:"kind"`
-	Metadata   ObjectMeta      `json:"metadata"`
-	Spec       AgentRoleSpec   `json:"spec"`
-	Status     AgentRoleStatus `json:"status,omitempty"`
+	APIVersion string          `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string          `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta      `json:"metadata" yaml:"metadata"`
+	Spec       AgentRoleSpec   `json:"spec" yaml:"spec"`
+	Status     AgentRoleStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type AgentRoleSpec struct {
-	Description string   `json:"description,omitempty"`
-	Permissions []string `json:"permissions,omitempty"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Permissions []string `json:"permissions,omitempty" yaml:"permissions,omitempty"`
 }
 
 type AgentRoleStatus struct {
-	Phase              string `json:"phase,omitempty"`
-	LastError          string `json:"lastError,omitempty"`
-	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
+	Phase              string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type AgentRoleList struct {
-	ListMeta `json:",inline"`
-	Items    []AgentRole `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []AgentRole `json:"items" yaml:"items"`
 }
 
 func (r *AgentRole) Normalize() error {
@@ -927,37 +944,37 @@ func (r *AgentRole) Normalize() error {
 
 // ToolPermission defines required permissions for invoking a tool action.
 type ToolPermission struct {
-	APIVersion string               `json:"apiVersion"`
-	Kind       string               `json:"kind"`
-	Metadata   ObjectMeta           `json:"metadata"`
-	Spec       ToolPermissionSpec   `json:"spec"`
-	Status     ToolPermissionStatus `json:"status,omitempty"`
+	APIVersion string               `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string               `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta           `json:"metadata" yaml:"metadata"`
+	Spec       ToolPermissionSpec   `json:"spec" yaml:"spec"`
+	Status     ToolPermissionStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type ToolPermissionSpec struct {
-	ToolRef             string          `json:"tool_ref,omitempty"`
-	Action              string          `json:"action,omitempty"`
-	RequiredPermissions []string        `json:"required_permissions,omitempty"`
-	MatchMode           string          `json:"match_mode,omitempty"`
-	ApplyMode           string          `json:"apply_mode,omitempty"`
-	TargetAgents        []string        `json:"target_agents,omitempty"`
-	OperationRules      []OperationRule `json:"operation_rules,omitempty"`
+	ToolRef             string          `json:"tool_ref,omitempty" yaml:"tool_ref,omitempty"`
+	Action              string          `json:"action,omitempty" yaml:"action,omitempty"`
+	RequiredPermissions []string        `json:"required_permissions,omitempty" yaml:"required_permissions,omitempty"`
+	MatchMode           string          `json:"match_mode,omitempty" yaml:"match_mode,omitempty"`
+	ApplyMode           string          `json:"apply_mode,omitempty" yaml:"apply_mode,omitempty"`
+	TargetAgents        []string        `json:"target_agents,omitempty" yaml:"target_agents,omitempty"`
+	OperationRules      []OperationRule `json:"operation_rules,omitempty" yaml:"operation_rules,omitempty"`
 }
 
 type OperationRule struct {
-	OperationClass string `json:"operation_class,omitempty"`
-	Verdict        string `json:"verdict,omitempty"`
+	OperationClass string `json:"operation_class,omitempty" yaml:"operation_class,omitempty"`
+	Verdict        string `json:"verdict,omitempty" yaml:"verdict,omitempty"`
 }
 
 type ToolPermissionStatus struct {
-	Phase              string `json:"phase,omitempty"`
-	LastError          string `json:"lastError,omitempty"`
-	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
+	Phase              string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type ToolPermissionList struct {
-	ListMeta `json:",inline"`
-	Items    []ToolPermission `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []ToolPermission `json:"items" yaml:"items"`
 }
 
 func (p *ToolPermission) Normalize() error {
@@ -1074,35 +1091,35 @@ func (p *ToolPermission) Normalize() error {
 
 // ToolApproval captures a pending human/system approval request for a tool invocation.
 type ToolApproval struct {
-	APIVersion string             `json:"apiVersion"`
-	Kind       string             `json:"kind"`
-	Metadata   ObjectMeta         `json:"metadata"`
-	Spec       ToolApprovalSpec   `json:"spec"`
-	Status     ToolApprovalStatus `json:"status,omitempty"`
+	APIVersion string             `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string             `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta         `json:"metadata" yaml:"metadata"`
+	Spec       ToolApprovalSpec   `json:"spec" yaml:"spec"`
+	Status     ToolApprovalStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type ToolApprovalSpec struct {
-	TaskRef        string `json:"task_ref"`
-	Tool           string `json:"tool"`
-	OperationClass string `json:"operation_class,omitempty"`
-	Agent          string `json:"agent,omitempty"`
-	Input          string `json:"input,omitempty"`
-	Reason         string `json:"reason,omitempty"`
-	TTL            string `json:"ttl,omitempty"`
+	TaskRef        string `json:"task_ref" yaml:"task_ref"`
+	Tool           string `json:"tool" yaml:"tool"`
+	OperationClass string `json:"operation_class,omitempty" yaml:"operation_class,omitempty"`
+	Agent          string `json:"agent,omitempty" yaml:"agent,omitempty"`
+	Input          string `json:"input,omitempty" yaml:"input,omitempty"`
+	Reason         string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	TTL            string `json:"ttl,omitempty" yaml:"ttl,omitempty"`
 }
 
 type ToolApprovalStatus struct {
-	Phase     string `json:"phase,omitempty"`
-	Decision  string `json:"decision,omitempty"`
-	DecidedBy string `json:"decided_by,omitempty"`
-	DecidedAt string `json:"decided_at,omitempty"`
-	Comment   string `json:"comment,omitempty"`
-	ExpiresAt string `json:"expires_at,omitempty"`
+	Phase     string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	Decision  string `json:"decision,omitempty" yaml:"decision,omitempty"`
+	DecidedBy string `json:"decided_by,omitempty" yaml:"decided_by,omitempty"`
+	DecidedAt string `json:"decided_at,omitempty" yaml:"decided_at,omitempty"`
+	Comment   string `json:"comment,omitempty" yaml:"comment,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
 }
 
 type ToolApprovalList struct {
-	ListMeta `json:",inline"`
-	Items    []ToolApproval `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []ToolApproval `json:"items" yaml:"items"`
 }
 
 func (a *ToolApproval) Normalize() error {
@@ -1165,82 +1182,82 @@ func (a *ToolApproval) Normalize() error {
 
 // TaskApproval captures a pending human review checkpoint for agent or task output.
 type TaskApproval struct {
-	APIVersion string             `json:"apiVersion"`
-	Kind       string             `json:"kind"`
-	Metadata   ObjectMeta         `json:"metadata"`
-	Spec       TaskApprovalSpec   `json:"spec"`
-	Status     TaskApprovalStatus `json:"status,omitempty"`
+	APIVersion string             `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string             `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta         `json:"metadata" yaml:"metadata"`
+	Spec       TaskApprovalSpec   `json:"spec" yaml:"spec"`
+	Status     TaskApprovalStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type TaskApprovalSpec struct {
-	TaskRef             string         `json:"task_ref"`
-	CheckpointID        string         `json:"checkpoint_id"`
-	CheckpointType      string         `json:"checkpoint_type,omitempty"`
-	Agent               string         `json:"agent,omitempty"`
-	Reason              string         `json:"reason,omitempty"`
-	TTL                 string         `json:"ttl,omitempty"`
-	AllowRequestChanges *bool          `json:"allow_request_changes,omitempty"`
-	MaxReviewCycles     int            `json:"max_review_cycles,omitempty"`
-	ReviewCycle         int            `json:"review_cycle,omitempty"`
-	Supersedes          string         `json:"supersedes,omitempty"`
-	Output              any            `json:"output,omitempty"`
-	OutputFormat        string         `json:"output_format,omitempty"`
-	ResumeContext       map[string]any `json:"resume_context,omitempty"`
+	TaskRef             string         `json:"task_ref" yaml:"task_ref"`
+	CheckpointID        string         `json:"checkpoint_id" yaml:"checkpoint_id"`
+	CheckpointType      string         `json:"checkpoint_type,omitempty" yaml:"checkpoint_type,omitempty"`
+	Agent               string         `json:"agent,omitempty" yaml:"agent,omitempty"`
+	Reason              string         `json:"reason,omitempty" yaml:"reason,omitempty"`
+	TTL                 string         `json:"ttl,omitempty" yaml:"ttl,omitempty"`
+	AllowRequestChanges *bool          `json:"allow_request_changes,omitempty" yaml:"allow_request_changes,omitempty"`
+	MaxReviewCycles     int            `json:"max_review_cycles,omitempty" yaml:"max_review_cycles,omitempty"`
+	ReviewCycle         int            `json:"review_cycle,omitempty" yaml:"review_cycle,omitempty"`
+	Supersedes          string         `json:"supersedes,omitempty" yaml:"supersedes,omitempty"`
+	Output              any            `json:"output,omitempty" yaml:"output,omitempty"`
+	OutputFormat        string         `json:"output_format,omitempty" yaml:"output_format,omitempty"`
+	ResumeContext       map[string]any `json:"resume_context,omitempty" yaml:"resume_context,omitempty"`
 }
 
 type TaskApprovalResumeMessage struct {
-	MessageID      string `json:"message_id,omitempty"`
-	IdempotencyKey string `json:"idempotency_key,omitempty"`
-	TaskID         string `json:"task_id,omitempty"`
-	Attempt        int    `json:"attempt,omitempty"`
-	System         string `json:"system,omitempty"`
-	Namespace      string `json:"namespace,omitempty"`
-	FromAgent      string `json:"from_agent,omitempty"`
-	ToAgent        string `json:"to_agent,omitempty"`
-	BranchID       string `json:"branch_id,omitempty"`
-	ParentBranchID string `json:"parent_branch_id,omitempty"`
-	Type           string `json:"type,omitempty"`
-	Payload        string `json:"payload,omitempty"`
-	Timestamp      string `json:"timestamp,omitempty"`
-	TraceID        string `json:"trace_id,omitempty"`
-	ParentID       string `json:"parent_id,omitempty"`
-	DelegateOf     string `json:"delegate_of,omitempty"`
+	MessageID      string `json:"message_id,omitempty" yaml:"message_id,omitempty"`
+	IdempotencyKey string `json:"idempotency_key,omitempty" yaml:"idempotency_key,omitempty"`
+	TaskID         string `json:"task_id,omitempty" yaml:"task_id,omitempty"`
+	Attempt        int    `json:"attempt,omitempty" yaml:"attempt,omitempty"`
+	System         string `json:"system,omitempty" yaml:"system,omitempty"`
+	Namespace      string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	FromAgent      string `json:"from_agent,omitempty" yaml:"from_agent,omitempty"`
+	ToAgent        string `json:"to_agent,omitempty" yaml:"to_agent,omitempty"`
+	BranchID       string `json:"branch_id,omitempty" yaml:"branch_id,omitempty"`
+	ParentBranchID string `json:"parent_branch_id,omitempty" yaml:"parent_branch_id,omitempty"`
+	Type           string `json:"type,omitempty" yaml:"type,omitempty"`
+	Payload        string `json:"payload,omitempty" yaml:"payload,omitempty"`
+	Timestamp      string `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+	TraceID        string `json:"trace_id,omitempty" yaml:"trace_id,omitempty"`
+	ParentID       string `json:"parent_id,omitempty" yaml:"parent_id,omitempty"`
+	DelegateOf     string `json:"delegate_of,omitempty" yaml:"delegate_of,omitempty"`
 }
 
 type TaskApprovalResumeContext struct {
-	Mode              string                      `json:"mode,omitempty"`
-	Action            string                      `json:"action,omitempty"`
-	System            string                      `json:"system,omitempty"`
-	ProducingAgent    string                      `json:"producing_agent,omitempty"`
-	CurrentMessage    *TaskApprovalResumeMessage  `json:"current_message,omitempty"`
-	NextMessages      []TaskApprovalResumeMessage `json:"next_messages,omitempty"`
-	RerunMessage      *TaskApprovalResumeMessage  `json:"rerun_message,omitempty"`
-	RuntimeInput      map[string]string           `json:"runtime_input,omitempty"`
-	NextRuntimeInput  map[string]string           `json:"next_runtime_input,omitempty"`
-	Output            map[string]string           `json:"output,omitempty"`
-	CurrentAgentIndex int                         `json:"current_agent_index,omitempty"`
-	NextAgentIndex    int                         `json:"next_agent_index,omitempty"`
+	Mode              string                      `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Action            string                      `json:"action,omitempty" yaml:"action,omitempty"`
+	System            string                      `json:"system,omitempty" yaml:"system,omitempty"`
+	ProducingAgent    string                      `json:"producing_agent,omitempty" yaml:"producing_agent,omitempty"`
+	CurrentMessage    *TaskApprovalResumeMessage  `json:"current_message,omitempty" yaml:"current_message,omitempty"`
+	NextMessages      []TaskApprovalResumeMessage `json:"next_messages,omitempty" yaml:"next_messages,omitempty"`
+	RerunMessage      *TaskApprovalResumeMessage  `json:"rerun_message,omitempty" yaml:"rerun_message,omitempty"`
+	RuntimeInput      map[string]string           `json:"runtime_input,omitempty" yaml:"runtime_input,omitempty"`
+	NextRuntimeInput  map[string]string           `json:"next_runtime_input,omitempty" yaml:"next_runtime_input,omitempty"`
+	Output            map[string]string           `json:"output,omitempty" yaml:"output,omitempty"`
+	CurrentAgentIndex int                         `json:"current_agent_index,omitempty" yaml:"current_agent_index,omitempty"`
+	NextAgentIndex    int                         `json:"next_agent_index,omitempty" yaml:"next_agent_index,omitempty"`
 }
 
 type TaskApprovalStatus struct {
-	Phase     string `json:"phase,omitempty"`
-	Decision  string `json:"decision,omitempty"`
-	DecidedBy string `json:"decided_by,omitempty"`
-	DecidedAt string `json:"decided_at,omitempty"`
-	Comment   string `json:"comment,omitempty"`
-	ExpiresAt string `json:"expires_at,omitempty"`
+	Phase     string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	Decision  string `json:"decision,omitempty" yaml:"decision,omitempty"`
+	DecidedBy string `json:"decided_by,omitempty" yaml:"decided_by,omitempty"`
+	DecidedAt string `json:"decided_at,omitempty" yaml:"decided_at,omitempty"`
+	Comment   string `json:"comment,omitempty" yaml:"comment,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
 }
 
-func EncodeTaskApprovalResumeContext(ctx TaskApprovalResumeContext) map[string]any {
+func EncodeTaskApprovalResumeContext(ctx TaskApprovalResumeContext) (map[string]any, error) {
 	raw, err := json.Marshal(ctx)
 	if err != nil {
-		return map[string]any{}
+		return nil, fmt.Errorf("encode resume context: %w", err)
 	}
 	var out map[string]any
 	if err := json.Unmarshal(raw, &out); err != nil {
-		return map[string]any{}
+		return nil, fmt.Errorf("decode resume context: %w", err)
 	}
-	return out
+	return out, nil
 }
 
 func DecodeTaskApprovalResumeContext(data map[string]any) (TaskApprovalResumeContext, error) {
@@ -1259,8 +1276,8 @@ func DecodeTaskApprovalResumeContext(data map[string]any) (TaskApprovalResumeCon
 }
 
 type TaskApprovalList struct {
-	ListMeta `json:",inline"`
-	Items    []TaskApproval `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []TaskApproval `json:"items" yaml:"items"`
 }
 
 func (a *TaskApproval) Normalize() error {
@@ -1378,174 +1395,174 @@ func TaskApprovalMaxReviewCycles(a TaskApproval) int {
 
 // Task defines one execution request routed to an AgentSystem.
 type Task struct {
-	APIVersion string     `json:"apiVersion"`
-	Kind       string     `json:"kind"`
-	Metadata   ObjectMeta `json:"metadata"`
-	Spec       TaskSpec   `json:"spec"`
-	Status     TaskStatus `json:"status,omitempty"`
+	APIVersion string     `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string     `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta `json:"metadata" yaml:"metadata"`
+	Spec       TaskSpec   `json:"spec" yaml:"spec"`
+	Status     TaskStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type TaskSpec struct {
-	System       string                 `json:"system,omitempty"`
-	Mode         string                 `json:"mode,omitempty"`
-	Input        map[string]string      `json:"input,omitempty"`
-	Priority     string                 `json:"priority,omitempty"`
-	MaxTurns     int                    `json:"max_turns,omitempty"`
-	Retry        TaskRetryPolicy        `json:"retry,omitempty"`
-	MessageRetry TaskMessageRetryPolicy `json:"message_retry,omitempty"`
-	Requirements TaskRequirements       `json:"requirements,omitempty"`
+	System       string                 `json:"system,omitempty" yaml:"system,omitempty"`
+	Mode         string                 `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Input        map[string]string      `json:"input,omitempty" yaml:"input,omitempty"`
+	Priority     string                 `json:"priority,omitempty" yaml:"priority,omitempty"`
+	MaxTurns     int                    `json:"max_turns,omitempty" yaml:"max_turns,omitempty"`
+	Retry        TaskRetryPolicy        `json:"retry,omitempty" yaml:"retry,omitempty"`
+	MessageRetry TaskMessageRetryPolicy `json:"message_retry,omitempty" yaml:"message_retry,omitempty"`
+	Requirements TaskRequirements       `json:"requirements,omitempty" yaml:"requirements,omitempty"`
 }
 
 type TaskRetryPolicy struct {
-	MaxAttempts int    `json:"max_attempts,omitempty"`
-	Backoff     string `json:"backoff,omitempty"`
+	MaxAttempts int    `json:"max_attempts,omitempty" yaml:"max_attempts,omitempty"`
+	Backoff     string `json:"backoff,omitempty" yaml:"backoff,omitempty"`
 }
 
 type TaskMessageRetryPolicy struct {
-	MaxAttempts  int      `json:"max_attempts,omitempty"`
-	Backoff      string   `json:"backoff,omitempty"`
-	MaxBackoff   string   `json:"max_backoff,omitempty"`
-	Jitter       string   `json:"jitter,omitempty"`
-	NonRetryable []string `json:"non_retryable,omitempty"`
+	MaxAttempts  int      `json:"max_attempts,omitempty" yaml:"max_attempts,omitempty"`
+	Backoff      string   `json:"backoff,omitempty" yaml:"backoff,omitempty"`
+	MaxBackoff   string   `json:"max_backoff,omitempty" yaml:"max_backoff,omitempty"`
+	Jitter       string   `json:"jitter,omitempty" yaml:"jitter,omitempty"`
+	NonRetryable []string `json:"non_retryable,omitempty" yaml:"non_retryable,omitempty"`
 }
 
 type TaskRequirements struct {
-	Region string `json:"region,omitempty"`
-	GPU    bool   `json:"gpu,omitempty"`
-	Model  string `json:"model,omitempty"`
+	Region string `json:"region,omitempty" yaml:"region,omitempty"`
+	GPU    bool   `json:"gpu,omitempty" yaml:"gpu,omitempty"`
+	Model  string `json:"model,omitempty" yaml:"model,omitempty"`
 }
 
 type TaskTraceEvent struct {
-	Timestamp           string `json:"timestamp,omitempty"`
-	StepID              string `json:"step_id,omitempty"`
-	Attempt             int    `json:"attempt,omitempty"`
-	Step                int    `json:"step,omitempty"`
-	BranchID            string `json:"branch_id,omitempty"`
-	Type                string `json:"type,omitempty"`
-	Agent               string `json:"agent,omitempty"`
-	Tool                string `json:"tool,omitempty"`
-	ToolContractVersion string `json:"tool_contract_version,omitempty"`
-	ToolRequestID       string `json:"tool_request_id,omitempty"`
-	ToolAttempt         int    `json:"tool_attempt,omitempty"`
-	ErrorCode           string `json:"error_code,omitempty"`
-	ErrorReason         string `json:"error_reason,omitempty"`
-	Retryable           *bool  `json:"retryable,omitempty"`
-	Message             string `json:"message,omitempty"`
-	LatencyMS           int64  `json:"latency_ms,omitempty"`
-	Tokens              int    `json:"tokens,omitempty"`
-	InputTokens         int    `json:"input_tokens,omitempty"`
-	OutputTokens        int    `json:"output_tokens,omitempty"`
-	TokenUsageSource    string `json:"token_usage_source,omitempty"`
-	ToolCalls           int    `json:"tool_calls,omitempty"`
-	MemoryWrites        int    `json:"memory_writes,omitempty"`
-	ToolAuthProfile     string `json:"tool_auth_profile,omitempty"`
-	ToolAuthSecretRef   string `json:"tool_auth_secret_ref,omitempty"`
+	Timestamp           string `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+	StepID              string `json:"step_id,omitempty" yaml:"step_id,omitempty"`
+	Attempt             int    `json:"attempt,omitempty" yaml:"attempt,omitempty"`
+	Step                int    `json:"step,omitempty" yaml:"step,omitempty"`
+	BranchID            string `json:"branch_id,omitempty" yaml:"branch_id,omitempty"`
+	Type                string `json:"type,omitempty" yaml:"type,omitempty"`
+	Agent               string `json:"agent,omitempty" yaml:"agent,omitempty"`
+	Tool                string `json:"tool,omitempty" yaml:"tool,omitempty"`
+	ToolContractVersion string `json:"tool_contract_version,omitempty" yaml:"tool_contract_version,omitempty"`
+	ToolRequestID       string `json:"tool_request_id,omitempty" yaml:"tool_request_id,omitempty"`
+	ToolAttempt         int    `json:"tool_attempt,omitempty" yaml:"tool_attempt,omitempty"`
+	ErrorCode           string `json:"error_code,omitempty" yaml:"error_code,omitempty"`
+	ErrorReason         string `json:"error_reason,omitempty" yaml:"error_reason,omitempty"`
+	Retryable           *bool  `json:"retryable,omitempty" yaml:"retryable,omitempty"`
+	Message             string `json:"message,omitempty" yaml:"message,omitempty"`
+	LatencyMS           int64  `json:"latency_ms,omitempty" yaml:"latency_ms,omitempty"`
+	Tokens              int    `json:"tokens,omitempty" yaml:"tokens,omitempty"`
+	InputTokens         int    `json:"input_tokens,omitempty" yaml:"input_tokens,omitempty"`
+	OutputTokens        int    `json:"output_tokens,omitempty" yaml:"output_tokens,omitempty"`
+	TokenUsageSource    string `json:"token_usage_source,omitempty" yaml:"token_usage_source,omitempty"`
+	ToolCalls           int    `json:"tool_calls,omitempty" yaml:"tool_calls,omitempty"`
+	MemoryWrites        int    `json:"memory_writes,omitempty" yaml:"memory_writes,omitempty"`
+	ToolAuthProfile     string `json:"tool_auth_profile,omitempty" yaml:"tool_auth_profile,omitempty"`
+	ToolAuthSecretRef   string `json:"tool_auth_secret_ref,omitempty" yaml:"tool_auth_secret_ref,omitempty"`
 }
 
 type TaskHistoryEvent struct {
-	Timestamp string `json:"timestamp,omitempty"`
-	Type      string `json:"type,omitempty"`
-	Worker    string `json:"worker,omitempty"`
-	Message   string `json:"message,omitempty"`
+	Timestamp string `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+	Type      string `json:"type,omitempty" yaml:"type,omitempty"`
+	Worker    string `json:"worker,omitempty" yaml:"worker,omitempty"`
+	Message   string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
 type TaskMessage struct {
-	Timestamp      string `json:"timestamp,omitempty"`
-	MessageID      string `json:"message_id,omitempty"`
-	IdempotencyKey string `json:"idempotency_key,omitempty"`
-	TaskID         string `json:"task_id,omitempty"`
-	Attempt        int    `json:"attempt,omitempty"`
-	System         string `json:"system,omitempty"`
-	FromAgent      string `json:"from_agent,omitempty"`
-	ToAgent        string `json:"to_agent,omitempty"`
-	BranchID       string `json:"branch_id,omitempty"`
-	ParentBranchID string `json:"parent_branch_id,omitempty"`
-	Type           string `json:"type,omitempty"`
-	Content        string `json:"content,omitempty"`
-	TraceID        string `json:"trace_id,omitempty"`
-	ParentID       string `json:"parent_id,omitempty"`
-	Phase          string `json:"phase,omitempty"`
-	Attempts       int    `json:"attempts,omitempty"`
-	MaxAttempts    int    `json:"max_attempts,omitempty"`
-	LastError      string `json:"last_error,omitempty"`
-	Worker         string `json:"worker,omitempty"`
-	ProcessedAt    string `json:"processed_at,omitempty"`
-	NextAttemptAt  string `json:"next_attempt_at,omitempty"`
-	DelegateOf     string `json:"delegate_of,omitempty"`
+	Timestamp      string `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+	MessageID      string `json:"message_id,omitempty" yaml:"message_id,omitempty"`
+	IdempotencyKey string `json:"idempotency_key,omitempty" yaml:"idempotency_key,omitempty"`
+	TaskID         string `json:"task_id,omitempty" yaml:"task_id,omitempty"`
+	Attempt        int    `json:"attempt,omitempty" yaml:"attempt,omitempty"`
+	System         string `json:"system,omitempty" yaml:"system,omitempty"`
+	FromAgent      string `json:"from_agent,omitempty" yaml:"from_agent,omitempty"`
+	ToAgent        string `json:"to_agent,omitempty" yaml:"to_agent,omitempty"`
+	BranchID       string `json:"branch_id,omitempty" yaml:"branch_id,omitempty"`
+	ParentBranchID string `json:"parent_branch_id,omitempty" yaml:"parent_branch_id,omitempty"`
+	Type           string `json:"type,omitempty" yaml:"type,omitempty"`
+	Content        string `json:"content,omitempty" yaml:"content,omitempty"`
+	TraceID        string `json:"trace_id,omitempty" yaml:"trace_id,omitempty"`
+	ParentID       string `json:"parent_id,omitempty" yaml:"parent_id,omitempty"`
+	Phase          string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	Attempts       int    `json:"attempts,omitempty" yaml:"attempts,omitempty"`
+	MaxAttempts    int    `json:"max_attempts,omitempty" yaml:"max_attempts,omitempty"`
+	LastError      string `json:"last_error,omitempty" yaml:"last_error,omitempty"`
+	Worker         string `json:"worker,omitempty" yaml:"worker,omitempty"`
+	ProcessedAt    string `json:"processed_at,omitempty" yaml:"processed_at,omitempty"`
+	NextAttemptAt  string `json:"next_attempt_at,omitempty" yaml:"next_attempt_at,omitempty"`
+	DelegateOf     string `json:"delegate_of,omitempty" yaml:"delegate_of,omitempty"`
 }
 
 type TaskMessageIdempotency struct {
-	Key       string `json:"key,omitempty"`
-	MessageID string `json:"message_id,omitempty"`
-	State     string `json:"state,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
-	ExpiresAt string `json:"expires_at,omitempty"`
-	Worker    string `json:"worker,omitempty"`
+	Key       string `json:"key,omitempty" yaml:"key,omitempty"`
+	MessageID string `json:"message_id,omitempty" yaml:"message_id,omitempty"`
+	State     string `json:"state,omitempty" yaml:"state,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
+	Worker    string `json:"worker,omitempty" yaml:"worker,omitempty"`
 }
 
 type TaskJoinSource struct {
-	MessageID string `json:"message_id,omitempty"`
-	FromAgent string `json:"from_agent,omitempty"`
-	BranchID  string `json:"branch_id,omitempty"`
-	Timestamp string `json:"timestamp,omitempty"`
-	Payload   string `json:"payload,omitempty"`
+	MessageID string `json:"message_id,omitempty" yaml:"message_id,omitempty"`
+	FromAgent string `json:"from_agent,omitempty" yaml:"from_agent,omitempty"`
+	BranchID  string `json:"branch_id,omitempty" yaml:"branch_id,omitempty"`
+	Timestamp string `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+	Payload   string `json:"payload,omitempty" yaml:"payload,omitempty"`
 }
 
 type TaskJoinState struct {
-	Attempt        int              `json:"attempt,omitempty"`
-	Node           string           `json:"node,omitempty"`
-	Mode           string           `json:"mode,omitempty"`
-	Expected       int              `json:"expected,omitempty"`
-	QuorumRequired int              `json:"quorum_required,omitempty"`
-	Activated      bool             `json:"activated,omitempty"`
-	ActivatedAt    string           `json:"activated_at,omitempty"`
-	ActivatedBy    string           `json:"activated_by,omitempty"`
-	Sources        []TaskJoinSource `json:"sources,omitempty"`
+	Attempt        int              `json:"attempt,omitempty" yaml:"attempt,omitempty"`
+	Node           string           `json:"node,omitempty" yaml:"node,omitempty"`
+	Mode           string           `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Expected       int              `json:"expected,omitempty" yaml:"expected,omitempty"`
+	QuorumRequired int              `json:"quorum_required,omitempty" yaml:"quorum_required,omitempty"`
+	Activated      bool             `json:"activated,omitempty" yaml:"activated,omitempty"`
+	ActivatedAt    string           `json:"activated_at,omitempty" yaml:"activated_at,omitempty"`
+	ActivatedBy    string           `json:"activated_by,omitempty" yaml:"activated_by,omitempty"`
+	Sources        []TaskJoinSource `json:"sources,omitempty" yaml:"sources,omitempty"`
 }
 
 type TaskDelegationState struct {
-	Attempt        int              `json:"attempt,omitempty"`
-	Node           string           `json:"node,omitempty"`
-	Mode           string           `json:"mode,omitempty"`
-	Expected       int              `json:"expected,omitempty"`
-	QuorumRequired int              `json:"quorum_required,omitempty"`
-	Activated      bool             `json:"activated,omitempty"`
-	ActivatedAt    string           `json:"activated_at,omitempty"`
-	ActivatedBy    string           `json:"activated_by,omitempty"`
-	Sources        []TaskJoinSource `json:"sources,omitempty"`
+	Attempt        int              `json:"attempt,omitempty" yaml:"attempt,omitempty"`
+	Node           string           `json:"node,omitempty" yaml:"node,omitempty"`
+	Mode           string           `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Expected       int              `json:"expected,omitempty" yaml:"expected,omitempty"`
+	QuorumRequired int              `json:"quorum_required,omitempty" yaml:"quorum_required,omitempty"`
+	Activated      bool             `json:"activated,omitempty" yaml:"activated,omitempty"`
+	ActivatedAt    string           `json:"activated_at,omitempty" yaml:"activated_at,omitempty"`
+	ActivatedBy    string           `json:"activated_by,omitempty" yaml:"activated_by,omitempty"`
+	Sources        []TaskJoinSource `json:"sources,omitempty" yaml:"sources,omitempty"`
 }
 
 type TaskBlockedOn struct {
-	Kind   string `json:"kind,omitempty"`
-	Name   string `json:"name,omitempty"`
-	Reason string `json:"reason,omitempty"`
+	Kind   string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Name   string `json:"name,omitempty" yaml:"name,omitempty"`
+	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
 }
 
 type TaskStatus struct {
-	Phase              string                   `json:"phase,omitempty"`
-	LastError          string                   `json:"lastError,omitempty"`
-	StartedAt          string                   `json:"startedAt,omitempty"`
-	CompletedAt        string                   `json:"completedAt,omitempty"`
-	NextAttemptAt      string                   `json:"nextAttemptAt,omitempty"`
-	Attempts           int                      `json:"attempts,omitempty"`
-	Output             map[string]string        `json:"output,omitempty"`
-	AssignedWorker     string                   `json:"assignedWorker,omitempty"`
-	ClaimedBy          string                   `json:"claimedBy,omitempty"`
-	LeaseUntil         string                   `json:"leaseUntil,omitempty"`
-	LastHeartbeat      string                   `json:"lastHeartbeat,omitempty"`
-	Trace              []TaskTraceEvent         `json:"trace,omitempty"`
-	History            []TaskHistoryEvent       `json:"history,omitempty"`
-	Messages           []TaskMessage            `json:"messages,omitempty"`
-	MessageIdempotency []TaskMessageIdempotency `json:"message_idempotency,omitempty"`
-	JoinStates         []TaskJoinState          `json:"join_states,omitempty"`
-	DelegationStates   []TaskDelegationState    `json:"delegation_states,omitempty"`
-	BlockedOn          *TaskBlockedOn           `json:"blocked_on,omitempty"`
-	ObservedGeneration int64                    `json:"observedGeneration,omitempty"`
+	Phase              string                   `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string                   `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	StartedAt          string                   `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
+	CompletedAt        string                   `json:"completedAt,omitempty" yaml:"completedAt,omitempty"`
+	NextAttemptAt      string                   `json:"nextAttemptAt,omitempty" yaml:"nextAttemptAt,omitempty"`
+	Attempts           int                      `json:"attempts,omitempty" yaml:"attempts,omitempty"`
+	Output             map[string]string        `json:"output,omitempty" yaml:"output,omitempty"`
+	AssignedWorker     string                   `json:"assignedWorker,omitempty" yaml:"assignedWorker,omitempty"`
+	ClaimedBy          string                   `json:"claimedBy,omitempty" yaml:"claimedBy,omitempty"`
+	LeaseUntil         string                   `json:"leaseUntil,omitempty" yaml:"leaseUntil,omitempty"`
+	LastHeartbeat      string                   `json:"lastHeartbeat,omitempty" yaml:"lastHeartbeat,omitempty"`
+	Trace              []TaskTraceEvent         `json:"trace,omitempty" yaml:"trace,omitempty"`
+	History            []TaskHistoryEvent       `json:"history,omitempty" yaml:"history,omitempty"`
+	Messages           []TaskMessage            `json:"messages,omitempty" yaml:"messages,omitempty"`
+	MessageIdempotency []TaskMessageIdempotency `json:"message_idempotency,omitempty" yaml:"message_idempotency,omitempty"`
+	JoinStates         []TaskJoinState          `json:"join_states,omitempty" yaml:"join_states,omitempty"`
+	DelegationStates   []TaskDelegationState    `json:"delegation_states,omitempty" yaml:"delegation_states,omitempty"`
+	BlockedOn          *TaskBlockedOn           `json:"blocked_on,omitempty" yaml:"blocked_on,omitempty"`
+	ObservedGeneration int64                    `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type TaskList struct {
-	ListMeta `json:",inline"`
-	Items    []Task `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []Task `json:"items" yaml:"items"`
 }
 
 func (t *Task) Normalize() error {
@@ -1574,6 +1591,12 @@ func (t *Task) Normalize() error {
 		t.Spec.Mode = mode
 	default:
 		return fmt.Errorf("invalid spec.mode %q: expected run or template", t.Spec.Mode)
+	}
+	if mode == "run" {
+		t.Spec.System = strings.TrimSpace(t.Spec.System)
+		if t.Spec.System == "" {
+			return fmt.Errorf("spec.system is required when spec.mode is run")
+		}
 	}
 	if t.Spec.Priority == "" {
 		t.Spec.Priority = "normal"
@@ -1655,39 +1678,39 @@ func (t *Task) Normalize() error {
 
 // TaskSchedule defines recurring task creation from a template task.
 type TaskSchedule struct {
-	APIVersion string             `json:"apiVersion"`
-	Kind       string             `json:"kind"`
-	Metadata   ObjectMeta         `json:"metadata"`
-	Spec       TaskScheduleSpec   `json:"spec"`
-	Status     TaskScheduleStatus `json:"status,omitempty"`
+	APIVersion string             `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string             `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta         `json:"metadata" yaml:"metadata"`
+	Spec       TaskScheduleSpec   `json:"spec" yaml:"spec"`
+	Status     TaskScheduleStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type TaskScheduleSpec struct {
-	TaskRef                 string    `json:"task_ref,omitempty"`
-	TaskTemplate            *TaskSpec `json:"task_template,omitempty"`
-	Schedule                string    `json:"schedule,omitempty"`
-	TimeZone                string    `json:"time_zone,omitempty"`
-	Suspend                 bool      `json:"suspend,omitempty"`
-	StartingDeadlineSeconds int       `json:"starting_deadline_seconds,omitempty"`
-	ConcurrencyPolicy       string    `json:"concurrency_policy,omitempty"`
-	SuccessfulHistoryLimit  int       `json:"successful_history_limit,omitempty"`
-	FailedHistoryLimit      int       `json:"failed_history_limit,omitempty"`
+	TaskRef                 string    `json:"task_ref,omitempty" yaml:"task_ref,omitempty"`
+	TaskTemplate            *TaskSpec `json:"task_template,omitempty" yaml:"task_template,omitempty"`
+	Schedule                string    `json:"schedule,omitempty" yaml:"schedule,omitempty"`
+	TimeZone                string    `json:"time_zone,omitempty" yaml:"time_zone,omitempty"`
+	Suspend                 bool      `json:"suspend,omitempty" yaml:"suspend,omitempty"`
+	StartingDeadlineSeconds int       `json:"starting_deadline_seconds,omitempty" yaml:"starting_deadline_seconds,omitempty"`
+	ConcurrencyPolicy       string    `json:"concurrency_policy,omitempty" yaml:"concurrency_policy,omitempty"`
+	SuccessfulHistoryLimit  int       `json:"successful_history_limit,omitempty" yaml:"successful_history_limit,omitempty"`
+	FailedHistoryLimit      int       `json:"failed_history_limit,omitempty" yaml:"failed_history_limit,omitempty"`
 }
 
 type TaskScheduleStatus struct {
-	Phase              string   `json:"phase,omitempty"`
-	LastError          string   `json:"lastError,omitempty"`
-	LastScheduleTime   string   `json:"lastScheduleTime,omitempty"`
-	LastSuccessfulTime string   `json:"lastSuccessfulTime,omitempty"`
-	NextScheduleTime   string   `json:"nextScheduleTime,omitempty"`
-	LastTriggeredTask  string   `json:"lastTriggeredTask,omitempty"`
-	ActiveRuns         []string `json:"activeRuns,omitempty"`
-	ObservedGeneration int64    `json:"observedGeneration,omitempty"`
+	Phase              string   `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string   `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	LastScheduleTime   string   `json:"lastScheduleTime,omitempty" yaml:"lastScheduleTime,omitempty"`
+	LastSuccessfulTime string   `json:"lastSuccessfulTime,omitempty" yaml:"lastSuccessfulTime,omitempty"`
+	NextScheduleTime   string   `json:"nextScheduleTime,omitempty" yaml:"nextScheduleTime,omitempty"`
+	LastTriggeredTask  string   `json:"lastTriggeredTask,omitempty" yaml:"lastTriggeredTask,omitempty"`
+	ActiveRuns         []string `json:"activeRuns,omitempty" yaml:"activeRuns,omitempty"`
+	ObservedGeneration int64    `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type TaskScheduleList struct {
-	ListMeta `json:",inline"`
-	Items    []TaskSchedule `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []TaskSchedule `json:"items" yaml:"items"`
 }
 
 func (t *TaskSchedule) Normalize() error {
@@ -1817,67 +1840,67 @@ func (t *TaskSchedule) Normalize() error {
 
 // TaskWebhook defines event-driven task creation from inbound webhook deliveries.
 type TaskWebhook struct {
-	APIVersion string            `json:"apiVersion"`
-	Kind       string            `json:"kind"`
-	Metadata   ObjectMeta        `json:"metadata"`
-	Spec       TaskWebhookSpec   `json:"spec"`
-	Status     TaskWebhookStatus `json:"status,omitempty"`
+	APIVersion string            `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string            `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta        `json:"metadata" yaml:"metadata"`
+	Spec       TaskWebhookSpec   `json:"spec" yaml:"spec"`
+	Status     TaskWebhookStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type TaskWebhookSpec struct {
-	TaskRef      string                 `json:"task_ref,omitempty"`
-	TaskTemplate *TaskSpec              `json:"task_template,omitempty"`
-	Suspend      bool                   `json:"suspend,omitempty"`
-	Auth         TaskWebhookAuthSpec    `json:"auth,omitempty"`
-	Idempotency  TaskWebhookIdempotency `json:"idempotency,omitempty"`
-	Payload      TaskWebhookPayloadSpec `json:"payload,omitempty"`
+	TaskRef      string                 `json:"task_ref,omitempty" yaml:"task_ref,omitempty"`
+	TaskTemplate *TaskSpec              `json:"task_template,omitempty" yaml:"task_template,omitempty"`
+	Suspend      bool                   `json:"suspend,omitempty" yaml:"suspend,omitempty"`
+	Auth         TaskWebhookAuthSpec    `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Idempotency  TaskWebhookIdempotency `json:"idempotency,omitempty" yaml:"idempotency,omitempty"`
+	Payload      TaskWebhookPayloadSpec `json:"payload,omitempty" yaml:"payload,omitempty"`
 }
 
 type TaskWebhookAuthSpec struct {
-	Profile           string `json:"profile,omitempty"`
-	SecretRef         string `json:"secret_ref,omitempty"`
-	SignatureHeader   string `json:"signature_header,omitempty"`
-	SignaturePrefix   string `json:"signature_prefix,omitempty"`
-	TimestampHeader   string `json:"timestamp_header,omitempty"`
-	MaxSkewSeconds    int    `json:"max_skew_seconds,omitempty"`
-	Algorithm         string `json:"algorithm,omitempty"`
-	PayloadFormat     string `json:"payload_format,omitempty"`
-	PayloadPrefix     string `json:"payload_prefix,omitempty"`
-	PayloadSeparator  string `json:"payload_separator,omitempty"`
-	SignatureEncoding string `json:"signature_encoding,omitempty"`
-	HeaderFormat      string `json:"header_format,omitempty"`
-	SignatureKey      string `json:"signature_key,omitempty"`
-	TimestampKey      string `json:"timestamp_key,omitempty"`
+	Profile           string `json:"profile,omitempty" yaml:"profile,omitempty"`
+	SecretRef         string `json:"secret_ref,omitempty" yaml:"secret_ref,omitempty"`
+	SignatureHeader   string `json:"signature_header,omitempty" yaml:"signature_header,omitempty"`
+	SignaturePrefix   string `json:"signature_prefix,omitempty" yaml:"signature_prefix,omitempty"`
+	TimestampHeader   string `json:"timestamp_header,omitempty" yaml:"timestamp_header,omitempty"`
+	MaxSkewSeconds    int    `json:"max_skew_seconds,omitempty" yaml:"max_skew_seconds,omitempty"`
+	Algorithm         string `json:"algorithm,omitempty" yaml:"algorithm,omitempty"`
+	PayloadFormat     string `json:"payload_format,omitempty" yaml:"payload_format,omitempty"`
+	PayloadPrefix     string `json:"payload_prefix,omitempty" yaml:"payload_prefix,omitempty"`
+	PayloadSeparator  string `json:"payload_separator,omitempty" yaml:"payload_separator,omitempty"`
+	SignatureEncoding string `json:"signature_encoding,omitempty" yaml:"signature_encoding,omitempty"`
+	HeaderFormat      string `json:"header_format,omitempty" yaml:"header_format,omitempty"`
+	SignatureKey      string `json:"signature_key,omitempty" yaml:"signature_key,omitempty"`
+	TimestampKey      string `json:"timestamp_key,omitempty" yaml:"timestamp_key,omitempty"`
 }
 
 type TaskWebhookIdempotency struct {
-	EventIDHeader       string `json:"event_id_header,omitempty"`
-	EventIDFromBody     string `json:"event_id_from_body,omitempty"`
-	DedupeWindowSeconds int    `json:"dedupe_window_seconds,omitempty"`
+	EventIDHeader       string `json:"event_id_header,omitempty" yaml:"event_id_header,omitempty"`
+	EventIDFromBody     string `json:"event_id_from_body,omitempty" yaml:"event_id_from_body,omitempty"`
+	DedupeWindowSeconds int    `json:"dedupe_window_seconds,omitempty" yaml:"dedupe_window_seconds,omitempty"`
 }
 
 type TaskWebhookPayloadSpec struct {
-	Mode     string `json:"mode,omitempty"`
-	InputKey string `json:"input_key,omitempty"`
+	Mode     string `json:"mode,omitempty" yaml:"mode,omitempty"`
+	InputKey string `json:"input_key,omitempty" yaml:"input_key,omitempty"`
 }
 
 type TaskWebhookStatus struct {
-	Phase              string `json:"phase,omitempty"`
-	LastError          string `json:"lastError,omitempty"`
-	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
-	EndpointID         string `json:"endpointID,omitempty"`
-	EndpointPath       string `json:"endpointPath,omitempty"`
-	LastDeliveryTime   string `json:"lastDeliveryTime,omitempty"`
-	LastEventID        string `json:"lastEventID,omitempty"`
-	LastTriggeredTask  string `json:"lastTriggeredTask,omitempty"`
-	AcceptedCount      int64  `json:"acceptedCount,omitempty"`
-	DuplicateCount     int64  `json:"duplicateCount,omitempty"`
-	RejectedCount      int64  `json:"rejectedCount,omitempty"`
+	Phase              string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
+	EndpointID         string `json:"endpointID,omitempty" yaml:"endpointID,omitempty"`
+	EndpointPath       string `json:"endpointPath,omitempty" yaml:"endpointPath,omitempty"`
+	LastDeliveryTime   string `json:"lastDeliveryTime,omitempty" yaml:"lastDeliveryTime,omitempty"`
+	LastEventID        string `json:"lastEventID,omitempty" yaml:"lastEventID,omitempty"`
+	LastTriggeredTask  string `json:"lastTriggeredTask,omitempty" yaml:"lastTriggeredTask,omitempty"`
+	AcceptedCount      int64  `json:"acceptedCount,omitempty" yaml:"acceptedCount,omitempty"`
+	DuplicateCount     int64  `json:"duplicateCount,omitempty" yaml:"duplicateCount,omitempty"`
+	RejectedCount      int64  `json:"rejectedCount,omitempty" yaml:"rejectedCount,omitempty"`
 }
 
 type TaskWebhookList struct {
-	ListMeta `json:",inline"`
-	Items    []TaskWebhook `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []TaskWebhook `json:"items" yaml:"items"`
 }
 
 func (t *TaskWebhook) Normalize() error {
@@ -2147,35 +2170,35 @@ func taskWebhookEndpointID(namespace, name string) string {
 
 // Worker defines a runtime worker that executes claimed tasks.
 type Worker struct {
-	APIVersion string       `json:"apiVersion"`
-	Kind       string       `json:"kind"`
-	Metadata   ObjectMeta   `json:"metadata"`
-	Spec       WorkerSpec   `json:"spec"`
-	Status     WorkerStatus `json:"status,omitempty"`
+	APIVersion string       `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string       `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta   `json:"metadata" yaml:"metadata"`
+	Spec       WorkerSpec   `json:"spec" yaml:"spec"`
+	Status     WorkerStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type WorkerSpec struct {
-	Region             string             `json:"region,omitempty"`
-	Capabilities       WorkerCapabilities `json:"capabilities,omitempty"`
-	MaxConcurrentTasks int                `json:"max_concurrent_tasks,omitempty"`
+	Region             string             `json:"region,omitempty" yaml:"region,omitempty"`
+	Capabilities       WorkerCapabilities `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	MaxConcurrentTasks int                `json:"max_concurrent_tasks,omitempty" yaml:"max_concurrent_tasks,omitempty"`
 }
 
 type WorkerCapabilities struct {
-	GPU             bool     `json:"gpu,omitempty"`
-	SupportedModels []string `json:"supported_models,omitempty"`
+	GPU             bool     `json:"gpu,omitempty" yaml:"gpu,omitempty"`
+	SupportedModels []string `json:"supported_models,omitempty" yaml:"supported_models,omitempty"`
 }
 
 type WorkerStatus struct {
-	Phase              string `json:"phase,omitempty"`
-	LastError          string `json:"lastError,omitempty"`
-	LastHeartbeat      string `json:"lastHeartbeat,omitempty"`
-	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
-	CurrentTasks       int    `json:"currentTasks,omitempty"`
+	Phase              string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	LastError          string `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	LastHeartbeat      string `json:"lastHeartbeat,omitempty" yaml:"lastHeartbeat,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
+	CurrentTasks       int    `json:"currentTasks,omitempty" yaml:"currentTasks,omitempty"`
 }
 
 type WorkerList struct {
-	ListMeta `json:",inline"`
-	Items    []Worker `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []Worker `json:"items" yaml:"items"`
 }
 
 func (w *Worker) Normalize() error {
@@ -2205,57 +2228,57 @@ func (w *Worker) Normalize() error {
 // The controller connects to the server, discovers tools via tools/list,
 // and auto-generates Tool resources for each discovered tool.
 type McpServer struct {
-	APIVersion string          `json:"apiVersion"`
-	Kind       string          `json:"kind"`
-	Metadata   ObjectMeta      `json:"metadata"`
-	Spec       McpServerSpec   `json:"spec"`
-	Status     McpServerStatus `json:"status,omitempty"`
+	APIVersion string          `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string          `json:"kind" yaml:"kind"`
+	Metadata   ObjectMeta      `json:"metadata" yaml:"metadata"`
+	Spec       McpServerSpec   `json:"spec" yaml:"spec"`
+	Status     McpServerStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type McpServerSpec struct {
-	Transport          string             `json:"transport"`
-	Command            string             `json:"command,omitempty"`
-	Args               []string           `json:"args,omitempty"`
-	Env                []McpServerEnvVar  `json:"env,omitempty"`
-	Endpoint           string             `json:"endpoint,omitempty"`
-	Image              string             `json:"image,omitempty"`
-	ImagePullSecret    string             `json:"image_pull_secret,omitempty"`
-	IdleTimeout        string             `json:"idle_timeout,omitempty"`
-	Auth               ToolAuth           `json:"auth,omitempty"`
-	ToolFilter         McpToolFilter      `json:"tool_filter,omitempty"`
-	Reconnect          McpReconnectPolicy `json:"reconnect,omitempty"`
-	Resources          ContainerResources `json:"resources,omitempty"`
-	DefaultToolRuntime *ToolRuntimePolicy `json:"default_tool_runtime,omitempty"`
+	Transport          string             `json:"transport" yaml:"transport"`
+	Command            string             `json:"command,omitempty" yaml:"command,omitempty"`
+	Args               []string           `json:"args,omitempty" yaml:"args,omitempty"`
+	Env                []McpServerEnvVar  `json:"env,omitempty" yaml:"env,omitempty"`
+	Endpoint           string             `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Image              string             `json:"image,omitempty" yaml:"image,omitempty"`
+	ImagePullSecret    string             `json:"image_pull_secret,omitempty" yaml:"image_pull_secret,omitempty"`
+	IdleTimeout        string             `json:"idle_timeout,omitempty" yaml:"idle_timeout,omitempty"`
+	Auth               ToolAuth           `json:"auth,omitempty" yaml:"auth,omitempty"`
+	ToolFilter         McpToolFilter      `json:"tool_filter,omitempty" yaml:"tool_filter,omitempty"`
+	Reconnect          McpReconnectPolicy `json:"reconnect,omitempty" yaml:"reconnect,omitempty"`
+	Resources          ContainerResources `json:"resources,omitempty" yaml:"resources,omitempty"`
+	DefaultToolRuntime *ToolRuntimePolicy `json:"default_tool_runtime,omitempty" yaml:"default_tool_runtime,omitempty"`
 }
 
 type McpServerEnvVar struct {
-	Name      string `json:"name"`
-	Value     string `json:"value,omitempty"`
-	SecretRef string `json:"secretRef,omitempty"`
-	MountPath string `json:"mountPath,omitempty"`
+	Name      string `json:"name" yaml:"name"`
+	Value     string `json:"value,omitempty" yaml:"value,omitempty"`
+	SecretRef string `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	MountPath string `json:"mountPath,omitempty" yaml:"mountPath,omitempty"`
 }
 
 type McpToolFilter struct {
-	Include []string `json:"include,omitempty"`
+	Include []string `json:"include,omitempty" yaml:"include,omitempty"`
 }
 
 type McpReconnectPolicy struct {
-	MaxAttempts int    `json:"max_attempts,omitempty"`
-	Backoff     string `json:"backoff,omitempty"`
+	MaxAttempts int    `json:"max_attempts,omitempty" yaml:"max_attempts,omitempty"`
+	Backoff     string `json:"backoff,omitempty" yaml:"backoff,omitempty"`
 }
 
 type McpServerStatus struct {
-	Phase              string   `json:"phase,omitempty"`
-	DiscoveredTools    []string `json:"discoveredTools,omitempty"`
-	GeneratedTools     []string `json:"generatedTools,omitempty"`
-	LastSyncedAt       string   `json:"lastSyncedAt,omitempty"`
-	LastError          string   `json:"lastError,omitempty"`
-	ObservedGeneration int64    `json:"observedGeneration,omitempty"`
+	Phase              string   `json:"phase,omitempty" yaml:"phase,omitempty"`
+	DiscoveredTools    []string `json:"discoveredTools,omitempty" yaml:"discoveredTools,omitempty"`
+	GeneratedTools     []string `json:"generatedTools,omitempty" yaml:"generatedTools,omitempty"`
+	LastSyncedAt       string   `json:"lastSyncedAt,omitempty" yaml:"lastSyncedAt,omitempty"`
+	LastError          string   `json:"lastError,omitempty" yaml:"lastError,omitempty"`
+	ObservedGeneration int64    `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type McpServerList struct {
-	ListMeta `json:",inline"`
-	Items    []McpServer `json:"items"`
+	ListMeta `json:",inline" yaml:",inline"`
+	Items    []McpServer `json:"items" yaml:"items"`
 }
 
 func (m *McpServer) Normalize() error {

--- a/resources/sealed_secret_crypto.go
+++ b/resources/sealed_secret_crypto.go
@@ -219,12 +219,25 @@ func unsealSecretValue(namespace, name, entryKey string, value SealedValue, priv
 	aad := sealedSecretAAD(namespace, name, entryKey)
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, aad)
 	if err != nil {
-		return "", fmt.Errorf("decrypt %q: %w", entryKey, err)
+		legacyAAD := legacySealedSecretAAD(namespace, name, entryKey)
+		plaintext, err = gcm.Open(nil, nonce, ciphertext, legacyAAD)
+		if err != nil {
+			return "", fmt.Errorf("decrypt %q: %w", entryKey, err)
+		}
 	}
 	return string(plaintext), nil
 }
 
+const sealedSecretAADVersion = "AES-256-GCM-v1"
+
 func sealedSecretAAD(namespace, name, entryKey string) []byte {
+	return []byte(sealedSecretAADVersion + "\x00" +
+		NormalizeNamespace(namespace) + "\x00" +
+		strings.TrimSpace(name) + "\x00" +
+		strings.TrimSpace(entryKey))
+}
+
+func legacySealedSecretAAD(namespace, name, entryKey string) []byte {
 	return []byte(NormalizeNamespace(namespace) + "\x00" + strings.TrimSpace(name) + "\x00" + strings.TrimSpace(entryKey))
 }
 

--- a/resources/sealed_secret_test.go
+++ b/resources/sealed_secret_test.go
@@ -1,6 +1,9 @@
 package resources
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSealUnsealSealedSecretRoundTrip(t *testing.T) {
 	material, err := GenerateSealingKeyMaterial()
@@ -71,5 +74,12 @@ func TestUnsealSealedSecretRejectsAADReplay(t *testing.T) {
 	sealed.Metadata.Name = "api-key-copy"
 	if _, err := UnsealSealedSecret(sealed, material.KeyID, material.PrivateKey); err == nil {
 		t.Fatal("expected AAD mismatch to fail decryption")
+	}
+}
+
+func TestSealedSecretAADIncludesAlgorithm(t *testing.T) {
+	aad := sealedSecretAAD("team-a", "my-secret", "key1")
+	if !strings.Contains(string(aad), sealedSecretAADVersion) {
+		t.Fatalf("AAD should include algorithm version %q, got %q", sealedSecretAADVersion, string(aad))
 	}
 }

--- a/resources/task_deepcopy.go
+++ b/resources/task_deepcopy.go
@@ -33,6 +33,10 @@ func copyTaskStatus(status TaskStatus) TaskStatus {
 	copy.MessageIdempotency = append([]TaskMessageIdempotency(nil), status.MessageIdempotency...)
 	copy.JoinStates = copyTaskJoinStates(status.JoinStates)
 	copy.DelegationStates = copyTaskDelegationStates(status.DelegationStates)
+	if status.BlockedOn != nil {
+		blockedOn := *status.BlockedOn
+		copy.BlockedOn = &blockedOn
+	}
 	return copy
 }
 

--- a/resources/task_deepcopy_test.go
+++ b/resources/task_deepcopy_test.go
@@ -1,0 +1,39 @@
+package resources
+
+import "testing"
+
+func TestDeepCopy_BlockedOnIsolation(t *testing.T) {
+	original := Task{
+		Status: TaskStatus{
+			BlockedOn: &TaskBlockedOn{
+				Kind:   "TaskApproval",
+				Name:   "my-approval",
+				Reason: "waiting for approval",
+			},
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied.Status.BlockedOn == original.Status.BlockedOn {
+		t.Fatal("DeepCopy shares BlockedOn pointer with original")
+	}
+
+	copied.Status.BlockedOn.Reason = "mutated"
+	if original.Status.BlockedOn.Reason != "waiting for approval" {
+		t.Fatalf("mutating copy's BlockedOn affected original: got %q", original.Status.BlockedOn.Reason)
+	}
+}
+
+func TestDeepCopy_BlockedOnNil(t *testing.T) {
+	original := Task{
+		Status: TaskStatus{
+			BlockedOn: nil,
+		},
+	}
+
+	copied := original.DeepCopy()
+	if copied.Status.BlockedOn != nil {
+		t.Fatal("expected nil BlockedOn in copy")
+	}
+}

--- a/runtime/agent_message_consumer.go
+++ b/runtime/agent_message_consumer.go
@@ -1046,7 +1046,7 @@ func (m *AgentMessageConsumerManager) applyDelegationGate(ctx context.Context, t
 		return delegationGateDecision{}, nil
 	}
 
-	join := resources.NormalizeGraphJoin(graphNode.DelegateJoin)
+	join, _ := resources.NormalizeGraphJoin(graphNode.DelegateJoin)
 	expected := len(graphNode.Delegates)
 	required := expected
 	if join.Mode == "quorum" {
@@ -2752,7 +2752,7 @@ func joinRequirements(system resources.AgentSystem, target string) (mode string,
 
 	mode = "wait_for_all"
 	if node, ok := system.Spec.Graph[target]; ok {
-		normalized := resources.NormalizeGraphJoin(node.Join)
+		normalized, _ := resources.NormalizeGraphJoin(node.Join)
 		mode = normalized.Mode
 		if mode == "" {
 			mode = "wait_for_all"
@@ -3037,6 +3037,14 @@ func copyStringMapRuntime(input map[string]string) map[string]string {
 	return out
 }
 
+func mustEncodeResumeContext(ctx resources.TaskApprovalResumeContext) map[string]any {
+	out, err := resources.EncodeTaskApprovalResumeContext(ctx)
+	if err != nil {
+		return map[string]any{}
+	}
+	return out
+}
+
 func resumeMessagesFromAgentMessages(messages []AgentMessage) []resources.TaskApprovalResumeMessage {
 	if len(messages) == 0 {
 		return nil
@@ -3126,7 +3134,7 @@ func (m *AgentMessageConsumerManager) pauseTaskForOutputReview(
 			Supersedes:          supersedes,
 			Output:              outputSnapshot,
 			OutputFormat:        "text",
-			ResumeContext:       resources.EncodeTaskApprovalResumeContext(resumeContext),
+			ResumeContext:       mustEncodeResumeContext(resumeContext),
 		},
 		Status: resources.TaskApprovalStatus{
 			Phase: "Pending",
@@ -3171,7 +3179,7 @@ func (m *AgentMessageConsumerManager) pauseTaskForOutputReview(
 		if checkpointType == "task_output" {
 			resumeContext.Output = copyStringMapRuntime(task.Status.Output)
 			approval.Spec.Output = copyStringMapRuntime(task.Status.Output)
-			approval.Spec.ResumeContext = resources.EncodeTaskApprovalResumeContext(resumeContext)
+			approval.Spec.ResumeContext = mustEncodeResumeContext(resumeContext)
 			if _, err := m.taskApprovals.Upsert(ctx, approval); err != nil {
 				return err
 			}

--- a/runtime/builtin_tools_memory.go
+++ b/runtime/builtin_tools_memory.go
@@ -87,6 +87,7 @@ func (s *SharedMemoryStore) Search(query string, topK int) []memoryEntry {
 			results = append(results, memoryEntry{Key: k, Value: v})
 		}
 	}
+	sort.Slice(results, func(i, j int) bool { return results[i].Key < results[j].Key })
 	if len(results) > topK {
 		results = results[:topK]
 	}
@@ -273,6 +274,10 @@ func (r *MemoryToolRuntime) handleIngest(ctx context.Context, input string) (str
 	}
 	if strings.TrimSpace(req.Content) == "" {
 		return "", fmt.Errorf("memory.ingest: content is required")
+	}
+	const maxIngestContentBytes = 10 * 1024 * 1024 // 10 MB
+	if len(req.Content) > maxIngestContentBytes {
+		return "", fmt.Errorf("memory.ingest: content exceeds %d byte limit", maxIngestContentBytes)
 	}
 
 	chunks := ChunkText(req.Content, req.ChunkSize, req.Overlap)

--- a/runtime/builtin_tools_memory_test.go
+++ b/runtime/builtin_tools_memory_test.go
@@ -1,0 +1,46 @@
+package agentruntime
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSharedMemorySearch_Deterministic(t *testing.T) {
+	store := NewSharedMemoryStore()
+	for i := 0; i < 20; i++ {
+		key := strings.Repeat("x", i+1)
+		store.Put("match-"+key, "value")
+	}
+
+	var firstResult []memoryEntry
+	for run := 0; run < 10; run++ {
+		results := store.Search("match", 5)
+		if run == 0 {
+			firstResult = results
+			continue
+		}
+		if len(results) != len(firstResult) {
+			t.Fatalf("run %d: got %d results, expected %d", run, len(results), len(firstResult))
+		}
+		for i := range results {
+			if results[i].Key != firstResult[i].Key {
+				t.Fatalf("run %d: result[%d] = %q, expected %q", run, i, results[i].Key, firstResult[i].Key)
+			}
+		}
+	}
+}
+
+func TestMemoryIngest_ContentSizeLimit(t *testing.T) {
+	store := NewSharedMemoryStore()
+	rt := &MemoryToolRuntime{memory: store}
+
+	largeContent := strings.Repeat("x", 11*1024*1024)
+	input := `{"source": "test", "content": "` + largeContent + `"}`
+	_, err := rt.handleIngest(nil, input)
+	if err == nil {
+		t.Fatal("expected error for oversized content")
+	}
+	if !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("expected byte limit error, got: %v", err)
+	}
+}


### PR DESCRIPTION
- DeepCopy isolates BlockedOn pointer to prevent shared mutable state
- Regex edge conditions: length-limited, compiled at normalization, cached
- ParseMemoryBytes: overflow guard + Kubernetes Gi/Mi/Ki suffixes
- Agent OutputSchema: depth/size/type validation at normalization
- YAML parsers reject multi-document streams (--- separator)
- All resource structs now carry yaml: tags matching json: tags
- NormalizeGraphJoin returns errors for invalid enum values
- Task.Normalize requires spec.system when mode=run
- EncodeTaskApprovalResumeContext propagates errors
- memory.ingest: 10 MB content size limit
- SharedMemoryStore.Search: deterministic sort before topK truncation
- Sealed secret AAD includes algorithm version (backward-compatible)
- YAML flow array split respects quoted commas
- Agent.ResolvedModel() accessor for json:"-" Model field


