### PR TITLE
add eval start cmd and --run flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **EvalRun docs and frontend type mismatches**: documentation used `dataset` instead of `dataset_ref`, showed `agent_overrides` as a list instead of a map, and used `system_prompt` instead of `prompt`. Frontend TypeScript types matched the incorrect docs rather than the Go backend. All examples, reference docs, and frontend types now match the actual `EvalRunSpec` schema.
 - **Helm chart hardening**: conditional NATS URL args (avoid passing empty `--nats-url=` when NATS is disabled), templated `containerPort` and probe settings from values (instead of hardcoded), added `seccompProfile: RuntimeDefault` to pod security contexts, security context on `helm test` pod, removed dead `postgres-password` key from chart-managed Secret, and removed placeholder sub-chart directories that shadowed real `helm dependency update`.
 
 ### Changed
 
+- **EvalRun suspended by default on apply**: `orlojctl apply` now creates EvalRun resources in a suspended state (`spec.suspended: true`) so they do not execute automatically. Use `orlojctl apply --run` to start immediately, `orlojctl eval start <name>` to start a suspended run, or `orlojctl eval run` (unchanged) to create and start in one step. New `POST /v1/eval-runs/{name}/start` API endpoint.
 - **Sealed Secrets UI consolidated into Secrets page**: removed the dedicated "Sealed Secrets" navigation entry and pages. Secrets that originate from a `SealedSecret` now show a "Sealed" source badge in the list and detail views, with the owning `SealedSecret` name. Old `/sealed-secrets` URLs redirect to `/secrets`.
 - **JetStream API migrated to `jetstream` package**: the agent message bus now uses `jetstream.New(nc)` and the push-based `consumer.Messages()` iterator instead of the deprecated `nc.JetStream()` v1 API with `PullSubscribe`/`Fetch` polling. This eliminates idle CPU from the 2-second poll loop and delivers messages instantly via server-side push with heartbeats.
 - **Stream bounded by `MaxBytes`**: the `ORLOJ_AGENT_MESSAGES` stream now enforces a 1 GiB `MaxBytes` cap alongside the existing 7-day `MaxAge`, preventing unbounded disk growth during message bursts.

--- a/api/eval_api.go
+++ b/api/eval_api.go
@@ -220,6 +220,8 @@ func (s *Server) handleEvalRuns(w http.ResponseWriter, r *http.Request) {
 		}
 		if ok {
 			obj.Status = existing.Status
+		} else if r.URL.Query().Get("run") != "true" {
+			obj.Spec.Suspended = true
 		}
 		obj, err = s.stores.EvalRuns.Upsert(r.Context(), obj)
 		if err != nil {
@@ -254,6 +256,11 @@ func (s *Server) handleEvalRunByName(w http.ResponseWriter, r *http.Request) {
 	if strings.HasSuffix(path, "/finalize") {
 		name := strings.TrimSuffix(path, "/finalize")
 		s.handleEvalRunFinalize(w, r, name)
+		return
+	}
+	if strings.HasSuffix(path, "/start") {
+		name := strings.TrimSuffix(path, "/start")
+		s.handleEvalRunStart(w, r, name)
 		return
 	}
 	if strings.HasSuffix(path, "/cancel") {
@@ -552,6 +559,39 @@ func (s *Server) handleEvalRunFinalize(w http.ResponseWriter, r *http.Request, n
 	obj.Status.Phase = resources.EvalRunPhaseSucceeded
 
 	obj, err = s.stores.EvalRuns.UpdateStatus(r.Context(), key, obj.Status)
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	s.publishResourceEvent("EvalRun", obj.Metadata.Name, "updated", obj)
+	writeJSON(w, http.StatusOK, obj)
+}
+
+func (s *Server) handleEvalRunStart(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	key := scopedNameForRequest(r, name)
+	obj, ok, err := s.stores.EvalRuns.Get(r.Context(), key)
+	if writeStoreFetchError(w, err) {
+		return
+	}
+	if !ok {
+		http.Error(w, fmt.Sprintf("eval run %q not found", name), http.StatusNotFound)
+		return
+	}
+	if !obj.Spec.Suspended {
+		http.Error(w, fmt.Sprintf("eval run %q is not suspended (phase: %s)", name, obj.Status.Phase), http.StatusConflict)
+		return
+	}
+	if obj.Status.Phase != resources.EvalRunPhasePending {
+		http.Error(w, fmt.Sprintf("eval run %q is in phase %q, not Pending", name, obj.Status.Phase), http.StatusConflict)
+		return
+	}
+
+	obj.Spec.Suspended = false
+	obj, err = s.stores.EvalRuns.Upsert(r.Context(), obj)
 	if err != nil {
 		writeStoreError(w, err)
 		return

--- a/api/eval_api_test.go
+++ b/api/eval_api_test.go
@@ -559,6 +559,187 @@ func TestEvalRunCancelTerminalPhase(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Start / Suspended
+// ---------------------------------------------------------------------------
+
+func TestEvalRunPostDefaultsSuspended(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+
+	seedEvalDataset(t, server.URL)
+
+	body, _ := json.Marshal(resources.EvalRun{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "EvalRun",
+		Metadata:   resources.ObjectMeta{Name: "auto-suspended"},
+		Spec: resources.EvalRunSpec{
+			DatasetRef: "golden",
+			System:     "test-system",
+		},
+	})
+	resp, err := http.Post(server.URL+"/v1/eval-runs", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, b)
+	}
+	var run resources.EvalRun
+	json.NewDecoder(resp.Body).Decode(&run)
+	if !run.Spec.Suspended {
+		t.Fatal("expected new eval run to be suspended by default")
+	}
+}
+
+func TestEvalRunPostWithRunQueryParam(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+
+	seedEvalDataset(t, server.URL)
+
+	body, _ := json.Marshal(resources.EvalRun{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "EvalRun",
+		Metadata:   resources.ObjectMeta{Name: "immediate-run"},
+		Spec: resources.EvalRunSpec{
+			DatasetRef: "golden",
+			System:     "test-system",
+		},
+	})
+	resp, err := http.Post(server.URL+"/v1/eval-runs?run=true", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, b)
+	}
+	var run resources.EvalRun
+	json.NewDecoder(resp.Body).Decode(&run)
+	if run.Spec.Suspended {
+		t.Fatal("expected eval run with ?run=true to not be suspended")
+	}
+}
+
+func TestEvalRunStart(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+
+	seedEvalDataset(t, server.URL)
+
+	body, _ := json.Marshal(resources.EvalRun{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "EvalRun",
+		Metadata:   resources.ObjectMeta{Name: "start-me"},
+		Spec: resources.EvalRunSpec{
+			DatasetRef: "golden",
+			System:     "test-system",
+		},
+	})
+	http.Post(server.URL+"/v1/eval-runs", "application/json", bytes.NewReader(body))
+
+	startReq, _ := http.NewRequest(http.MethodPost, server.URL+"/v1/eval-runs/start-me/start", nil)
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer startResp.Body.Close()
+	if startResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(startResp.Body)
+		t.Fatalf("expected 200, got %d: %s", startResp.StatusCode, b)
+	}
+	var run resources.EvalRun
+	json.NewDecoder(startResp.Body).Decode(&run)
+	if run.Spec.Suspended {
+		t.Fatal("expected suspended to be false after start")
+	}
+	if run.Status.Phase != resources.EvalRunPhasePending {
+		t.Fatalf("expected Pending phase, got %q", run.Status.Phase)
+	}
+}
+
+func TestEvalRunStartNotSuspended(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+
+	seedEvalDataset(t, server.URL)
+
+	body, _ := json.Marshal(resources.EvalRun{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "EvalRun",
+		Metadata:   resources.ObjectMeta{Name: "already-active"},
+		Spec: resources.EvalRunSpec{
+			DatasetRef: "golden",
+			System:     "test-system",
+		},
+	})
+	http.Post(server.URL+"/v1/eval-runs?run=true", "application/json", bytes.NewReader(body))
+
+	startReq, _ := http.NewRequest(http.MethodPost, server.URL+"/v1/eval-runs/already-active/start", nil)
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer startResp.Body.Close()
+	if startResp.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409 for start on non-suspended run, got %d", startResp.StatusCode)
+	}
+}
+
+func TestEvalRunStartWrongPhase(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+
+	seedEvalDataset(t, server.URL)
+
+	body, _ := json.Marshal(resources.EvalRun{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "EvalRun",
+		Metadata:   resources.ObjectMeta{Name: "wrong-phase"},
+		Spec: resources.EvalRunSpec{
+			DatasetRef: "golden",
+			System:     "test-system",
+		},
+	})
+	http.Post(server.URL+"/v1/eval-runs", "application/json", bytes.NewReader(body))
+
+	statusBody, _ := json.Marshal(map[string]any{
+		"status": map[string]any{"phase": "Succeeded"},
+	})
+	req, _ := http.NewRequest(http.MethodPut, server.URL+"/v1/eval-runs/wrong-phase/status", bytes.NewReader(statusBody))
+	req.Header.Set("Content-Type", "application/json")
+	http.DefaultClient.Do(req)
+
+	startReq, _ := http.NewRequest(http.MethodPost, server.URL+"/v1/eval-runs/wrong-phase/start", nil)
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer startResp.Body.Close()
+	if startResp.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409 for start on wrong phase, got %d", startResp.StatusCode)
+	}
+}
+
+func TestEvalRunStartNotFound(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+
+	startReq, _ := http.NewRequest(http.MethodPost, server.URL+"/v1/eval-runs/nonexistent/start", nil)
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer startResp.Body.Close()
+	if startResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", startResp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Compare
 // ---------------------------------------------------------------------------
 

--- a/cli/orlojctl.go
+++ b/cli/orlojctl.go
@@ -151,7 +151,7 @@ func newApplyCommand() *cobra.Command {
 		RunE:  runApply,
 	}
 	cmd.Flags().StringP("file", "f", "", "path to resource manifest file or directory")
-	cmd.Flags().Bool("run", false, "include runnable Task manifests when applying a directory")
+	cmd.Flags().Bool("run", false, "include runnable Task manifests and start EvalRun manifests immediately")
 	cmd.Flags().Bool("dry-run", false, "preview changes without persisting")
 	return cmd
 }
@@ -268,6 +268,9 @@ func runApply(cmd *cobra.Command, args []string) error {
 		if includeRunnable && endpoint == "/v1/tasks" {
 			postURL += "?rerun=true"
 		}
+		if includeRunnable && endpoint == "/v1/eval-runs" {
+			postURL += "?run=true"
+		}
 		resp, err := http.Post(postURL, "application/json", bytes.NewReader(payload))
 		if err != nil {
 			applyErrs = append(applyErrs, fmt.Sprintf("%s: apply request failed: %v", f, err))
@@ -282,8 +285,11 @@ func runApply(cmd *cobra.Command, args []string) error {
 		}
 
 		actualName := nameFromResponseBody(body, name)
+		isSuspendedEvalRun := !includeRunnable && endpoint == "/v1/eval-runs"
 		if actualName != name {
 			fmt.Printf("applied %s/%s (rerun as %s)\n", strings.ToLower(kind), name, actualName)
+		} else if isSuspendedEvalRun {
+			fmt.Printf("applied %s/%s (suspended; use --run or 'orlojctl eval start %s' to execute)\n", strings.ToLower(kind), name, name)
 		} else {
 			fmt.Printf("applied %s/%s\n", strings.ToLower(kind), name)
 		}

--- a/cli/orlojctl_eval.go
+++ b/cli/orlojctl_eval.go
@@ -24,6 +24,7 @@ func newEvalCommand() *cobra.Command {
 	}
 	cmd.AddCommand(
 		newEvalRunCommand(),
+		newEvalStartCommand(),
 		newEvalListCommand(),
 		newEvalGetCommand(),
 		newEvalCompareCommand(),
@@ -96,7 +97,7 @@ func runEvalRun(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to encode eval run: %w", err)
 	}
 
-	reqURL := strings.TrimRight(server, "/") + "/v1/eval-runs"
+	reqURL := strings.TrimRight(server, "/") + "/v1/eval-runs?run=true"
 	resp, err := http.Post(reqURL, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to create eval run: %w", err)
@@ -120,6 +121,51 @@ func runEvalRun(cmd *cobra.Command, _ []string) error {
 		return waitAndPrintEvalRun(server, created.Metadata.Name, ns, output)
 	}
 	return nil
+}
+
+func newEvalStartCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start <name>",
+		Short: "Start a suspended eval run",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			server := resolveServer(cmd)
+			ns := resolveNamespace(cmd)
+			wait, _ := cmd.Flags().GetBool("wait")
+			output, _ := cmd.Flags().GetString("output")
+
+			reqURL := strings.TrimRight(server, "/") + "/v1/eval-runs/" + url.PathEscape(args[0]) + "/start"
+			if ns != "" {
+				reqURL += "?namespace=" + url.QueryEscape(ns)
+			}
+			resp, err := http.Post(reqURL, "application/json", nil)
+			if err != nil {
+				return fmt.Errorf("failed to start eval run: %w", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode >= 300 {
+				body, _ := io.ReadAll(resp.Body)
+				return fmt.Errorf("start failed: %s", bytes.TrimSpace(body))
+			}
+
+			var started resources.EvalRun
+			if err := json.NewDecoder(resp.Body).Decode(&started); err != nil {
+				return fmt.Errorf("failed to decode response: %w", err)
+			}
+
+			fmt.Printf("eval run %s started (phase: %s)\n", started.Metadata.Name, started.Status.Phase)
+
+			if wait {
+				fmt.Println("waiting for eval run to complete...")
+				return waitAndPrintEvalRun(server, started.Metadata.Name, ns, output)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().Bool("wait", false, "block until the run completes")
+	cmd.Flags().StringP("output", "o", "table", "output format: table|json")
+	return cmd
 }
 
 func waitAndPrintEvalRun(server, name, ns, format string) error {

--- a/controllers/eval_run_controller.go
+++ b/controllers/eval_run_controller.go
@@ -71,6 +71,9 @@ func (c *EvalRunController) ReconcileOnce(ctx context.Context) error {
 		run := &runs[i]
 		switch run.Status.Phase {
 		case resources.EvalRunPhasePending:
+			if run.Spec.Suspended {
+				continue
+			}
 			if err := c.reconcilePending(ctx, run); err != nil {
 				c.logf("error reconciling pending eval run %s: %v", run.Metadata.Name, err)
 			}

--- a/controllers/eval_run_controller_test.go
+++ b/controllers/eval_run_controller_test.go
@@ -110,6 +110,46 @@ func TestEvalRunController_ReconcilePending_CreatesTasksAndTransitions(t *testin
 	}
 }
 
+func TestEvalRunController_ReconcilePending_SkipsSuspendedRuns(t *testing.T) {
+	ctx := context.Background()
+	c, runs, datasets, tasks := newEvalRunControllerHarness(t)
+
+	seedDatasetForController(t, datasets)
+
+	run := resources.EvalRun{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "EvalRun",
+		Metadata:   resources.ObjectMeta{Name: "suspended-run", Namespace: "default"},
+		Spec: resources.EvalRunSpec{
+			DatasetRef:  "golden",
+			System:      "test-system",
+			Scoring:     resources.EvalScoringConfig{Strategy: "exact_match"},
+			Concurrency: 2,
+			Suspended:   true,
+		},
+	}
+	if _, err := runs.Upsert(ctx, run); err != nil {
+		t.Fatalf("seed suspended eval run: %v", err)
+	}
+
+	if err := c.ReconcileOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, _ := runs.Get(ctx, "default/suspended-run")
+	if !ok {
+		t.Fatal("eval run not found after reconcile")
+	}
+	if got.Status.Phase == resources.EvalRunPhaseRunning {
+		t.Fatal("suspended eval run should not have transitioned to Running")
+	}
+
+	allTasks, _ := tasks.List(ctx)
+	if len(allTasks) != 0 {
+		t.Fatalf("expected 0 tasks for suspended run, got %d", len(allTasks))
+	}
+}
+
 func TestEvalRunController_ReconcilePending_MissingDataset(t *testing.T) {
 	ctx := context.Background()
 	c, runs, _, _ := newEvalRunControllerHarness(t)

--- a/docs/pages/guides/run-agent-evaluation.md
+++ b/docs/pages/guides/run-agent-evaluation.md
@@ -107,7 +107,7 @@ kind: EvalRun
 metadata:
   name: triage-eval-exact
 spec:
-  dataset: triage-golden
+  dataset_ref: triage-golden
   system: support-triage-system
   scoring:
     strategy: exact_match
@@ -116,7 +116,10 @@ spec:
 ```
 
 ```bash
-orlojctl apply -f eval-run.yaml
+orlojctl apply -f eval-run.yaml               # creates the run in suspended state
+orlojctl eval start triage-eval-exact          # start it when ready
+# or apply and start immediately:
+orlojctl apply -f eval-run.yaml --run
 ```
 
 ## Step 3: Run with LLM-as-Judge
@@ -140,7 +143,7 @@ kind: EvalRun
 metadata:
   name: triage-eval-llm
 spec:
-  dataset: triage-golden
+  dataset_ref: triage-golden
   system: support-triage-system
   scoring:
     strategy: llm_judge
@@ -162,7 +165,7 @@ kind: EvalRun
 metadata:
   name: triage-eval-claude
 spec:
-  dataset: triage-golden
+  dataset_ref: triage-golden
   system: support-triage-system
   scoring:
     strategy: llm_judge
@@ -170,15 +173,15 @@ spec:
     rubric: "Rate accuracy and helpfulness of the triage classification (0-1)."
   concurrency: 4
   agent_overrides:
-    - agent: triage-agent
+    triage-agent:
       model_ref: claude-sonnet
 ```
 
-Apply and wait for completion:
+Apply and start:
 
 ```bash
-orlojctl apply -f eval-claude.yaml
-orlojctl get eval-runs triage-eval-claude -w
+orlojctl apply -f eval-claude.yaml --run
+orlojctl eval get triage-eval-claude -w
 ```
 
 ## Step 5: Compare Runs

--- a/docs/pages/reference/resources/eval-run.md
+++ b/docs/pages/reference/resources/eval-run.md
@@ -13,7 +13,7 @@ metadata:
   name: triage-gpt4o-20260510
   namespace: default
 spec:
-  dataset: support-triage-golden
+  dataset_ref: support-triage-golden
   system: support-triage-system
   scoring:
     strategy: llm_judge
@@ -22,8 +22,8 @@ spec:
   concurrency: 5
   timeout: 120s
   agent_overrides:
-    - agent: triage-agent
-      system_prompt: "You are a support triage bot. Classify and route."
+    triage-agent:
+      prompt: "You are a support triage bot. Classify and route."
       model_ref: gpt-4o-mini
 ```
 
@@ -31,22 +31,22 @@ spec:
 
 | Field | Type | Description |
 |---|---|---|
-| `dataset` | string, required | Name of the [EvalDataset](./eval-dataset.md) to evaluate against. |
+| `dataset_ref` | string, required | Name of the [EvalDataset](./eval-dataset.md) to evaluate against. |
 | `system` | string, required | Name of the [AgentSystem](./agent-system.md) to evaluate. |
 | `scoring` | EvalScoringConfig | Default scoring strategy for all samples. Per-sample overrides in the dataset take precedence. |
-| `concurrency` | int | Maximum parallel tasks (samples) to execute. Defaults to 1. Minimum 1. |
+| `concurrency` | int | Maximum parallel tasks (samples) to execute. Defaults to 5. Minimum 1. |
 | `timeout` | duration string | Per-sample task timeout (e.g. `120s`, `5m`). Must be a valid Go `time.Duration`. |
-| `agent_overrides` | []AgentOverride | Ephemeral overrides for agent configuration within this run. |
+| `agent_overrides` | map[string]AgentOverride | Ephemeral overrides for agent configuration within this run. Keys are agent names. |
 | `labels` | map[string]string | Arbitrary labels for filtering and comparison. |
+| `suspended` | bool | When true, the controller will not execute this run. Defaults to `true` when created via `apply` (use `--run` to override or `orlojctl eval start` to trigger later). Defaults to `false` when created via `orlojctl eval run`. |
 
 ### AgentOverride
 
-Used for A/B testing models, prompts, or parameters without modifying the base agent resource.
+Used for A/B testing models, prompts, or parameters without modifying the base agent resource. The map key is the name of the agent to override.
 
 | Field | Type | Description |
 |---|---|---|
-| `agent` | string, required | Name of the agent to override. |
-| `system_prompt` | string | Override the agent's system prompt. |
+| `prompt` | string | Override the agent's system prompt. |
 | `model_ref` | string | Override the agent's model endpoint. |
 
 ### EvalScoringConfig
@@ -59,8 +59,9 @@ See [EvalDataset](./eval-dataset.md#evalscoringconfig) for the full field list.
 - `kind` defaults to `EvalRun`.
 - `metadata.namespace` defaults to `default`.
 - `status.phase` defaults to `Pending`.
-- `spec.concurrency` defaults to 1; must be >= 1.
-- `spec.dataset` and `spec.system` are required.
+- `spec.suspended` defaults to `true` when created via `POST /v1/eval-runs` (unless `?run=true` is set). `orlojctl eval run` sets `?run=true` automatically.
+- `spec.concurrency` defaults to 5; must be >= 1.
+- `spec.dataset_ref` and `spec.system` are required.
 - `spec.timeout` must be a valid Go duration string when set.
 - `llm_judge` scoring requires `model_ref`.
 - `custom` scoring requires `tool_ref`.
@@ -113,7 +114,7 @@ Pending ──► Running ──► Scoring ──► Succeeded
 
 | Phase | Meaning |
 |---|---|
-| `Pending` | Created, waiting for the controller. |
+| `Pending` | Created, waiting for the controller. If `spec.suspended` is true, the controller skips the run until it is started. |
 | `Running` | Tasks are being created and executed (up to `concurrency` in parallel). |
 | `Scoring` | All tasks completed; scoring pipeline is evaluating results. |
 | `PendingReview` | Manual scoring; awaiting human annotations before finalization. |
@@ -133,6 +134,7 @@ Pending ──► Running ──► Scoring ──► Succeeded
 | `GET` | `/v1/eval-runs/{name}/export` | Export results as JSON (or CSV with `?format=csv`). |
 | `PUT` | `/v1/eval-runs/{name}/results/{sample}` | Annotate a single sample (manual review). |
 | `POST` | `/v1/eval-runs/{name}/results` | Bulk import sample annotations. |
+| `POST` | `/v1/eval-runs/{name}/start` | Start a suspended eval run. |
 | `POST` | `/v1/eval-runs/{name}/finalize` | Finalize a PendingReview run (computes summary). |
 | `POST` | `/v1/eval-runs/{name}/cancel` | Cancel a running eval. |
 | `GET` | `/v1/eval-runs/compare?names=a,b,c` | Compare multiple runs side-by-side. |
@@ -140,7 +142,8 @@ Pending ──► Running ──► Scoring ──► Succeeded
 ## CLI Quick Reference
 
 ```bash
-orlojctl eval run --dataset golden --system my-system      # Start a run
+orlojctl eval run --dataset golden --system my-system      # Create and start a run
+orlojctl eval start my-run                                  # Start a suspended run
 orlojctl eval list                                          # List all runs
 orlojctl eval get my-run                                    # Get run detail
 orlojctl eval export my-run --format csv                    # Export for review
@@ -149,6 +152,8 @@ orlojctl eval import my-run -f reviewed.csv                 # Bulk import
 orlojctl eval finalize my-run                               # Finalize manual run
 orlojctl eval compare run-a run-b                           # Compare runs
 orlojctl eval datasets                                      # List datasets
+orlojctl apply -f eval-run.yaml                             # Apply (suspended by default)
+orlojctl apply -f eval-run.yaml --run                       # Apply and start immediately
 ```
 
 ## Related

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -934,8 +934,7 @@ export interface EvalSummary {
 }
 
 export interface AgentOverride {
-  agent: string;
-  system_prompt?: string;
+  prompt?: string;
   model_ref?: string;
 }
 
@@ -946,11 +945,12 @@ export interface EvalRun {
   spec: {
     dataset_ref: string;
     system: string;
-    agent_overrides?: AgentOverride[];
+    agent_overrides?: Record<string, AgentOverride>;
     scoring?: EvalScoringConfig;
     concurrency?: number;
     timeout?: string;
     labels?: Record<string, string>;
+    suspended?: boolean;
   };
   status?: {
     phase?: string;

--- a/frontend/src/pages/EvalRunDetail.tsx
+++ b/frontend/src/pages/EvalRunDetail.tsx
@@ -192,7 +192,7 @@ export function EvalRunDetail() {
               )}
             </div>
 
-            {run.spec.agent_overrides && run.spec.agent_overrides.length > 0 && (
+            {run.spec.agent_overrides && Object.keys(run.spec.agent_overrides).length > 0 && (
               <div style={{ marginTop: "1.5rem" }}>
                 <h3 className="detail-section-title">Agent overrides</h3>
                 <div className="detail-table-wrap">
@@ -201,19 +201,19 @@ export function EvalRunDetail() {
                       <tr>
                         <th>Agent</th>
                         <th>Model ref</th>
-                        <th>System prompt</th>
+                        <th>Prompt</th>
                       </tr>
                     </thead>
                     <tbody>
-                      {run.spec.agent_overrides.map((o) => (
-                        <tr key={o.agent}>
-                          <td className="mono">{o.agent}</td>
+                      {Object.entries(run.spec.agent_overrides).map(([agent, o]) => (
+                        <tr key={agent}>
+                          <td className="mono">{agent}</td>
                           <td className="mono text-secondary">{o.model_ref || "—"}</td>
                           <td className="text-secondary">
-                            {o.system_prompt
-                              ? o.system_prompt.length > 60
-                                ? o.system_prompt.slice(0, 60) + "…"
-                                : o.system_prompt
+                            {o.prompt
+                              ? o.prompt.length > 60
+                                ? o.prompt.slice(0, 60) + "…"
+                                : o.prompt
                               : "—"}
                           </td>
                         </tr>

--- a/openapi/schemas/eval-run.yaml
+++ b/openapi/schemas/eval-run.yaml
@@ -44,6 +44,7 @@ components:
         labels:
           type: object
           additionalProperties: { type: string }
+        suspended: { type: boolean, default: false }
     EvalRunStatus:
       type: object
       properties:

--- a/resources/eval_types.go
+++ b/resources/eval_types.go
@@ -188,6 +188,7 @@ type EvalRunSpec struct {
 	Concurrency           int                       `json:"concurrency,omitempty" yaml:"concurrency,omitempty"`
 	Timeout               string                    `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 	Labels                map[string]string         `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Suspended             bool                      `json:"suspended,omitempty" yaml:"suspended,omitempty"`
 }
 
 // AgentOverride holds per-agent prompt/model overrides for A/B comparisons.

--- a/resources/eval_types_test.go
+++ b/resources/eval_types_test.go
@@ -208,6 +208,39 @@ func TestEvalRunNormalize(t *testing.T) {
 			t.Fatalf("expected valid timeout, got error: %v", err)
 		}
 	})
+
+	t.Run("suspended field preserved", func(t *testing.T) {
+		run := EvalRun{
+			Metadata: ObjectMeta{Name: "run"},
+			Spec: EvalRunSpec{
+				DatasetRef: "ds",
+				System:     "sys",
+				Suspended:  true,
+			},
+		}
+		if err := run.Normalize(); err != nil {
+			t.Fatal(err)
+		}
+		if !run.Spec.Suspended {
+			t.Fatal("expected Suspended to be preserved as true")
+		}
+	})
+
+	t.Run("suspended defaults to false", func(t *testing.T) {
+		run := EvalRun{
+			Metadata: ObjectMeta{Name: "run"},
+			Spec: EvalRunSpec{
+				DatasetRef: "ds",
+				System:     "sys",
+			},
+		}
+		if err := run.Normalize(); err != nil {
+			t.Fatal(err)
+		}
+		if run.Spec.Suspended {
+			t.Fatal("expected Suspended to default to false")
+		}
+	})
 }
 
 func TestComputeEvalSummary(t *testing.T) {


### PR DESCRIPTION
- apply -f (file or dir) -- creates EvalRun with suspended: true; prints applied evalrun/X (suspended)
- apply -f --run -- creates EvalRun with suspended: false; controller picks it up immediately
- orlojctl eval run --dataset --system -- creates with suspended: false (current behavior, unchanged)
- orlojctl eval start <name> -- new command; clears suspended on an existing run so the controller picks it up
- POST /v1/eval-runs/{name}/start -- new API endpoint backing eval start
