### PR TITLE
charts/orloj: commit Chart.lock so GitOps tools can resolve subchart deps

### DIFF
--- a/charts/orloj/.gitignore
+++ b/charts/orloj/.gitignore
@@ -1,3 +1,2 @@
-# Helm dependency artifacts (run `helm dependency update` before install)
+# Helm dependency artifacts (run `helm dependency build` to materialize)
 charts/*.tgz
-Chart.lock

--- a/charts/orloj/Chart.lock
+++ b/charts/orloj/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.4.16
+- name: nats
+  repository: https://nats-io.github.io/k8s/helm/charts/
+  version: 1.2.11
+digest: sha256:fd3ba3244e9af4759aa5ffc7d900fefe58bee594d0bbb530524f86f9cd5031f9
+generated: "2026-05-14T09:33:09.736458+01:00"


### PR DESCRIPTION
## Summary

The orloj Helm chart declares `postgresql` and `nats` as subchart dependencies, but `Chart.lock` is `.gitignore`d, so it never ships with the repo.

GitOps tooling that renders the chart directly from the git source (ArgoCD, Flux, etc.) invokes `helm dependency build` — which **requires a committed lockfile** — before rendering. Without `Chart.lock`, the subcharts are never fetched and rendering fails.

This PR:

- Removes `Chart.lock` from `charts/orloj/.gitignore`
- Commits `Chart.lock` resolved against the current `dependencies:` ranges (`postgresql` 16.4.16, `nats` 1.2.11)

`helm dependency build` rebuilds the local `charts/*.tgz` from the lockfile deterministically, and `helm install ./charts/orloj` continues to work for users who run `helm dependency update` themselves (the lockfile gets refreshed before install if needed).

## Test plan

- [x] `helm dependency build` against the committed lockfile succeeds offline once `.tgz`s are cached
- [x] `helm template orloj ./charts/orloj --namespace orloj` renders cleanly with the lockfile-resolved subcharts
- [x] Re-running `helm dependency update` reproduces the same lockfile digest