### PR TITLE
feat(McpServer): add `allowPrivate` field for trusted internal MCP servers

### DIFF
--- a/docs/pages/reference/resources/mcp-server.md
+++ b/docs/pages/reference/resources/mcp-server.md
@@ -30,6 +30,7 @@ Represents a connection to an external MCP (Model Context Protocol) server. The 
   - `timeout` (duration string): max tool call execution time (e.g. `30s`, `2m`).
   - `isolation_mode` (string): isolation mode for tool execution.
   - `retry` (object): retry policy (see [Tool resource](./tool.md)).
+- `allowPrivate` (boolean): http transport only. When `true`, permits this MCP server's HTTP transport to connect to RFC 1918 / ULA / CGNAT addresses (e.g. in-cluster Services like `http://mcp.internal.svc.cluster.local:8000`). Loopback, link-local, cloud metadata, and unspecified addresses remain blocked regardless. Defaults to `false`; set `true` only for trusted internal MCP servers. Has no effect on `stdio` transport.
 
 ## Defaults and Validation
 

--- a/resources/manifest_parser_completeness_test.go
+++ b/resources/manifest_parser_completeness_test.go
@@ -399,6 +399,7 @@ spec:
   image: ghcr.io/org/mcp:v1
   image_pull_secret: ghcr-creds
   idle_timeout: 5m
+  allowPrivate: true
   args:
     - --port=8080
   env:

--- a/resources/manifest_parser_ext.go
+++ b/resources/manifest_parser_ext.go
@@ -2405,6 +2405,9 @@ func ParseMcpServerManifest(data []byte) (McpServer, error) {
 			out.Spec.ImagePullSecret = value
 		case section == "spec" && subsection == "" && (key == "idle_timeout" || key == "idleTimeout"):
 			out.Spec.IdleTimeout = value
+		case section == "spec" && subsection == "" && (key == "allowPrivate" || key == "allow_private"):
+			b := strings.EqualFold(strings.TrimSpace(value), "true")
+			out.Spec.AllowPrivate = &b
 		case section == "spec" && subsection == "auth" && (key == "secretRef" || key == "secret_ref"):
 			out.Spec.Auth.SecretRef = value
 		case section == "spec" && subsection == "auth" && key == "profile":

--- a/resources/resource_types.go
+++ b/resources/resource_types.go
@@ -2297,6 +2297,12 @@ type McpServerSpec struct {
 	Reconnect          McpReconnectPolicy `json:"reconnect,omitempty" yaml:"reconnect,omitempty"`
 	Resources          ContainerResources `json:"resources,omitempty" yaml:"resources,omitempty"`
 	DefaultToolRuntime *ToolRuntimePolicy `json:"default_tool_runtime,omitempty" yaml:"default_tool_runtime,omitempty"`
+	// AllowPrivate permits this MCP server's HTTP transport to connect to
+	// RFC 1918 / ULA / CGNAT addresses (e.g. in-cluster Services). Loopback,
+	// link-local, cloud metadata, and unspecified addresses remain blocked
+	// regardless. Defaults to false; set true only for trusted internal MCP
+	// servers. Has no effect on stdio transport.
+	AllowPrivate *bool `json:"allowPrivate,omitempty" yaml:"allowPrivate,omitempty"`
 }
 
 type McpServerEnvVar struct {

--- a/runtime/mcp_session.go
+++ b/runtime/mcp_session.go
@@ -476,9 +476,14 @@ func (m *McpSessionManager) buildHTTPTransport(ctx context.Context, server resou
 			headers[headerName] = secret
 		}
 	}
+	allowPrivate := false
+	if server.Spec.AllowPrivate != nil {
+		allowPrivate = *server.Spec.AllowPrivate
+	}
 	return NewStreamableHTTPMcpTransport(StreamableHTTPMcpTransportConfig{
-		Endpoint: server.Spec.Endpoint,
-		Headers:  headers,
+		Endpoint:     server.Spec.Endpoint,
+		Headers:      headers,
+		AllowPrivate: allowPrivate,
 	}), nil
 }
 


### PR DESCRIPTION
## Why

`McpServer`'s HTTP transport currently constructs its `SafeHTTPClient` with `allowPrivate=false` unconditionally ([`runtime/mcp_session.go:479`](https://github.com/OrlojHQ/orloj/blob/main/runtime/mcp_session.go#L479)), which blocks any connection to an RFC 1918 / ULA / CGNAT destination — including in-cluster Kubernetes Services. That makes it impossible to point an `McpServer` at a sibling Service like `http://my-mcp.svc.cluster.local:8000`. The only workaround today is to expose the MCP via a public Gateway / LB, which adds a hop and an unnecessary public surface for internal-only tooling.

`ModelEndpoint` already has an `allowPrivate` field for exactly this reason (trusted local/private model gateways like Ollama, vLLM, LiteLLM, LocalAI). This PR mirrors that on `McpServerSpec`.

## What

- **`McpServerSpec.AllowPrivate *bool`** (`json:\"allowPrivate\"`, `yaml:\"allowPrivate\"`). Pointer so the YAML loader can distinguish \"unset\" from explicit `false`.
- **`runtime/mcp_session.go`**: thread the value into `StreamableHTTPMcpTransportConfig.AllowPrivate`. Defaults to `false` when unset.
- **`resources/manifest_parser_ext.go`**: parse `allowPrivate` / `allow_private` at `spec` top level.
- **`resources/manifest_parser_completeness_test.go`**: `mcpServerMaximalYAML` fixture updated with `allowPrivate: true`. `TestYAMLParserFieldCompleteness/McpServer` would otherwise fail (and did locally during development — included as a self-check that the new field is parsed).
- **`docs/pages/reference/resources/mcp-server.md`**: describe the new field.

Loopback (`127.0.0.0/8`), link-local (`169.254/16`), cloud metadata (`169.254.169.254`, `fd00:ec2::254`), and unspecified addresses remain blocked regardless of `allowPrivate`. Has no effect on `stdio` transport (no network dial).

## Example

```yaml
apiVersion: orloj.dev/v1
kind: McpServer
metadata:
  name: internal-mcp
spec:
  transport: http
  endpoint: http://internal-mcp.svc.cluster.local:8000
  allowPrivate: true
```

## Tests

```
$ go test ./resources/... ./runtime/... -count=1 -timeout 120s
ok      github.com/OrlojHQ/orloj/resources                   0.742s
ok      github.com/OrlojHQ/orloj/runtime                     9.205s
ok      github.com/OrlojHQ/orloj/runtime/conformance         0.022s
ok      github.com/OrlojHQ/orloj/runtime/conformance/cases   0.011s

$ go vet ./resources/... ./runtime/...
(clean)
```