### PR TITLE
feat(frontend): redesign dashboard with bento layout and live trace feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **UI: Gold/bronze design system**: replaced green accent palette with a warm gold (#F5B041) and bronze (#D68930) theme across all surfaces, sidebar, cards, and graph nodes. Updated dark and light theme CSS variables for a premium modern feel.
+- **UI: Agent system detail page**: redesigned from tab-based layout to a single-page bento-box dashboard featuring a System Health Horizon banner (task success rate with sparkline, API reachability, workers online), full-width topology view with glowing gold edges and pulsing running nodes, and a three-column bottom grid (system definitions, recent tasks, task trace timeline).
+
 ## [0.16.1] - 2026-05-21
 
 ### Added

--- a/frontend/src/components/GraphView.tsx
+++ b/frontend/src/components/GraphView.tsx
@@ -198,12 +198,12 @@ const KIND_CONFIG: Record<NodeKind, { icon: React.ReactNode; colorVar: string }>
   system:  { icon: <Network   size={14} />, colorVar: "var(--accent)" },
   adapter: { icon: <Shield     size={14} />, colorVar: "var(--yellow)" },
   agent:   { icon: <Bot        size={14} />, colorVar: "var(--green)" },
-  model:   { icon: <Database   size={14} />, colorVar: "var(--blue)" },
+  model:   { icon: <Database   size={14} />, colorVar: "var(--accent-blue)" },
   tool:    { icon: <Wrench     size={14} />, colorVar: "var(--yellow)" },
   secret:  { icon: <Lock       size={14} />, colorVar: "var(--orange)" },
   memory:  { icon: <Brain      size={14} />, colorVar: "var(--purple)" },
   role:    { icon: <UserCog   size={14} />, colorVar: "var(--purple)" },
-  task:    { icon: <ListTodo   size={14} />, colorVar: "var(--blue)" },
+  task:    { icon: <ListTodo   size={14} />, colorVar: "var(--accent-blue)" },
   schedule:{ icon: <CalendarClock size={14} />, colorVar: "var(--orange)" },
   webhook: { icon: <Webhook    size={14} />, colorVar: "var(--orange)" },
   worker:  { icon: <Cpu        size={14} />, colorVar: "var(--green)" },
@@ -343,7 +343,7 @@ function buildTree(
   // -- Dagre graph: TB layout, all nodes included -----------------------------
 
   const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
-  g.setGraph({ rankdir: "LR", nodesep: 80, ranksep: 140, marginx: 50, marginy: 50 });
+  g.setGraph({ rankdir: "LR", nodesep: 120, ranksep: 200, marginx: 60, marginy: 60 });
 
   const sysId = nid("system", system.metadata.name);
   g.setNode(sysId, { width: NODE_W + 20, height: NODE_H + 8 });
@@ -723,11 +723,7 @@ function buildTree(
       edgeAnimated = tgtAgent ? runningAgents.has(tgtAgent) : false;
     }
 
-    // Routing edges are neutral gray at rest so an idle pipeline with many
-    // agents doesn't read as a wall of green. They only paint accent when
-    // actively animating (handled by the `.animated` CSS rule) or when the
-    // hover-focus subtree highlights them.
-    const strokeColor = "var(--edge-stroke)";
+    const strokeColor = edgeAnimated ? "var(--accent)" : "var(--edge-stroke)";
     const arrowColor = edgeAnimated ? "var(--accent)" : "var(--edge-stroke)";
 
     edges.push({
@@ -738,11 +734,11 @@ function buildTree(
       targetHandle,
       animated: edgeAnimated,
       className: routing ? "edge--routing" : "edge--dep",
-      type: agentToAgent ? "default" : "smoothstep",
+      type: "default",
       markerEnd: { type: MarkerType.ArrowClosed, width: routing ? 12 : 10, height: routing ? 12 : 10, color: arrowColor },
       style: {
         stroke: strokeColor,
-        strokeWidth: routing ? 1.5 : 1,
+        strokeWidth: routing ? 2.5 : 1.5,
         strokeDasharray: routing ? undefined : "3 4",
         // Dep edges: single-source opacity via CSS (.edge--dep { stroke-opacity }).
         // Routing edges keep a slight inline opacity for a softer line at rest.
@@ -769,7 +765,7 @@ interface GraphViewProps {
 export function GraphView({ system, related, onNodeClick, animated, runningAgents }: GraphViewProps) {
   const isMobile = useIsMobile();
   const [showLegend, setShowLegend] = useState(false);
-  const [showMinimap, setShowMinimap] = useState(false);
+  const [showMinimap, setShowMinimap] = useState(true);
   const [focusedNode, setFocusedNode] = useState<string | null>(null);
   const agentNames = system.spec.agents ?? [];
   const graph = system.spec.graph ?? {};
@@ -957,7 +953,7 @@ export function GraphView({ system, related, onNodeClick, animated, runningAgent
         maxZoom={2}
         proOptions={{ hideAttribution: true }}
       >
-        <Background gap={28} size={1} color="var(--graph-grid)" />
+        <Background gap={32} size={0.5} color="var(--graph-grid)" />
         <Controls position="bottom-right" showInteractive={false} />
         {!isMobile && showMinimap && (
           <MiniMap

--- a/frontend/src/components/SystemDefinitions.tsx
+++ b/frontend/src/components/SystemDefinitions.tsx
@@ -1,0 +1,84 @@
+import type { Agent, ModelEndpoint, Tool, Worker } from "../api/types";
+
+interface SystemDefinitionsProps {
+  agents: Agent[];
+  modelEndpoints: ModelEndpoint[];
+  tools: Tool[];
+  workers: Worker[];
+  systemAgentNames: string[];
+  apiReachable: boolean;
+}
+
+export function SystemDefinitions({
+  agents,
+  modelEndpoints,
+  tools,
+  workers,
+  systemAgentNames,
+  apiReachable,
+}: SystemDefinitionsProps) {
+  const systemAgents = agents.filter((a) =>
+    systemAgentNames.includes(a.metadata.name),
+  );
+  const modelsUsed = new Set(
+    systemAgents.map((a) => a.spec.model_ref).filter(Boolean),
+  );
+  const toolsUsed = new Set(systemAgents.flatMap((a) => a.spec.tools ?? []));
+
+  const modelCount = modelEndpoints.filter((m) =>
+    modelsUsed.has(m.metadata.name),
+  ).length;
+  const toolCount = tools.filter((t) => toolsUsed.has(t.metadata.name)).length;
+
+  const workersOnline = workers.filter((w) => {
+    const p = (w.status?.phase ?? "").toLowerCase();
+    return p === "healthy" || p === "ready";
+  }).length;
+
+  const readyCount = modelEndpoints.filter(
+    (m) =>
+      modelsUsed.has(m.metadata.name) &&
+      (m.status?.phase ?? "").toLowerCase() === "ready",
+  ).length;
+
+  return (
+    <div className="sys-definitions">
+      <h3 className="sys-definitions__title">SYSTEM DEFINITIONS</h3>
+      <div className="sys-definitions__grid">
+        <div className="sys-definitions__item">
+          <span className="sys-definitions__item-label">Agents</span>
+          <span className="sys-definitions__item-value">
+            {systemAgentNames.length}
+          </span>
+        </div>
+        <div className="sys-definitions__item">
+          <span className="sys-definitions__item-label">Models</span>
+          <span className="sys-definitions__item-value">{modelCount}</span>
+        </div>
+        <div className="sys-definitions__item">
+          <span className="sys-definitions__item-label">Tools</span>
+          <span className="sys-definitions__item-value">{toolCount}</span>
+        </div>
+        <div className="sys-definitions__item">
+          <span className="sys-definitions__item-label">API reachability</span>
+          <span className="sys-definitions__item-value">
+            {apiReachable ? 1 : 0}
+          </span>
+        </div>
+        <div className="sys-definitions__item">
+          <span className="sys-definitions__item-label">Workers</span>
+          <span className="sys-definitions__item-value">{workersOnline}</span>
+        </div>
+        <div className="sys-definitions__item">
+          <span className="sys-definitions__item-label">Workers</span>
+          <span className="sys-definitions__item-value">{workers.length}</span>
+          <span className="sys-definitions__item-sub">Last 24 hours</span>
+        </div>
+      </div>
+      <div className="sys-definitions__footer">
+        <span className="sys-definitions__footer-item">Total on</span>
+        <span className="sys-definitions__footer-item">{readyCount} ready</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SystemHealthHorizon.tsx
+++ b/frontend/src/components/SystemHealthHorizon.tsx
@@ -1,0 +1,146 @@
+import { useMemo } from "react";
+import { Activity, Wifi, Cpu } from "lucide-react";
+import type { Task, Worker } from "../api/types";
+
+interface SystemHealthHorizonProps {
+  tasks: Task[];
+  systemName?: string;
+  apiReachable: boolean;
+  workers: Worker[];
+}
+
+function generateSparklinePoints(tasks: Task[], width: number, height: number): string {
+  if (tasks.length === 0) return "";
+
+  const sorted = [...tasks]
+    .filter((t) => t.status?.completedAt || t.status?.startedAt)
+    .sort((a, b) => {
+      const aTime = a.status?.completedAt ?? a.status?.startedAt ?? "";
+      const bTime = b.status?.completedAt ?? b.status?.startedAt ?? "";
+      return aTime.localeCompare(bTime);
+    });
+
+  if (sorted.length < 2) {
+    const y = sorted.length === 1 && sorted[0].status?.phase?.toLowerCase() === "succeeded"
+      ? height * 0.1
+      : height * 0.5;
+    return `M 0 ${y} L ${width} ${y}`;
+  }
+
+  const bucketCount = Math.min(sorted.length, 20);
+  const bucketSize = Math.ceil(sorted.length / bucketCount);
+  const rates: number[] = [];
+
+  for (let i = 0; i < bucketCount; i++) {
+    const bucket = sorted.slice(i * bucketSize, (i + 1) * bucketSize);
+    const succeeded = bucket.filter((t) => t.status?.phase?.toLowerCase() === "succeeded").length;
+    rates.push(bucket.length > 0 ? succeeded / bucket.length : 1);
+  }
+
+  const xStep = width / (rates.length - 1);
+  const points = rates.map((rate, idx) => {
+    const x = idx * xStep;
+    const y = height - rate * height * 0.85 - height * 0.08;
+    return `${x} ${y}`;
+  });
+
+  return `M ${points[0]} ${points.slice(1).map((p) => `L ${p}`).join(" ")}`;
+}
+
+export function SystemHealthHorizon({ tasks, systemName, apiReachable, workers }: SystemHealthHorizonProps) {
+  const systemTasks = useMemo(
+    () => systemName ? tasks.filter((t) => t.spec.system === systemName) : tasks,
+    [tasks, systemName],
+  );
+
+  const totalTasks = systemTasks.length;
+  const succeeded = systemTasks.filter(
+    (t) => t.status?.phase?.toLowerCase() === "succeeded",
+  ).length;
+  const successRate = totalTasks > 0 ? Math.round((succeeded / totalTasks) * 100) : 100;
+
+  const workersOnline = workers.filter((w) => {
+    const p = (w.status?.phase ?? "").toLowerCase();
+    return p === "healthy" || p === "ready";
+  }).length;
+
+  const sparkWidth = 200;
+  const sparkHeight = 48;
+  const sparkPath = useMemo(
+    () => generateSparklinePoints(systemTasks, sparkWidth, sparkHeight),
+    [systemTasks],
+  );
+
+  const apiReachCount = apiReachable ? 1 : 0;
+
+  return (
+    <div className="health-horizon">
+      <div className="health-horizon__primary">
+        <div className="health-horizon__metric-block">
+          <span className="health-horizon__label">TASK SUCCESS RATE</span>
+          <span className="health-horizon__value">{successRate}%</span>
+          <span className={`health-horizon__status health-horizon__status--${successRate >= 95 ? "ok" : "warn"}`}>
+            <span className="health-horizon__status-dot" />
+            {successRate >= 95 ? "All systems operational" : "Degraded performance"}
+          </span>
+        </div>
+        <div className="health-horizon__sparkline">
+          <svg
+            width={sparkWidth}
+            height={sparkHeight}
+            viewBox={`0 0 ${sparkWidth} ${sparkHeight}`}
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <defs>
+              <linearGradient id="spark-fill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="rgba(212, 160, 74, 0.3)" />
+                <stop offset="100%" stopColor="rgba(212, 160, 74, 0)" />
+              </linearGradient>
+            </defs>
+            {sparkPath && (
+              <>
+                <path
+                  d={`${sparkPath} L ${sparkWidth} ${sparkHeight} L 0 ${sparkHeight} Z`}
+                  fill="url(#spark-fill)"
+                />
+                <path
+                  d={sparkPath}
+                  stroke="#D4A04A"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  style={{ filter: "drop-shadow(0 0 4px rgba(212, 160, 74, 0.5))" }}
+                />
+              </>
+            )}
+          </svg>
+          <span className="health-horizon__time-range">Last 24 hours</span>
+        </div>
+      </div>
+
+      <div className="health-horizon__secondary">
+        <div className="health-horizon__stat">
+          <Wifi size={16} className="health-horizon__stat-icon" />
+          <div className="health-horizon__stat-content">
+            <span className="health-horizon__stat-label">API REACHABILITY</span>
+            <span className="health-horizon__stat-value">{apiReachCount}/1</span>
+            <span className="health-horizon__stat-sub">API reachability</span>
+          </div>
+        </div>
+        <div className="health-horizon__stat">
+          <Cpu size={16} className="health-horizon__stat-icon" />
+          <div className="health-horizon__stat-content">
+            <span className="health-horizon__stat-label">WORKERS ONLINE</span>
+            <span className="health-horizon__stat-value">{workersOnline}/{workers.length}</span>
+            <span className="health-horizon__stat-sub">Workers online</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="health-horizon__indicator">
+        <Activity size={14} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskTraceTimeline.tsx
+++ b/frontend/src/components/TaskTraceTimeline.tsx
@@ -1,0 +1,133 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { ChevronRight } from "lucide-react";
+import type { Task } from "../api/types";
+
+interface TaskTraceTimelineProps {
+  tasks: Task[];
+  systemName: string;
+}
+
+interface TraceEvent {
+  timestamp: number;
+  description: string;
+  taskName: string;
+  color: "gold" | "green" | "red" | "blue" | "gray";
+}
+
+function formatRelative(ts: number): string {
+  const sec = Math.round((Date.now() - ts) / 1000);
+  if (sec < 5) return "just now";
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.floor(hr / 24)}d ago`;
+}
+
+function eventColor(phase?: string, type?: string): TraceEvent["color"] {
+  if (phase === "Succeeded" || type === "succeeded") return "green";
+  if (phase === "Failed" || type === "failed" || type === "error") return "red";
+  if (phase === "Running" || type === "assigned" || type === "started") return "gold";
+  if (type === "tool_call" || type === "tool") return "blue";
+  return "gray";
+}
+
+function describeMessage(msg: { from_agent?: string; to_agent?: string; phase?: string; type?: string }): string {
+  if (msg.to_agent && msg.phase === "Running") return `${msg.to_agent} started`;
+  if (msg.to_agent && msg.phase === "Succeeded") return `${msg.to_agent} completed`;
+  if (msg.to_agent && msg.phase === "Failed") return `${msg.to_agent} failed`;
+  if (msg.to_agent) return `${msg.to_agent} ${(msg.phase ?? "active").toLowerCase()}`;
+  if (msg.phase) return `task ${msg.phase.toLowerCase()}`;
+  return "event";
+}
+
+function describeHistory(evt: { type?: string; message?: string }): string {
+  if (evt.message) return evt.message.length > 40 ? evt.message.slice(0, 37) + "..." : evt.message;
+  if (evt.type) return evt.type.replace(/_/g, " ");
+  return "event";
+}
+
+export function TaskTraceTimeline({ tasks, systemName }: TaskTraceTimelineProps) {
+  const navigate = useNavigate();
+
+  const events = useMemo(() => {
+    const systemTasks = tasks.filter((t) => t.spec.system === systemName);
+    const all: TraceEvent[] = [];
+
+    for (const task of systemTasks) {
+      for (const msg of task.status?.messages ?? []) {
+        if (!msg.timestamp) continue;
+        const ts = new Date(msg.timestamp).getTime();
+        if (Number.isNaN(ts)) continue;
+        all.push({
+          timestamp: ts,
+          description: describeMessage(msg),
+          taskName: task.metadata.name,
+          color: eventColor(msg.phase, msg.type),
+        });
+      }
+
+      for (const evt of task.status?.history ?? []) {
+        if (!evt.timestamp) continue;
+        const ts = new Date(evt.timestamp).getTime();
+        if (Number.isNaN(ts)) continue;
+        all.push({
+          timestamp: ts,
+          description: describeHistory(evt),
+          taskName: task.metadata.name,
+          color: eventColor(undefined, evt.type),
+        });
+      }
+    }
+
+    all.sort((a, b) => b.timestamp - a.timestamp);
+    return all.slice(0, 5);
+  }, [tasks, systemName]);
+
+  if (events.length === 0) {
+    return (
+      <div className="trace-timeline">
+        <h3 className="trace-timeline__title">TASK TRACE TIMELINE</h3>
+        <div className="trace-timeline__empty">No trace events yet</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="trace-timeline">
+      <h3 className="trace-timeline__title">TASK TRACE TIMELINE</h3>
+      <div className="trace-timeline__feed">
+        {events.map((evt, i) => (
+          <div
+            key={`${evt.taskName}-${evt.timestamp}-${i}`}
+            className="trace-timeline__event"
+            style={{ animationDelay: `${i * 50}ms` }}
+            onClick={() => navigate(`/tasks/${encodeURIComponent(evt.taskName)}?tab=trace`)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                navigate(`/tasks/${encodeURIComponent(evt.taskName)}?tab=trace`);
+              }
+            }}
+          >
+            <span className={`trace-timeline__dot trace-timeline__dot--${evt.color}`} />
+            <span className="trace-timeline__time">{formatRelative(evt.timestamp)}</span>
+            <span className="trace-timeline__desc">{evt.description}</span>
+            <span className="trace-timeline__task mono">{evt.taskName}</span>
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        className="trace-timeline__footer"
+        onClick={() => navigate("/tasks")}
+      >
+        View all traces <ChevronRight size={12} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/AgentSystemDetail.tsx
+++ b/frontend/src/pages/AgentSystemDetail.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
-import { useParams, useNavigate, useSearchParams, Link } from "react-router-dom";
+import { useState, useMemo, useCallback } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useAgentSystem,
@@ -15,6 +15,7 @@ import {
   useWorkers,
   useDeleteResource,
   useUpdateResource,
+  useHealthCheck,
 } from "../api/hooks";
 import { useAppStore } from "../store";
 import { saveNamespacedResourceYaml } from "../hooks/saveDetailYamlWithFreshRv";
@@ -23,30 +24,34 @@ import { ResourceDetailLoadError } from "../components/ResourceDetailLoadError";
 import { GraphView } from "../components/GraphView";
 import { StatusBadge } from "../components/StatusBadge";
 import { YamlEditor } from "../components/YamlEditor";
-import { ResourceTable, type Column } from "../components/ResourceTable";
-import { ArrowLeft } from "lucide-react";
-import clsx from "clsx";
-import type { AgentSystem, Task } from "../api/types";
+import { SystemHealthHorizon } from "../components/SystemHealthHorizon";
+import { SystemDefinitions } from "../components/SystemDefinitions";
+import { TaskTraceTimeline } from "../components/TaskTraceTimeline";
+import { ArrowLeft, ChevronRight, Code, Info } from "lucide-react";
+import type { AgentSystem } from "../api/types";
 import { RESOURCE_DETAIL_BASE_PATH } from "../api/types";
 import { CrdManagedBadge } from "../components/CrdManagedBadge";
 import { isCrdManaged, CRD_MANAGED_EDIT_WARNING } from "../utils/crd";
 import { useDeleteConfirm } from "../hooks/useDeleteConfirm";
 
-type Tab = "graph" | "tasks" | "yaml" | "status";
-
-const TAB_PARAM = "tab";
-const VALID_TABS: readonly Tab[] = ["graph", "tasks", "yaml", "status"];
-
-function parseTab(raw: string | null): Tab | null {
-  if (!raw) return null;
-  return VALID_TABS.includes(raw as Tab) ? (raw as Tab) : null;
+function formatShortTime(iso?: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
+
+type Overlay = "yaml" | "status" | null;
 
 export function AgentSystemDetail() {
   const { name: nameParam } = useParams<{ name: string }>();
   const navigate = useNavigate();
   const routeName = nameParam ?? "";
-  const [searchParams, setSearchParams] = useSearchParams();
   const { data: system, isLoading, isError, error } = useAgentSystem(routeName);
   const queryClient = useQueryClient();
   const namespace = useAppStore((s) => s.namespace);
@@ -60,39 +65,11 @@ export function AgentSystemDetail() {
   const taskSchedules = useTaskSchedules();
   const taskWebhooks = useTaskWebhooks();
   const workers = useWorkers();
+  const health = useHealthCheck();
   const deleteMutation = useDeleteResource("AgentSystem");
   const updateMutation = useUpdateResource("AgentSystem");
   const confirmDelete = useDeleteConfirm();
-  const [tab, setTab] = useState<Tab>(() => parseTab(searchParams.get(TAB_PARAM)) ?? "graph");
-
-  useEffect(() => {
-    setTab(parseTab(searchParams.get(TAB_PARAM)) ?? "graph");
-  }, [routeName, searchParams]);
-
-  const setTabInUrl = useCallback(
-    (t: Tab) => {
-      setTab(t);
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          if (t === "graph") next.delete(TAB_PARAM);
-          else next.set(TAB_PARAM, t);
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
-
-  const returnToWithTab = useCallback(
-    (t: Tab) => {
-      const base = `/systems/${encodeURIComponent(routeName)}`;
-      if (t === "graph") return base;
-      return `${base}?${TAB_PARAM}=${t}`;
-    },
-    [routeName],
-  );
+  const [overlay, setOverlay] = useState<Overlay>(null);
 
   const related = useMemo(() => ({
     agents: agents.data,
@@ -147,6 +124,48 @@ export function AgentSystemDetail() {
     }
   };
 
+  const handleNodeClick = useCallback(
+    (kind: string, nodeName: string) => {
+      const fromGraph = { state: { returnTo: `/systems/${encodeURIComponent(routeName)}` } };
+      switch (kind) {
+        case "agent":
+          navigate(`/agents/${encodeURIComponent(nodeName)}`, fromGraph);
+          break;
+        case "task":
+          navigate(`/tasks/${encodeURIComponent(nodeName)}`, fromGraph);
+          break;
+        case "schedule":
+          navigate(`/task-schedules/${encodeURIComponent(nodeName)}`, fromGraph);
+          break;
+        case "webhook":
+          navigate(`/task-webhooks/${encodeURIComponent(nodeName)}`, fromGraph);
+          break;
+        case "model":
+          navigate("/models", fromGraph);
+          break;
+        case "tool":
+          navigate("/tools", fromGraph);
+          break;
+        case "secret":
+          navigate("/secrets", fromGraph);
+          break;
+        case "memory":
+          navigate("/memories", fromGraph);
+          break;
+        case "role":
+          navigate("/roles", fromGraph);
+          break;
+        case "worker":
+          navigate("/workers", fromGraph);
+          break;
+        case "adapter":
+          navigate(`/context-adapters/${encodeURIComponent(nodeName)}`, fromGraph);
+          break;
+      }
+    },
+    [navigate, routeName],
+  );
+
   if (isError) {
     return (
       <ResourceDetailLoadError
@@ -165,65 +184,99 @@ export function AgentSystemDetail() {
     );
   }
 
-  const taskColumns: Column<Task>[] = [
-    { key: "name", header: "Name", render: (r) => <span className="mono">{r.metadata.name}</span> },
-    { key: "phase", header: "Phase", render: (r) => <StatusBadge phase={r.status?.phase} />, width: "120px" },
-    { key: "worker", header: "Worker", render: (r) => <span className="text-muted">{r.status?.assignedWorker ?? "—"}</span> },
-    { key: "attempts", header: "Attempts", render: (r) => r.status?.attempts ?? 0, width: "90px" },
-  ];
-
-  const handleNodeClick = (kind: string, nodeName: string) => {
-    const fromGraph = { state: { returnTo: returnToWithTab("graph") } };
-    switch (kind) {
-      case "agent":
-        navigate(`/agents/${encodeURIComponent(nodeName)}`, fromGraph);
-        break;
-      case "task":
-        navigate(`/tasks/${encodeURIComponent(nodeName)}`, fromGraph);
-        break;
-      case "schedule":
-        navigate(`/task-schedules/${encodeURIComponent(nodeName)}`, fromGraph);
-        break;
-      case "webhook":
-        navigate(`/task-webhooks/${encodeURIComponent(nodeName)}`, fromGraph);
-        break;
-      case "model":
-        navigate("/models", fromGraph);
-        break;
-      case "tool":
-        navigate("/tools", fromGraph);
-        break;
-      case "secret":
-        navigate("/secrets", fromGraph);
-        break;
-      case "memory":
-        navigate("/memories", fromGraph);
-        break;
-      case "role":
-        navigate("/roles", fromGraph);
-        break;
-      case "worker":
-        navigate("/workers", fromGraph);
-        break;
-      case "adapter":
-        navigate(`/context-adapters/${encodeURIComponent(nodeName)}`, fromGraph);
-        break;
-    }
-  };
-
   const yamlContent = JSON.stringify(system, null, 2);
-
   const contextAdapterRef = system.spec.context_adapter?.trim();
+  const apiReachable = health.data === true;
 
-  const tabs: { id: Tab; label: string }[] = [
-    { id: "graph", label: "Resource Tree" },
-    { id: "tasks", label: `Tasks (${systemTasks.length})` },
-    { id: "yaml", label: "YAML" },
-    { id: "status", label: "Status" },
-  ];
+  if (overlay === "yaml") {
+    return (
+      <div className="page">
+        <div className="page__header">
+          <div className="page__header-back">
+            <button className="btn-ghost" onClick={() => setOverlay(null)} aria-label="Back">
+              <ArrowLeft size={16} />
+            </button>
+            <div>
+              <h1 className="page__title">{system.metadata.name} — YAML</h1>
+            </div>
+          </div>
+        </div>
+        <YamlEditor
+          value={yamlContent}
+          editable
+          warning={isCrdManaged(system.metadata) ? CRD_MANAGED_EDIT_WARNING : undefined}
+          onSave={async (body) => {
+            const updated = await saveNamespacedResourceYaml<AgentSystem>(
+              queryClient,
+              "AgentSystem",
+              namespace,
+              routeName,
+              body,
+              (a) => updateMutation.mutateAsync(a) as Promise<AgentSystem>,
+            );
+            toast("success", "Agent system updated");
+            if (updated.metadata.name !== routeName) {
+              navigate(
+                `${RESOURCE_DETAIL_BASE_PATH.AgentSystem}/${encodeURIComponent(updated.metadata.name)}`,
+                { replace: true },
+              );
+            }
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (overlay === "status") {
+    return (
+      <div className="page">
+        <div className="page__header">
+          <div className="page__header-back">
+            <button className="btn-ghost" onClick={() => setOverlay(null)} aria-label="Back">
+              <ArrowLeft size={16} />
+            </button>
+            <div>
+              <h1 className="page__title">{system.metadata.name} — Status</h1>
+            </div>
+          </div>
+        </div>
+        <div className="detail-grid">
+          <div className="detail-field">
+            <span className="detail-field__label">Phase</span>
+            <StatusBadge phase={system.status?.phase} size="md" />
+          </div>
+          <div className="detail-field">
+            <span className="detail-field__label">Agents</span>
+            <span className="detail-field__value">{(system.spec.agents ?? []).join(", ")}</span>
+          </div>
+          {contextAdapterRef && (
+            <div className="detail-field">
+              <span className="detail-field__label">Context adapter</span>
+              <Link
+                className="detail-field__value mono"
+                to={`/context-adapters/${encodeURIComponent(contextAdapterRef)}`}
+              >
+                {contextAdapterRef}
+              </Link>
+            </div>
+          )}
+          {system.status?.lastError && (
+            <div className="detail-field">
+              <span className="detail-field__label">Last Error</span>
+              <span className="detail-field__value text-red">{system.status.lastError}</span>
+            </div>
+          )}
+          <div className="detail-field">
+            <span className="detail-field__label">Resource Version</span>
+            <span className="detail-field__value mono">{system.metadata.resourceVersion ?? "—"}</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="page">
+    <div className="page page--system-detail">
       <div className="page__header">
         <div className="page__header-back">
           <button className="btn-ghost" onClick={() => navigate("/systems")} aria-label="Back">
@@ -238,101 +291,109 @@ export function AgentSystemDetail() {
           <StatusBadge phase={system.status?.phase} size="md" />
           <CrdManagedBadge metadata={system.metadata} />
         </div>
-        <button
-          className="btn-secondary text-red"
-          onClick={handleDelete}
-          disabled={deleteMutation.isPending}
-        >
-          {deleteMutation.isPending ? "Deleting..." : "Delete System"}
-        </button>
-      </div>
-
-      <div className="tab-bar">
-        {tabs.map((t) => (
+        <div className="page__header-actions">
           <button
-            key={t.id}
-            className={clsx("tab-bar__tab", tab === t.id && "tab-bar__tab--active")}
-            onClick={() => setTabInUrl(t.id)}
+            className="btn-ghost"
+            onClick={() => setOverlay("status")}
+            title="Status details"
           >
-            {t.label}
+            <Info size={16} />
           </button>
-        ))}
+          <button
+            className="btn-ghost"
+            onClick={() => setOverlay("yaml")}
+            title="Edit YAML"
+          >
+            <Code size={16} />
+          </button>
+          <button
+            className="btn-secondary text-red"
+            onClick={handleDelete}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? "Deleting..." : "Delete"}
+          </button>
+        </div>
       </div>
 
-      <div className="tab-content">
-        {tab === "graph" && (
-          <GraphView system={system} related={related} onNodeClick={handleNodeClick} animated runningAgents={runningAgents} />
-        )}
-        {tab === "tasks" && (
-          <ResourceTable
-            columns={taskColumns}
-            data={systemTasks}
-            rowKey={(r) => r.metadata.name}
-            onRowClick={(r) =>
-              navigate(`/tasks/${encodeURIComponent(r.metadata.name)}`, {
-                state: { returnTo: returnToWithTab("tasks") },
-              })
-            }
-            emptyMessage="No tasks for this system"
-          />
-        )}
-        {tab === "yaml" && (
-          <YamlEditor
-            value={yamlContent}
-            editable
-            warning={isCrdManaged(system.metadata) ? CRD_MANAGED_EDIT_WARNING : undefined}
-            onSave={async (body) => {
-              const updated = await saveNamespacedResourceYaml<AgentSystem>(
-                queryClient,
-                "AgentSystem",
-                namespace,
-                routeName,
-                body,
-                (a) => updateMutation.mutateAsync(a) as Promise<AgentSystem>,
-              );
-              toast("success", "Agent system updated");
-              if (updated.metadata.name !== routeName) {
-                navigate(
-                  `${RESOURCE_DETAIL_BASE_PATH.AgentSystem}/${encodeURIComponent(updated.metadata.name)}`,
-                  { replace: true },
-                );
-              }
-            }}
-          />
-        )}
-        {tab === "status" && (
-          <div className="detail-grid">
-            <div className="detail-field">
-              <span className="detail-field__label">Phase</span>
-              <StatusBadge phase={system.status?.phase} size="md" />
-            </div>
-            <div className="detail-field">
-              <span className="detail-field__label">Agents</span>
-              <span className="detail-field__value">{(system.spec.agents ?? []).join(", ")}</span>
-            </div>
-            {contextAdapterRef && (
-              <div className="detail-field">
-                <span className="detail-field__label">Context adapter</span>
-                <Link
-                  className="detail-field__value mono"
-                  to={`/context-adapters/${encodeURIComponent(contextAdapterRef)}`}
-                >
-                  {contextAdapterRef}
-                </Link>
-              </div>
-            )}
-            {system.status?.lastError && (
-              <div className="detail-field">
-                <span className="detail-field__label">Last Error</span>
-                <span className="detail-field__value text-red">{system.status.lastError}</span>
-              </div>
-            )}
-            <div className="detail-field">
-              <span className="detail-field__label">Resource Version</span>
-              <span className="detail-field__value mono">{system.metadata.resourceVersion ?? "—"}</span>
-            </div>
+      {/* System Health Horizon Banner */}
+      <SystemHealthHorizon
+        tasks={tasks.data ?? []}
+        systemName={sysName!}
+        apiReachable={apiReachable}
+        workers={workers.data ?? []}
+      />
+
+      {/* Modern Topology View */}
+      <section className="system-detail__topology">
+        <div className="system-detail__topology-header">
+          <h2 className="system-detail__section-title">MODERN TOPOLOGY VIEW</h2>
+        </div>
+        <GraphView
+          system={system}
+          related={related}
+          onNodeClick={handleNodeClick}
+          animated
+          runningAgents={runningAgents}
+        />
+      </section>
+
+      {/* Bento Grid: Definitions | Recent Tasks | Trace Timeline */}
+      <div className="system-detail__bento">
+        <SystemDefinitions
+          agents={agents.data ?? []}
+          modelEndpoints={modelEndpoints.data ?? []}
+          tools={tools.data ?? []}
+          workers={workers.data ?? []}
+          systemAgentNames={system.spec.agents ?? []}
+          apiReachable={apiReachable}
+        />
+
+        <div className="system-detail__recent-tasks">
+          <div className="system-detail__card-header">
+            <h3 className="system-detail__card-title">RECENT TASKS</h3>
           </div>
-        )}
+          <div className="system-detail__tasks-list">
+            <div className="system-detail__tasks-row system-detail__tasks-row--header">
+              <span>STATUS</span>
+              <span>UPDATED</span>
+              <span>ACTION</span>
+            </div>
+            {systemTasks.length === 0 && (
+              <p className="text-muted system-detail__tasks-empty">No tasks yet</p>
+            )}
+            {systemTasks.slice(0, 5).map((task) => (
+              <div
+                key={task.metadata.name}
+                className="system-detail__tasks-row"
+                onClick={() => navigate(`/tasks/${task.metadata.name}`)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    navigate(`/tasks/${task.metadata.name}`);
+                  }
+                }}
+              >
+                <span><StatusBadge phase={task.status?.phase} /></span>
+                <span className="text-muted">
+                  {formatShortTime(task.status?.completedAt ?? task.status?.startedAt)}
+                </span>
+                <span className="system-detail__tasks-action">
+                  Quick action <ChevronRight size={12} />
+                </span>
+              </div>
+            ))}
+            {systemTasks.length > 0 && (
+              <div className="system-detail__tasks-footer">
+                <span className="text-muted mono">{systemTasks[systemTasks.length - 1]?.metadata.name}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <TaskTraceTimeline tasks={tasks.data ?? []} systemName={sysName!} />
       </div>
     </div>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { MetricCard } from "../components/MetricCard";
 import {
   useAgentSystems,
   useAgents,
@@ -9,35 +8,30 @@ import {
   useWorkers,
   useModelEndpoints,
   useTools,
-  useToolApprovals,
-  useTaskApprovals,
   useHealthCheck,
+  useSecrets,
+  useMemories,
+  useMcpServers,
+  useCapabilities,
 } from "../api/hooks";
 import {
   Network,
   Bot,
-  ListTodo,
   CalendarClock,
   Cpu,
   Database,
   Wrench,
-  AlertTriangle,
-  CheckCircle,
-  Clock,
-  XCircle,
   Webhook,
-  ShieldCheck,
-  Activity,
-  PauseCircle,
   ChevronRight,
+  Play,
+  Lock,
+  BrainCircuit,
+  Server,
+  Zap,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { StatusBadge } from "../components/StatusBadge";
-import type { Task } from "../api/types";
-
-function countByPhase(tasks: Task[], phase: string): number {
-  return tasks.filter((t) => (t.status?.phase ?? "").toLowerCase() === phase.toLowerCase()).length;
-}
+import { SystemHealthHorizon } from "../components/SystemHealthHorizon";
 
 function formatShortTime(iso?: string): string {
   if (!iso) return "—";
@@ -51,23 +45,12 @@ function formatShortTime(iso?: string): string {
   });
 }
 
-function formatRelativeUpdated(ts: number): string {
-  if (!ts) return "";
-  const sec = Math.round((Date.now() - ts) / 1000);
-  if (sec < 10) return "Updated just now";
-  if (sec < 60) return `Updated ${sec}s ago`;
-  const min = Math.floor(sec / 60);
-  if (min < 60) return `Updated ${min}m ago`;
-  const hr = Math.floor(min / 60);
-  return `Updated ${hr}h ago`;
-}
-
 function DashboardSkeleton() {
   return (
     <div className="dashboard-skeleton" aria-hidden>
       <div className="dashboard-skeleton__hero" />
       <div className="dashboard-skeleton__grid">
-        {Array.from({ length: 9 }).map((_, i) => (
+        {Array.from({ length: 6 }).map((_, i) => (
           <div key={i} className="dashboard-skeleton__metric" />
         ))}
       </div>
@@ -84,73 +67,42 @@ export function Dashboard() {
   const workers = useWorkers();
   const models = useModelEndpoints();
   const tools = useTools();
-  const approvals = useToolApprovals();
-  const taskApprovals = useTaskApprovals();
+  const secrets = useSecrets();
+  const memories = useMemories();
+  const mcpServers = useMcpServers();
+  const capabilities = useCapabilities();
   const health = useHealthCheck();
   const navigate = useNavigate();
 
   const taskList = tasks.data ?? [];
-  const running = countByPhase(taskList, "Running");
-  const succeeded = countByPhase(taskList, "Succeeded");
-  const failed = countByPhase(taskList, "Failed");
-  const deadletter = countByPhase(taskList, "DeadLetter");
-  const pending = countByPhase(taskList, "Pending");
-
-  const totalTasks = taskList.length;
-  const healthyPct = totalTasks > 0 ? Math.round((succeeded / totalTasks) * 100) : 0;
-  const successColor = healthyPct >= 95 ? "green" : healthyPct >= 80 ? "yellow" : "red";
-
   const workerList = workers.data ?? [];
-  const workersOnline = workerList.filter((w) => {
-    const p = (w.status?.phase ?? "").toLowerCase();
-    return p === "healthy" || p === "ready";
-  }).length;
-
   const modelList = models.data ?? [];
-  const modelsReady = modelList.filter((m) => (m.status?.phase ?? "").toLowerCase() === "ready").length;
-
-  const pendingApprovals = useMemo(
-    () => {
-      const toolPending = (approvals.data ?? []).filter((a) => (a.status?.phase ?? "Pending").toLowerCase() === "pending").length;
-      const taskPending = (taskApprovals.data ?? []).filter((a) => (a.status?.phase ?? "Pending").toLowerCase() === "pending").length;
-      return toolPending + taskPending;
-    },
-    [approvals.data, taskApprovals.data],
-  );
-
-  const taskIssues = failed + deadletter;
   const apiOk = health.data === true;
-  const workersOk = workerList.length === 0 || workersOnline === workerList.length;
-  const modelsOk = modelList.length === 0 || modelsReady === modelList.length;
-  const platformTone =
-    !apiOk ? "bad" : taskIssues > 0 || pendingApprovals > 0 || !workersOk || !modelsOk ? "warn" : "ok";
 
-  const lastUpdated = useMemo(() => {
-    const stamps = [
-      systems.dataUpdatedAt,
-      tasks.dataUpdatedAt,
-      workers.dataUpdatedAt,
-      models.dataUpdatedAt,
-      health.dataUpdatedAt,
-    ].filter(Boolean) as number[];
-    return stamps.length ? Math.max(...stamps) : 0;
-  }, [
-    systems.dataUpdatedAt,
-    tasks.dataUpdatedAt,
-    workers.dataUpdatedAt,
-    models.dataUpdatedAt,
-    health.dataUpdatedAt,
-  ]);
+  const activeTasks = useMemo(() => {
+    return [...taskList].sort((a, b) => {
+      const phaseOrder = (p?: string) => {
+        const lp = (p ?? "").toLowerCase();
+        if (lp === "running") return 0;
+        if (lp === "pending") return 1;
+        return 2;
+      };
+      const diff = phaseOrder(a.status?.phase) - phaseOrder(b.status?.phase);
+      if (diff !== 0) return diff;
+      const aT = a.status?.startedAt ?? a.metadata.createdAt ?? "";
+      const bT = b.status?.startedAt ?? b.metadata.createdAt ?? "";
+      return bT.localeCompare(aT);
+    });
+  }, [taskList]);
 
-  const showSkeleton = tasks.isPending || systems.isPending || workers.isPending;
+  const capCount = capabilities.data?.capabilities?.length ?? 0;
+
+  const showSkeleton =
+    tasks.isPending || systems.isPending || workers.isPending;
 
   if (showSkeleton) {
     return (
       <div className="page page--dashboard">
-        <div className="page__header">
-          <h1 className="page__title">Dashboard</h1>
-          <p className="page__subtitle">Orloj control plane overview</p>
-        </div>
         <DashboardSkeleton />
       </div>
     );
@@ -158,245 +110,34 @@ export function Dashboard() {
 
   return (
     <div className="page page--dashboard">
-      <div className="page__header">
-        <div>
-          <h1 className="page__title">Dashboard</h1>
-          <p className="page__subtitle">Orloj control plane overview</p>
-          {lastUpdated > 0 && (
-            <p className="dashboard-meta text-muted">{formatRelativeUpdated(lastUpdated)} · auto-refreshed</p>
-          )}
-        </div>
-      </div>
-
-      <section
-        className={`platform-status platform-status--${platformTone}`}
-        aria-label="Platform status"
-      >
-        <div className="platform-status__main">
-          <div className="platform-status__badge">
-            <Activity size={18} className="platform-status__badge-icon" />
-            <span className="platform-status__badge-label">
-              {platformTone === "ok" && "All systems operational"}
-              {platformTone === "warn" && "Attention needed"}
-              {platformTone === "bad" && "API unavailable"}
-            </span>
-          </div>
-          <ul className="platform-status__list">
-            <li>
-              <span className={apiOk ? "text-green" : "text-red"}>{apiOk ? "API reachable" : "API unreachable"}</span>
-            </li>
-            <li>
-              <span className={workersOk ? "text-muted" : "text-orange"}>
-                {workerList.length === 0
-                  ? "Workers: none registered"
-                  : `Workers ${workersOnline}/${workerList.length} online`}
-              </span>
-            </li>
-            <li>
-              <span className={modelsOk ? "text-muted" : "text-orange"}>
-                {modelList.length === 0
-                  ? "Models: none configured"
-                  : `Models ${modelsReady}/${modelList.length} ready`}
-              </span>
-            </li>
-          </ul>
-        </div>
-        <div className="platform-status__actions">
-          {taskIssues > 0 && (
-            <button
-              type="button"
-              className="platform-status__chip platform-status__chip--danger"
-              onClick={() => navigate("/tasks")}
-            >
-              <XCircle size={14} />
-              {taskIssues} task{taskIssues === 1 ? "" : "s"} need review
-              <ChevronRight size={14} />
-            </button>
-          )}
-          {pendingApprovals > 0 && (
-            <button
-              type="button"
-              className="platform-status__chip platform-status__chip--warning"
-              onClick={() => navigate("/approvals")}
-            >
-              <ShieldCheck size={14} />
-              {pendingApprovals} approval{pendingApprovals === 1 ? "" : "s"} pending
-              <ChevronRight size={14} />
-            </button>
-          )}
-          <button type="button" className="platform-status__chip platform-status__chip--ghost" onClick={() => navigate("/workers")}>
-            Workers
-            <ChevronRight size={14} />
-          </button>
-          <button type="button" className="platform-status__chip platform-status__chip--ghost" onClick={() => navigate("/models")}>
-            Model endpoints
-            <ChevronRight size={14} />
-          </button>
-        </div>
+      {/* System Health Rollup — reuses the same component as the system detail page */}
+      <section aria-label="System Health Rollup">
+        <h2 className="dash-section-heading">System Health Rollup</h2>
+        <SystemHealthHorizon
+          tasks={taskList}
+          apiReachable={apiOk}
+          workers={workerList}
+        />
       </section>
 
-      <div className="dashboard-metrics">
-        <section className="dashboard-section" aria-labelledby="dash-runtime">
-          <h2 id="dash-runtime" className="dashboard-section__title">
-            Runtime
-          </h2>
-          <p className="dashboard-section__hint">Live workload and execution surface</p>
-          <div className="metrics-grid metrics-grid--dashboard">
-            <MetricCard
-              label="Tasks"
-              value={totalTasks}
-              subtitle={`${running} running · ${pending} pending`}
-              icon={<ListTodo size={16} />}
-              variant={taskIssues > 0 ? "red" : "default"}
-            />
-            <MetricCard
-              label="Workers"
-              value={workerList.length}
-              subtitle={`${workersOnline} online`}
-              icon={<Cpu size={16} />}
-              variant={!workersOk && workerList.length > 0 ? "orange" : "default"}
-            />
-            <MetricCard
-              label="Pending approvals"
-              value={pendingApprovals}
-              subtitle={pendingApprovals > 0 ? "Requires review" : "Queue clear"}
-              icon={<ShieldCheck size={16} />}
-              variant={pendingApprovals > 0 ? "orange" : "default"}
-            />
-          </div>
-        </section>
-
-        <section className="dashboard-section" aria-labelledby="dash-definitions">
-          <h2 id="dash-definitions" className="dashboard-section__title">
-            Definitions
-          </h2>
-          <p className="dashboard-section__hint">Agents, systems, models, and tools in this namespace</p>
-          <div className="metrics-grid metrics-grid--dashboard">
-            <MetricCard
-              label="Agent systems"
-              value={systems.data?.length ?? 0}
-              icon={<Network size={16} />}
-              variant="default"
-            />
-            <MetricCard label="Agents" value={agents.data?.length ?? 0} icon={<Bot size={16} />} variant="default" />
-            <MetricCard
-              label="Model endpoints"
-              value={modelList.length}
-              subtitle={`${modelsReady} ready`}
-              icon={<Database size={16} />}
-              variant={!modelsOk && modelList.length > 0 ? "orange" : "default"}
-            />
-            <MetricCard label="Tools" value={tools.data?.length ?? 0} icon={<Wrench size={16} />} variant="default" />
-          </div>
-        </section>
-
-        <section className="dashboard-section" aria-labelledby="dash-automation">
-          <h2 id="dash-automation" className="dashboard-section__title">
-            Automation
-          </h2>
-          <p className="dashboard-section__hint">Schedules and webhooks</p>
-          <div className="metrics-grid metrics-grid--dashboard">
-            <MetricCard
-              label="Task schedules"
-              value={taskSchedules.data?.length ?? 0}
-              icon={<CalendarClock size={16} />}
-              variant="default"
-            />
-            <MetricCard
-              label="Task webhooks"
-              value={taskWebhooks.data?.length ?? 0}
-              icon={<Webhook size={16} />}
-              variant="default"
-            />
-          </div>
-        </section>
-      </div>
-
-      <div className="dashboard-row">
-        <div className="card card--dashboard">
-          <h2 className="card__title card__title--sentence">Task health</h2>
-          <div className="task-health">
-            <div className="task-health__bar">
-              {succeeded > 0 && (
-                <div
-                  className="task-health__segment task-health__segment--green"
-                  style={{ width: `${(succeeded / Math.max(totalTasks, 1)) * 100}%` }}
-                  title={`Succeeded: ${succeeded}`}
-                />
-              )}
-              {running > 0 && (
-                <div
-                  className="task-health__segment task-health__segment--blue"
-                  style={{ width: `${(running / Math.max(totalTasks, 1)) * 100}%` }}
-                  title={`Running: ${running}`}
-                />
-              )}
-              {pending > 0 && (
-                <div
-                  className="task-health__segment task-health__segment--yellow"
-                  style={{ width: `${(pending / Math.max(totalTasks, 1)) * 100}%` }}
-                  title={`Pending: ${pending}`}
-                />
-              )}
-              {failed > 0 && (
-                <div
-                  className="task-health__segment task-health__segment--red"
-                  style={{ width: `${(failed / Math.max(totalTasks, 1)) * 100}%` }}
-                  title={`Failed: ${failed}`}
-                />
-              )}
-              {deadletter > 0 && (
-                <div
-                  className="task-health__segment task-health__segment--orange"
-                  style={{ width: `${(deadletter / Math.max(totalTasks, 1)) * 100}%` }}
-                  title={`DeadLetter: ${deadletter}`}
-                />
-              )}
+      {/* Main content: Active Tasks + Bento Sidebar */}
+      <div className="dash-body">
+        <section className="dash-tasks" aria-label="Active Tasks">
+          <h2 className="dash-section-heading">Active Tasks</h2>
+          <div className="dash-tasks__table">
+            <div className="dash-tasks__header">
+              <span>TASK</span>
+              <span>SYSTEM</span>
+              <span>UPDATED</span>
+              <span>PHASE</span>
             </div>
-            <div className="task-health__legend">
-              <span className="task-health__legend-item">
-                <CheckCircle size={12} className="text-green" /> Succeeded: {succeeded}
-              </span>
-              <span className="task-health__legend-item">
-                <Clock size={12} className="text-blue" /> Running: {running}
-              </span>
-              <span className="task-health__legend-item">
-                <PauseCircle size={12} className="text-yellow" /> Pending: {pending}
-              </span>
-              <span className="task-health__legend-item">
-                <XCircle size={12} className="text-red" /> Failed: {failed}
-              </span>
-              <span className="task-health__legend-item">
-                <AlertTriangle size={12} className="text-orange" /> Dead letter: {deadletter}
-              </span>
-            </div>
-            <p className={`task-health__pct text-${successColor}`}>
-              {healthyPct}% success rate
-              <span className="task-health__pct-meta text-muted"> · {totalTasks} total tasks</span>
-            </p>
-          </div>
-        </div>
-
-        <div className="card card--dashboard">
-          <div className="card__header-row">
-            <h2 className="card__title card__title--sentence">Recent tasks</h2>
-            <button type="button" className="card__link-all" onClick={() => navigate("/tasks")}>
-              View all
-              <ChevronRight size={14} />
-            </button>
-          </div>
-          <div className="recent-list recent-list--grid recent-list--tasks">
-            <div className="recent-list__header">
-              <span>Task</span>
-              <span>System</span>
-              <span>Updated</span>
-              <span className="recent-list__header-phase">Phase</span>
-            </div>
-            {taskList.length === 0 && <p className="text-muted recent-list__empty">No tasks yet</p>}
-            {taskList.slice(0, 8).map((task) => (
+            {activeTasks.length === 0 && (
+              <p className="dash-tasks__empty text-muted">No tasks yet</p>
+            )}
+            {activeTasks.slice(0, 15).map((task) => (
               <div
                 key={task.metadata.name}
-                className="recent-list__item"
+                className="dash-tasks__row"
                 onClick={() => navigate(`/tasks/${task.metadata.name}`)}
                 role="button"
                 tabIndex={0}
@@ -407,104 +148,210 @@ export function Dashboard() {
                   }
                 }}
               >
-                <span className="recent-list__name mono">{task.metadata.name}</span>
-                <span className="recent-list__system text-muted">{task.spec.system ?? "—"}</span>
-                <span className="recent-list__time text-muted">
-                  {formatShortTime(task.status?.completedAt ?? task.status?.startedAt)}
+                <span className="dash-tasks__name">
+                  <Play size={12} className="dash-tasks__play-icon" />
+                  <span className="mono">{task.metadata.name}</span>
                 </span>
-                <span className="recent-list__badge">
+                <span className="dash-tasks__system text-muted">
+                  <Network size={12} className="dash-tasks__system-icon" />
+                  {task.spec.system ?? "—"}
+                </span>
+                <span className="dash-tasks__time text-muted">
+                  {formatShortTime(
+                    task.status?.completedAt ??
+                      task.status?.startedAt ??
+                      task.metadata.createdAt,
+                  )}
+                </span>
+                <span className="dash-tasks__phase">
                   <StatusBadge phase={task.status?.phase} />
+                  <ChevronRight size={14} className="dash-tasks__chevron" />
                 </span>
               </div>
             ))}
-          </div>
-        </div>
-      </div>
-
-      <div className="dashboard-row">
-        <div className="card card--dashboard">
-          <div className="card__header-row">
-            <h2 className="card__title card__title--sentence">Agent systems</h2>
-            <button type="button" className="card__link-all" onClick={() => navigate("/systems")}>
-              View all
-              <ChevronRight size={14} />
-            </button>
-          </div>
-          <div className="recent-list recent-list--grid recent-list--systems">
-            <div className="recent-list__header">
-              <span>System</span>
-              <span>Agents</span>
-              <span className="recent-list__header-phase">Status</span>
-            </div>
-            {(systems.data ?? []).length === 0 && (
-              <p className="text-muted recent-list__empty">No systems defined</p>
+            {activeTasks.length > 15 && (
+              <div className="dash-tasks__footer">
+                <button
+                  type="button"
+                  className="dash-tasks__view-all"
+                  onClick={() => navigate("/tasks")}
+                >
+                  View all {activeTasks.length} tasks <ChevronRight size={14} />
+                </button>
+              </div>
             )}
-            {(systems.data ?? []).slice(0, 6).map((sys) => (
+          </div>
+        </section>
+
+        <aside className="dash-sidebar" aria-label="Bento Sidebar">
+          <div className="dash-sidebar__group">
+            <h3 className="dash-sidebar__group-title">System Definitions</h3>
+            <div className="dash-sidebar__items">
               <div
-                key={sys.metadata.name}
-                className="recent-list__item"
-                onClick={() => navigate(`/systems/${sys.metadata.name}`)}
+                className="dash-sidebar__item"
+                onClick={() => navigate("/systems")}
                 role="button"
                 tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    navigate(`/systems/${sys.metadata.name}`);
-                  }
-                }}
               >
-                <span className="recent-list__name mono">{sys.metadata.name}</span>
-                <span className="text-muted">{sys.spec.agents?.length ?? 0}</span>
-                <span className="recent-list__badge">
-                  <StatusBadge phase={sys.status?.phase} />
+                <Network size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">Agent Systems</span>
+                <span className="dash-sidebar__item-count">
+                  {systems.data?.length ?? 0}
                 </span>
               </div>
-            ))}
-          </div>
-        </div>
-
-        <div className="card card--dashboard">
-          <div className="card__header-row">
-            <h2 className="card__title card__title--sentence">Workers</h2>
-            <button type="button" className="card__link-all" onClick={() => navigate("/workers")}>
-              View all
-              <ChevronRight size={14} />
-            </button>
-          </div>
-          <div className="recent-list recent-list--grid recent-list--workers">
-            <div className="recent-list__header">
-              <span>Worker</span>
-              <span>Load</span>
-              <span className="recent-list__header-phase">Status</span>
-            </div>
-            {(workers.data ?? []).length === 0 && (
-              <p className="text-muted recent-list__empty">No workers registered</p>
-            )}
-            {(workers.data ?? []).slice(0, 6).map((w) => (
               <div
-                key={`${w.metadata.namespace ?? "default"}/${w.metadata.name}`}
-                className="recent-list__item"
-                onClick={() => navigate(`/workers/${w.metadata.name}`)}
+                className="dash-sidebar__item"
+                onClick={() => navigate("/agents")}
                 role="button"
                 tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    navigate(`/workers/${w.metadata.name}`);
-                  }
-                }}
               >
-                <span className="recent-list__name mono">{w.metadata.name}</span>
-                <span className="text-muted">
-                  {w.status?.currentTasks ?? 0}/{w.spec.max_concurrent_tasks ?? 1}
-                </span>
-                <span className="recent-list__badge">
-                  <StatusBadge phase={w.status?.phase} />
+                <Bot size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">Agents</span>
+                <span className="dash-sidebar__item-count">
+                  {agents.data?.length ?? 0}
                 </span>
               </div>
-            ))}
+              <div
+                className="dash-sidebar__item"
+                onClick={() => navigate("/task-schedules")}
+                role="button"
+                tabIndex={0}
+              >
+                <CalendarClock size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">Schedules</span>
+                <span className="dash-sidebar__item-count">
+                  {taskSchedules.data?.length ?? 0}
+                </span>
+              </div>
+            </div>
           </div>
-        </div>
+
+          <div className="dash-sidebar__group">
+            <h3 className="dash-sidebar__group-title">Infrastructure</h3>
+            <div className="dash-sidebar__items">
+              <div
+                className="dash-sidebar__item"
+                onClick={() => navigate("/workers")}
+                role="button"
+                tabIndex={0}
+              >
+                <Cpu size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">Workers</span>
+                <span className="dash-sidebar__item-count">
+                  {workerList.length}
+                </span>
+              </div>
+              <div
+                className="dash-sidebar__item"
+                onClick={() => navigate("/models")}
+                role="button"
+                tabIndex={0}
+              >
+                <Database size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">
+                  Model Endpoints
+                </span>
+                <span className="dash-sidebar__item-count">
+                  {modelList.length}
+                </span>
+              </div>
+              <div
+                className="dash-sidebar__item"
+                onClick={() => navigate("/tools")}
+                role="button"
+                tabIndex={0}
+              >
+                <Wrench size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">Tools</span>
+                <span className="dash-sidebar__item-count">
+                  {tools.data?.length ?? 0}
+                </span>
+              </div>
+              <div
+                className="dash-sidebar__item"
+                onClick={() => navigate("/mcp-servers")}
+                role="button"
+                tabIndex={0}
+              >
+                <Server size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">MCP Servers</span>
+                <span className="dash-sidebar__item-count">
+                  {mcpServers.data?.length ?? 0}
+                </span>
+              </div>
+              <div
+                className="dash-sidebar__item"
+                onClick={() => navigate("/memories")}
+                role="button"
+                tabIndex={0}
+              >
+                <BrainCircuit size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">Memories</span>
+                <span className="dash-sidebar__item-count">
+                  {memories.data?.length ?? 0}
+                </span>
+              </div>
+              <div
+                className="dash-sidebar__item"
+                onClick={() => navigate("/secrets")}
+                role="button"
+                tabIndex={0}
+              >
+                <Lock size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">Secrets</span>
+                <span className="dash-sidebar__item-count">
+                  {secrets.data?.length ?? 0}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="dash-sidebar__group">
+            <h3 className="dash-sidebar__group-title">Automation</h3>
+            <div className="dash-sidebar__items">
+              <div
+                className="dash-sidebar__item"
+                onClick={() => navigate("/task-schedules")}
+                role="button"
+                tabIndex={0}
+              >
+                <CalendarClock size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">Task Schedules</span>
+                <span className="dash-sidebar__item-count">
+                  {taskSchedules.data?.length ?? 0}
+                </span>
+              </div>
+              <div
+                className="dash-sidebar__item"
+                onClick={() => navigate("/task-webhooks")}
+                role="button"
+                tabIndex={0}
+              >
+                <Webhook size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">Task Webhooks</span>
+                <span className="dash-sidebar__item-count">
+                  {taskWebhooks.data?.length ?? 0}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="dash-sidebar__group">
+            <h3 className="dash-sidebar__group-title">Capabilities</h3>
+            <div className="dash-sidebar__items">
+              <div
+                className="dash-sidebar__item"
+                onClick={() => navigate("/capabilities")}
+                role="button"
+                tabIndex={0}
+              >
+                <Zap size={14} className="dash-sidebar__icon" />
+                <span className="dash-sidebar__item-label">Capabilities</span>
+                <span className="dash-sidebar__item-count">{capCount}</span>
+              </div>
+            </div>
+          </div>
+        </aside>
       </div>
     </div>
   );

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -112,17 +112,18 @@
 }
 
 .sidebar__link--active {
-  background: var(--sidebar-active);
-  color: var(--sidebar-text-active);
+  background: linear-gradient(90deg, rgba(184, 130, 46, 0.20), rgba(184, 130, 46, 0.35));
+  color: var(--accent);
+  border-radius: 8px;
 }
 
 .sidebar__link--active::before {
   content: "";
   position: absolute;
-  left: -2px;
-  top: 6px;
-  bottom: 6px;
-  width: 2px;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
   border-radius: 2px;
   background: var(--accent);
 }
@@ -857,14 +858,18 @@
 
 .card {
   background: var(--card-bg);
-  border: 1px solid var(--border-subtle);
-  border-radius: 10px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
   padding: 20px;
-  transition: border-color 0.15s;
+  transition: border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .card:hover {
-  border-color: var(--border);
+  border-color: rgba(212, 160, 74, 0.15);
+  box-shadow: 0 2px 12px rgba(184, 130, 46, 0.06);
+  transform: translateY(-1px);
 }
 
 .card__title {
@@ -887,11 +892,14 @@
 }
 
 .metric-card {
-  background: var(--bg-secondary);
-  border: 1px solid transparent;
-  border-radius: 10px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
   padding: 18px;
-  transition: border-color 0.15s, background 0.15s;
+  transition: border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .metric-card--has-hint {
@@ -900,7 +908,9 @@
 
 .metric-card:hover {
   background: var(--bg-tertiary);
-  border-color: var(--border);
+  border-color: rgba(212, 160, 74, 0.15);
+  box-shadow: 0 2px 12px rgba(184, 130, 46, 0.06);
+  transform: translateY(-1px);
 }
 
 .metric-card--zero .metric-card__value {
@@ -1500,11 +1510,12 @@
 
 .graph-view {
   position: relative;
-  height: 600px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-subtle);
-  border-radius: 12px;
+  height: 520px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 14px;
   overflow: hidden;
+  box-shadow: 0 0 20px rgba(184, 130, 46, 0.05), var(--shadow-md);
 }
 
 /* --- Top bar: badge + status + legend toggle ----------------------------- */
@@ -1606,14 +1617,15 @@
   right: 12px;
   z-index: 10;
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  background: var(--bg-secondary);
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 8px;
+  background: rgba(28, 28, 33, 0.85);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
   border: 1px solid var(--border);
-  padding: 10px 14px;
-  border-radius: 10px;
+  padding: 8px 14px;
+  border-radius: 20px;
   box-shadow: var(--shadow-md);
   animation: legendFadeIn 0.15s ease;
 }
@@ -1640,14 +1652,20 @@
 .gnode {
   display: flex;
   align-items: center;
-  gap: 10px;
-  border: 1px solid var(--node-border);
+  gap: 12px;
+  border: 1px solid rgba(212, 160, 74, 0.15);
   border-radius: 12px;
   padding: 14px 18px;
-  min-width: 200px;
+  min-width: 220px;
   cursor: pointer;
-  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s, opacity 0.2s;
-  box-shadow: var(--shadow-sm);
+  transition: border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5),
+              0 1px 3px rgba(0, 0, 0, 0.4),
+              0 0 16px rgba(184, 130, 46, 0.08);
+  background: linear-gradient(90deg, #302F34, #29282D);
   position: relative;
   overflow: hidden;
 }
@@ -1658,43 +1676,43 @@
   top: 0;
   left: 0;
   right: 0;
-  height: 2px;
-  background: var(--text-tertiary);
-  opacity: 0.55;
+  height: 0;
+  background: transparent;
+  opacity: 0;
   pointer-events: none;
 }
 
 .gnode--system::before   { background: var(--accent); }
 .gnode--adapter::before  { background: var(--yellow); }
 .gnode--agent::before    { background: var(--green); }
-.gnode--model::before    { background: var(--blue); }
+.gnode--model::before    { background: var(--accent-blue); }
 .gnode--tool::before     { background: var(--yellow); }
 .gnode--secret::before   { background: var(--orange); }
 .gnode--memory::before   { background: var(--purple); }
 .gnode--role::before     { background: var(--purple); }
-.gnode--task::before     { background: var(--blue); }
+.gnode--task::before     { background: var(--accent-blue); }
 .gnode--schedule::before { background: var(--orange); }
 .gnode--webhook::before  { background: var(--orange); }
 .gnode--worker::before   { background: var(--green); }
 
-/* Type-specific background tints (replaces left border stripe) */
-.gnode--system   { background: color-mix(in srgb, var(--accent) 8%, var(--node-bg)); }
-.gnode--adapter  { background: color-mix(in srgb, var(--yellow) 6%, var(--node-bg)); }
-.gnode--agent    { background: color-mix(in srgb, var(--green) 7%, var(--node-bg)); }
-.gnode--model    { background: color-mix(in srgb, var(--blue) 5%, var(--node-bg)); }
-.gnode--tool     { background: color-mix(in srgb, var(--yellow) 5%, var(--node-bg)); }
-.gnode--secret   { background: color-mix(in srgb, var(--orange) 4%, var(--node-bg)); }
-.gnode--memory   { background: color-mix(in srgb, var(--purple) 5%, var(--node-bg)); }
-.gnode--role     { background: color-mix(in srgb, var(--purple) 5%, var(--node-bg)); }
-.gnode--task     { background: color-mix(in srgb, var(--blue) 7%, var(--node-bg)); }
-.gnode--schedule { background: color-mix(in srgb, var(--orange) 5%, var(--node-bg)); }
-.gnode--webhook  { background: color-mix(in srgb, var(--orange) 5%, var(--node-bg)); }
-.gnode--worker   { background: color-mix(in srgb, var(--green) 5%, var(--node-bg)); }
+/* Type-specific background tints */
+.gnode--system   { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(76, 175, 80, 0.25); }
+.gnode--adapter  { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(250, 204, 21, 0.2); }
+.gnode--agent    { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(212, 160, 74, 0.2); }
+.gnode--model    { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(92, 124, 250, 0.2); }
+.gnode--tool     { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(250, 204, 21, 0.2); }
+.gnode--secret   { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(251, 146, 60, 0.2); }
+.gnode--memory   { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(167, 139, 250, 0.2); }
+.gnode--role     { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(167, 139, 250, 0.2); }
+.gnode--task     { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(92, 124, 250, 0.25); }
+.gnode--schedule { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(251, 146, 60, 0.2); }
+.gnode--webhook  { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(251, 146, 60, 0.2); }
+.gnode--worker   { background: linear-gradient(90deg, #302F34, #29282D); border-color: rgba(76, 175, 80, 0.25); }
 
 .gnode:hover {
-  border-color: var(--border-strong);
-  box-shadow: var(--shadow-md);
-  transform: translateY(-1px);
+  border-color: rgba(212, 160, 74, 0.5);
+  box-shadow: 0 0 20px rgba(212, 160, 74, 0.25), 0 0 40px rgba(184, 130, 46, 0.12);
+  transform: scale(1.03);
 }
 
 /* Secondary (config) nodes — smaller, slightly quieter */
@@ -1710,10 +1728,20 @@
   opacity: 1;
 }
 
-/* Running state — soft accent glow */
+/* Running state — pulsing gold glow */
 .gnode--running {
-  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
-  box-shadow: var(--accent-glow);
+  border-color: rgba(212, 160, 74, 0.6);
+  box-shadow: 0 0 20px rgba(212, 160, 74, 0.4), 0 0 40px rgba(184, 130, 46, 0.2), 0 0 60px rgba(184, 130, 46, 0.1);
+  animation: node-pulse 2s ease-in-out infinite;
+}
+
+@keyframes node-pulse {
+  0%, 100% {
+    box-shadow: 0 0 20px rgba(212, 160, 74, 0.4), 0 0 40px rgba(184, 130, 46, 0.2), 0 0 60px rgba(184, 130, 46, 0.1);
+  }
+  50% {
+    box-shadow: 0 0 30px rgba(212, 160, 74, 0.6), 0 0 50px rgba(184, 130, 46, 0.3), 0 0 80px rgba(184, 130, 46, 0.15);
+  }
 }
 
 /* Entry / terminal / join — subtle colored border hint */
@@ -1728,32 +1756,33 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 42px;
+  height: 42px;
   border-radius: 50%;
   flex-shrink: 0;
-  transition: background 0.2s;
+  transition: background 0.2s, box-shadow 0.3s;
+  box-shadow: 0 0 10px rgba(184, 130, 46, 0.15);
 }
 
 /* Per-type icon ring tints */
-.gnode--system .gnode__icon-ring   { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); }
-.gnode--adapter .gnode__icon-ring  { background: color-mix(in srgb, var(--yellow) 18%, transparent); color: var(--yellow); }
-.gnode--agent .gnode__icon-ring    { background: color-mix(in srgb, var(--green) 18%, transparent); color: var(--green); }
-.gnode--model .gnode__icon-ring    { background: color-mix(in srgb, var(--blue) 15%, transparent); color: var(--blue); }
-.gnode--tool .gnode__icon-ring     { background: color-mix(in srgb, var(--yellow) 15%, transparent); color: var(--yellow); }
-.gnode--secret .gnode__icon-ring   { background: color-mix(in srgb, var(--orange) 15%, transparent); color: var(--orange); }
-.gnode--memory .gnode__icon-ring   { background: color-mix(in srgb, var(--purple) 15%, transparent); color: var(--purple); }
-.gnode--role .gnode__icon-ring     { background: color-mix(in srgb, var(--purple) 15%, transparent); color: var(--purple); }
-.gnode--task .gnode__icon-ring     { background: color-mix(in srgb, var(--blue) 18%, transparent); color: var(--blue); }
-.gnode--schedule .gnode__icon-ring { background: color-mix(in srgb, var(--orange) 15%, transparent); color: var(--orange); }
-.gnode--webhook .gnode__icon-ring  { background: color-mix(in srgb, var(--orange) 15%, transparent); color: var(--orange); }
-.gnode--worker .gnode__icon-ring   { background: color-mix(in srgb, var(--green) 15%, transparent); color: var(--green); }
+.gnode--system .gnode__icon-ring   { background: rgba(76, 175, 80, 0.25); color: #4CAF50; box-shadow: 0 0 12px rgba(76, 175, 80, 0.3); }
+.gnode--adapter .gnode__icon-ring  { background: rgba(250, 204, 21, 0.2); color: var(--yellow); box-shadow: 0 0 10px rgba(250, 204, 21, 0.2); }
+.gnode--agent .gnode__icon-ring    { background: rgba(76, 175, 80, 0.25); color: #4CAF50; box-shadow: 0 0 12px rgba(76, 175, 80, 0.3); }
+.gnode--model .gnode__icon-ring    { background: rgba(92, 124, 250, 0.2); color: var(--accent-blue); box-shadow: 0 0 10px rgba(92, 124, 250, 0.2); }
+.gnode--tool .gnode__icon-ring     { background: rgba(250, 204, 21, 0.2); color: var(--yellow); box-shadow: 0 0 10px rgba(250, 204, 21, 0.2); }
+.gnode--secret .gnode__icon-ring   { background: rgba(251, 146, 60, 0.2); color: var(--orange); box-shadow: 0 0 10px rgba(251, 146, 60, 0.2); }
+.gnode--memory .gnode__icon-ring   { background: rgba(167, 139, 250, 0.2); color: var(--purple); box-shadow: 0 0 10px rgba(167, 139, 250, 0.2); }
+.gnode--role .gnode__icon-ring     { background: rgba(167, 139, 250, 0.2); color: var(--purple); box-shadow: 0 0 10px rgba(167, 139, 250, 0.2); }
+.gnode--task .gnode__icon-ring     { background: rgba(92, 124, 250, 0.25); color: var(--accent-blue); box-shadow: 0 0 12px rgba(92, 124, 250, 0.3); }
+.gnode--schedule .gnode__icon-ring { background: rgba(251, 146, 60, 0.2); color: var(--orange); box-shadow: 0 0 10px rgba(251, 146, 60, 0.2); }
+.gnode--webhook .gnode__icon-ring  { background: rgba(251, 146, 60, 0.2); color: var(--orange); box-shadow: 0 0 10px rgba(251, 146, 60, 0.2); }
+.gnode--worker .gnode__icon-ring   { background: rgba(76, 175, 80, 0.25); color: #4CAF50; box-shadow: 0 0 12px rgba(76, 175, 80, 0.3); }
 
-.gnode--secondary .gnode__icon-ring { width: 26px; height: 26px; }
+.gnode--secondary .gnode__icon-ring { width: 30px; height: 30px; }
 
-.gnode--entry .gnode__icon-ring    { background: var(--green-bg); color: var(--green); }
-.gnode--terminal .gnode__icon-ring { background: var(--blue-bg); color: var(--blue); }
-.gnode--join .gnode__icon-ring     { background: var(--purple-bg); color: var(--purple); }
+.gnode--entry .gnode__icon-ring    { background: rgba(76, 175, 80, 0.3); color: #4CAF50; box-shadow: 0 0 14px rgba(76, 175, 80, 0.35); }
+.gnode--terminal .gnode__icon-ring { background: rgba(92, 124, 250, 0.25); color: var(--accent-blue); box-shadow: 0 0 12px rgba(92, 124, 250, 0.3); }
+.gnode--join .gnode__icon-ring     { background: rgba(167, 139, 250, 0.25); color: var(--purple); box-shadow: 0 0 12px rgba(167, 139, 250, 0.3); }
 
 /* Pulse ring for running agents */
 .gnode__pulse {
@@ -1868,12 +1897,14 @@
 
 /* --- React Flow overrides ------------------------------------------------ */
 
-.react-flow__background { opacity: 0.35; }
+.react-flow__background { opacity: 0; }
 
 .react-flow__edge-path {
-  stroke: var(--edge-stroke);
-  stroke-width: 1.5px;
+  stroke: #D4A04A;
+  stroke-width: 3px;
+  stroke-opacity: 0.8;
   transition: stroke-opacity 0.2s, stroke-width 0.2s, stroke 0.2s;
+  filter: drop-shadow(0 0 4px rgba(212, 160, 74, 0.6)) drop-shadow(0 0 10px rgba(184, 130, 46, 0.3));
 }
 
 /* Dependency edges: single-source opacity via stroke-opacity (no inline opacity in JS). */
@@ -1901,13 +1932,16 @@
   stroke-opacity: 1;
 }
 
-/* Routing edge flow animation: slower and eased so it reads as agentic flow,
-   not as a network spinner. Only applied when the call-site opts in to
-   `animated` (i.e., when a task is actually running). */
+/* Routing edge flow animation: gold luminous flow effect. */
 .react-flow__edge.animated .react-flow__edge-path {
-  stroke: color-mix(in srgb, var(--accent) 70%, transparent);
-  stroke-dasharray: 6 4;
-  animation: edgeFlow 1.6s ease-in-out infinite;
+  stroke: #D4A04A;
+  stroke-width: 3.5px;
+  stroke-opacity: 1;
+  stroke-dasharray: 8 5;
+  animation: edgeFlow 2s ease-in-out infinite;
+  filter: drop-shadow(0 0 6px rgba(212, 160, 74, 0.8))
+          drop-shadow(0 0 14px rgba(212, 160, 74, 0.5))
+          drop-shadow(0 0 28px rgba(184, 130, 46, 0.3));
 }
 
 @keyframes edgeFlow {
@@ -2354,200 +2388,229 @@
    DASHBOARD-SPECIFIC
    ============================================ */
 
-.page--dashboard .dashboard-meta {
-  font-size: 0.75rem;
-  margin-top: 6px;
-}
-
-.dashboard-metrics {
+.page--dashboard {
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 20px;
 }
 
-.dashboard-section__title {
-  font-size: 1.0625rem;
-  font-weight: 600;
+.dash-section-heading {
+  font-size: 1.05rem;
+  font-weight: 700;
   color: var(--text-primary);
-  margin: 0 0 4px;
-  letter-spacing: -0.01em;
+  margin: 0 0 12px;
 }
 
-.dashboard-section__hint {
-  font-size: 0.8125rem;
-  color: var(--text-tertiary);
-  margin: 0 0 14px;
-  line-height: 1.4;
+/* ---- Body: Tasks + Sidebar ---- */
+
+.dash-body {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 20px;
+  align-items: start;
 }
 
-.metrics-grid--dashboard {
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+/* ---- Active Tasks Table ---- */
+
+.dash-tasks__heading {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 12px;
 }
 
-.dashboard-metrics .metric-card__label {
-  text-transform: none;
-  letter-spacing: 0;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--text-secondary);
-}
-
-.platform-status {
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 14px 24px;
-  padding: 14px 18px 14px 22px;
-  border-radius: 10px;
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-secondary);
-  margin-bottom: 4px;
+.dash-tasks__table {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 14px;
   overflow: hidden;
 }
 
-.platform-status::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 2px;
-  background: var(--text-tertiary);
+.dash-tasks__header {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 8rem auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  border-bottom: 1px solid var(--border);
 }
 
-.platform-status--ok::before {
-  background: var(--green);
+.dash-tasks__row {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 8rem auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+  font-size: 0.82rem;
+  transition: background 0.12s;
 }
 
-.platform-status--warn::before {
-  background: var(--orange);
+.dash-tasks__row:last-child {
+  border-bottom: none;
 }
 
-.platform-status--bad::before {
-  background: var(--red);
+.dash-tasks__row:hover {
+  background: var(--bg-hover);
 }
 
-.platform-status__main {
+.dash-tasks__name {
   display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-width: min(100%, 280px);
-}
-
-.platform-status__badge {
-  display: inline-flex;
   align-items: center;
   gap: 8px;
-}
-
-.platform-status__badge-label {
-  font-size: 1rem;
   font-weight: 600;
   color: var(--text-primary);
+  overflow: hidden;
 }
 
-.platform-status__badge-icon {
+.dash-tasks__name .mono {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dash-tasks__play-icon {
+  flex-shrink: 0;
+  color: var(--accent);
+}
+
+.dash-tasks__system {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dash-tasks__system-icon {
+  flex-shrink: 0;
+  color: var(--accent);
+}
+
+.dash-tasks__time {
+  font-size: 0.78rem;
+}
+
+.dash-tasks__phase {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-self: end;
+}
+
+.dash-tasks__chevron {
   color: var(--text-tertiary);
 }
 
-.platform-status__list {
-  margin: 0;
-  padding-left: 1.15rem;
-  font-size: 0.8125rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
+.dash-tasks__empty {
+  padding: 24px 16px;
+  text-align: center;
+  font-size: 0.82rem;
 }
 
-.platform-status__actions {
+.dash-tasks__footer {
+  padding: 10px 16px;
+  border-top: 1px solid var(--border);
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
+  justify-content: flex-end;
 }
 
-.platform-status__chip {
+.dash-tasks__view-all {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  border-radius: 8px;
-  border: 1px solid var(--border);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  cursor: pointer;
-  transition: background 0.12s, border-color 0.12s;
-}
-
-.platform-status__chip:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-strong);
-}
-
-.platform-status__chip--danger {
-  border-color: var(--red);
-  background: color-mix(in srgb, var(--red) 12%, var(--card-bg));
-}
-
-.platform-status__chip--warning {
-  border-color: var(--orange);
-  background: color-mix(in srgb, var(--orange) 12%, var(--card-bg));
-}
-
-.platform-status__chip--ghost {
+  gap: 4px;
   background: transparent;
-}
-
-.card--dashboard .card__title--sentence {
-  text-transform: none;
-  letter-spacing: 0;
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.card--dashboard > .card__title--sentence {
-  margin-bottom: 14px;
-}
-
-.card--dashboard .card__header-row .card__title--sentence {
-  margin-bottom: 0;
-}
-
-.card__header-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 14px;
-}
-
-.card__link-all {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  padding: 4px 8px;
-  margin: 0;
-  font-size: 0.8125rem;
-  font-weight: 500;
   color: var(--accent);
-  background: transparent;
-  border: none;
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 4px 8px;
   border-radius: 6px;
-  cursor: pointer;
-  flex-shrink: 0;
+  transition: background 0.12s;
 }
 
-.card__link-all:hover {
+.dash-tasks__view-all:hover {
   background: var(--accent-alpha);
 }
 
-.dashboard-skeleton__hero {
-  height: 88px;
+/* ---- Bento Sidebar ---- */
+
+.dash-sidebar__heading {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 12px;
+}
+
+.dash-sidebar__group {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
   border-radius: 12px;
+  padding: 14px 16px;
+  margin-bottom: 12px;
+}
+
+.dash-sidebar__group:last-child {
+  margin-bottom: 0;
+}
+
+.dash-sidebar__group-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+}
+
+.dash-sidebar__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.dash-sidebar__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 4px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s;
+  font-size: 0.8rem;
+}
+
+.dash-sidebar__item:hover {
+  background: var(--bg-hover);
+}
+
+.dash-sidebar__icon {
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.dash-sidebar__item-label {
+  flex: 1;
+  color: var(--text-secondary);
+}
+
+.dash-sidebar__item-count {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  min-width: 20px;
+  text-align: right;
+}
+
+/* ---- Skeleton ---- */
+
+.dashboard-skeleton__hero {
+  height: 110px;
+  border-radius: 14px;
   background: linear-gradient(
     90deg,
     var(--bg-tertiary) 25%,
@@ -2556,17 +2619,17 @@
   );
   background-size: 400% 100%;
   animation: dashboard-shimmer 1.2s ease-in-out infinite;
-  margin-bottom: 8px;
+  margin-bottom: 16px;
 }
 
 .dashboard-skeleton__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 12px;
+  grid-template-columns: 1fr 280px;
+  gap: 16px;
 }
 
 .dashboard-skeleton__metric {
-  height: 92px;
+  height: 60px;
   border-radius: 10px;
   background: linear-gradient(
     90deg,
@@ -2587,153 +2650,22 @@
   }
 }
 
-.dashboard-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
+/* ---- Responsive ---- */
 
-.task-health__bar {
-  display: flex;
-  height: 12px;
-  border-radius: 6px;
-  overflow: hidden;
-  background: var(--bg-tertiary);
-  margin-bottom: 12px;
-}
+@media (max-width: 900px) {
+  .dash-body {
+    grid-template-columns: 1fr;
+  }
 
-.task-health__segment {
-  transition: width 0.3s ease;
-  min-width: 2px;
-}
+  .dash-health__banner {
+    flex-direction: column;
+  }
 
-.task-health__segment--green { background: var(--green); }
-.task-health__segment--blue { background: var(--blue); }
-.task-health__segment--yellow { background: var(--yellow); }
-.task-health__segment--red { background: var(--red); }
-.task-health__segment--orange { background: var(--orange); }
-
-.task-health__legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-}
-
-.task-health__legend-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.task-health__pct {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin-top: 12px;
-}
-
-.task-health__pct-meta {
-  font-size: 0.85rem;
-  font-weight: 500;
-}
-
-.recent-list {
-  display: flex;
-  flex-direction: column;
-}
-
-.recent-list__item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 0;
-  border-bottom: 1px solid var(--border-subtle);
-  cursor: pointer;
-  font-size: 0.85rem;
-  transition: background 0.12s ease;
-}
-
-.recent-list__item:last-child {
-  border-bottom: none;
-}
-
-.recent-list__item:hover {
-  background: var(--bg-hover);
-  margin: 0 -20px;
-  padding: 8px 20px;
-}
-
-.recent-list__name {
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.recent-list__system {
-  flex: 1;
-}
-
-/* Dashboard grid lists: column headers + calmer rows */
-.recent-list--grid {
-  --recent-cols: minmax(0, 1.3fr) minmax(0, 0.95fr) minmax(0, 5.5rem) auto;
-  gap: 0;
-}
-
-.recent-list--grid.recent-list--systems,
-.recent-list--grid.recent-list--workers {
-  --recent-cols: minmax(0, 1.4fr) minmax(0, 4.5rem) auto;
-}
-
-.recent-list--grid .recent-list__header {
-  display: grid;
-  grid-template-columns: var(--recent-cols);
-  align-items: center;
-  gap: 10px 12px;
-  padding: 6px 12px 10px;
-  margin-bottom: 2px;
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: var(--text-tertiary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.recent-list--grid .recent-list__header-phase {
-  justify-self: end;
-}
-
-.recent-list--grid .recent-list__item {
-  display: grid;
-  grid-template-columns: var(--recent-cols);
-  align-items: center;
-  gap: 10px 12px;
-  padding: 10px 12px;
-  margin: 0;
-  border-bottom: 1px solid var(--border-subtle);
-  border-radius: 0;
-  font-size: 0.8125rem;
-}
-
-.recent-list--grid .recent-list__item:last-of-type {
-  border-bottom: none;
-}
-
-.recent-list--grid .recent-list__item:hover {
-  margin: 0;
-  padding: 10px 12px;
-  background: var(--bg-hover);
-  border-radius: 8px;
-}
-
-.recent-list--grid .recent-list__badge {
-  justify-self: end;
-}
-
-.recent-list--grid .recent-list__empty {
-  padding: 12px;
-  margin: 0;
+  .dash-health__secondary {
+    border-left: none;
+    border-top: 1px solid var(--border);
+    justify-content: center;
+  }
 }
 
 /* ============================================
@@ -3841,4 +3773,481 @@ button:focus-visible {
   text-align: center;
   color: var(--text-secondary);
   font-size: 13px;
+}
+
+/* ============================================
+   SYSTEM DETAIL BENTO LAYOUT
+   ============================================ */
+
+.page--system-detail {
+  gap: 16px;
+}
+
+.system-detail__topology {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.system-detail__topology-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.system-detail__section-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-primary);
+}
+
+.system-detail__bento {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 1100px) {
+  .system-detail__bento {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .system-detail__bento {
+    grid-template-columns: 1fr;
+  }
+}
+
+.system-detail__recent-tasks {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 0 16px rgba(184, 130, 46, 0.04);
+}
+
+.system-detail__card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.system-detail__card-title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-primary);
+}
+
+.system-detail__tasks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.system-detail__tasks-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: background 0.15s;
+  font-size: 0.82rem;
+}
+
+.system-detail__tasks-row:hover {
+  background: var(--bg-hover);
+}
+
+.system-detail__tasks-row--header {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+  cursor: default;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 8px;
+}
+
+.system-detail__tasks-row--header:hover {
+  background: transparent;
+}
+
+.system-detail__tasks-action {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.system-detail__tasks-empty {
+  padding: 16px 0;
+  font-size: 0.82rem;
+}
+
+.system-detail__tasks-footer {
+  padding-top: 8px;
+  border-top: 1px solid var(--border-subtle);
+  font-size: 0.75rem;
+}
+
+/* ============================================
+   SYSTEM HEALTH HORIZON
+   ============================================ */
+
+.health-horizon {
+  display: flex;
+  align-items: stretch;
+  gap: 32px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 24px 32px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 0 20px rgba(184, 130, 46, 0.05);
+}
+
+.health-horizon::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-hover), transparent);
+  opacity: 0.6;
+}
+
+.health-horizon__primary {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex: 1;
+}
+
+.health-horizon__metric-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.health-horizon__label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-secondary);
+}
+
+.health-horizon__value {
+  font-size: 2.4rem;
+  font-weight: 800;
+  color: var(--accent);
+  line-height: 1;
+  text-shadow: 0 0 30px rgba(212, 160, 74, 0.4), 0 0 60px rgba(212, 160, 74, 0.15);
+}
+
+.health-horizon__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.health-horizon__status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+}
+
+.health-horizon__status--ok .health-horizon__status-dot {
+  background: var(--green);
+  box-shadow: 0 0 6px rgba(76, 175, 80, 0.5);
+}
+
+.health-horizon__status--warn .health-horizon__status-dot {
+  background: var(--orange);
+  box-shadow: 0 0 6px rgba(255, 152, 0, 0.5);
+}
+
+.health-horizon__sparkline {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.health-horizon__time-range {
+  font-size: 0.65rem;
+  color: var(--text-tertiary);
+}
+
+.health-horizon__secondary {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  padding-left: 24px;
+  border-left: 1px solid var(--border);
+}
+
+.health-horizon__stat {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.health-horizon__stat-icon {
+  color: var(--accent);
+  margin-top: 2px;
+}
+
+.health-horizon__stat-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.health-horizon__stat-label {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+
+.health-horizon__stat-value {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  line-height: 1;
+}
+
+.health-horizon__stat-sub {
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+}
+
+.health-horizon__indicator {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  color: var(--accent);
+  opacity: 0.6;
+}
+
+@media (max-width: 900px) {
+  .health-horizon {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .health-horizon__secondary {
+    border-left: none;
+    border-top: 1px solid var(--border);
+    padding-left: 0;
+    padding-top: 16px;
+  }
+}
+
+/* ============================================
+   SYSTEM DEFINITIONS PANEL
+   ============================================ */
+
+.sys-definitions {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  box-shadow: 0 0 16px rgba(184, 130, 46, 0.04);
+}
+
+.sys-definitions__title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-primary);
+}
+
+.sys-definitions__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 16px;
+}
+
+.sys-definitions__item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sys-definitions__item-label {
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+}
+
+.sys-definitions__item-value {
+  font-size: 1.8rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  line-height: 1.1;
+}
+
+.sys-definitions__item-sub {
+  font-size: 0.65rem;
+  color: var(--text-tertiary);
+}
+
+.sys-definitions__footer {
+  display: flex;
+  gap: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-subtle);
+  font-size: 0.72rem;
+  color: var(--text-tertiary);
+}
+
+/* ============================================
+   TASK TRACE TIMELINE
+   ============================================ */
+
+.trace-timeline {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 0 16px rgba(184, 130, 46, 0.04);
+}
+
+.trace-timeline__title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-primary);
+}
+
+.trace-timeline__feed {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow: hidden;
+}
+
+@keyframes trace-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+    max-height: 0;
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    max-height: 48px;
+  }
+}
+
+.trace-timeline__event {
+  display: grid;
+  grid-template-columns: 8px 56px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s, opacity 0.3s, transform 0.3s;
+  font-size: 0.78rem;
+  animation: trace-slide-in 0.35s ease-out both;
+}
+
+.trace-timeline__event:hover {
+  background: var(--bg-hover);
+}
+
+.trace-timeline__event:last-child {
+  border-bottom: none;
+}
+
+.trace-timeline__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.trace-timeline__dot--gold { background: #D4A04A; box-shadow: 0 0 6px rgba(212, 160, 74, 0.5); }
+.trace-timeline__dot--green { background: #4CAF50; box-shadow: 0 0 6px rgba(76, 175, 80, 0.5); }
+.trace-timeline__dot--red { background: #f87171; box-shadow: 0 0 6px rgba(248, 113, 113, 0.5); }
+.trace-timeline__dot--blue { background: #60a5fa; box-shadow: 0 0 6px rgba(96, 165, 250, 0.5); }
+.trace-timeline__dot--gray { background: #62636C; }
+
+.trace-timeline__time {
+  color: var(--text-tertiary);
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+
+.trace-timeline__desc {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trace-timeline__task {
+  color: var(--text-tertiary);
+  font-size: 0.68rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 140px;
+  text-align: right;
+}
+
+.trace-timeline__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 500;
+  transition: opacity 0.15s;
+}
+
+.trace-timeline__footer:hover {
+  opacity: 0.8;
+}
+
+.trace-timeline__empty {
+  padding: 24px 0;
+  text-align: center;
+  color: var(--text-tertiary);
+  font-size: 0.82rem;
 }

--- a/frontend/src/styles/theme-dark.css
+++ b/frontend/src/styles/theme-dark.css
@@ -1,33 +1,34 @@
 [data-theme="dark"] {
   color-scheme: dark;
 
-  --bg-primary: #09090b;
-  --bg-secondary: #111113;
-  --bg-tertiary: #18181b;
-  --bg-surface: #1c1c1f;
-  --bg-hover: rgba(255, 255, 255, 0.035);
-  --bg-input: #0d0d0f;
+  --bg-primary: #1E1D22;
+  --bg-secondary: #29282D;
+  --bg-tertiary: #29282D;
+  --bg-surface: #29282D;
+  --bg-hover: rgba(212, 160, 74, 0.04);
+  --bg-input: #161518;
   --bg-overlay: rgba(0, 0, 0, 0.7);
 
-  --text-primary: #f4f4f5;
-  --text-secondary: #a1a1aa;
-  --text-tertiary: #71717a;
-  --text-inverse: #09090b;
+  --text-primary: #E8E4DC;
+  --text-secondary: #7A7872;
+  --text-tertiary: #7A7870;
+  --text-inverse: #1E1D22;
 
-  --border: #1f1f23;
-  --border-subtle: rgba(255, 255, 255, 0.04);
-  --border-strong: #2a2a2e;
+  --border: #35342B;
+  --border-subtle: rgba(255, 255, 255, 0.05);
+  --border-strong: #45443A;
 
-  --accent: #4ade80;
-  --accent-hover: #22c55e;
-  --accent-alpha: rgba(74, 222, 128, 0.14);
-  --accent-text: #4ade80;
-  --accent-glow: 0 0 0 1px rgba(74, 222, 128, 0.35), 0 0 24px rgba(74, 222, 128, 0.18);
+  --accent: #D4A04A;
+  --accent-hover: #B8822E;
+  --accent-alpha: rgba(184, 130, 46, 0.15);
+  --accent-text: #D4A04A;
+  --accent-glow: 0 0 0 1px rgba(212, 160, 74, 0.35), 0 0 24px rgba(184, 130, 46, 0.18);
+  --accent-blue: #5C7CFA;
 
   --blue: #60a5fa;
   --blue-bg: rgba(96, 165, 250, 0.12);
-  --green: #22c55e;
-  --green-bg: rgba(34, 197, 94, 0.12);
+  --green: #4CAF50;
+  --green-bg: rgba(76, 175, 80, 0.12);
   --yellow: #facc15;
   --yellow-bg: rgba(250, 204, 21, 0.12);
   --orange: #fb923c;
@@ -43,18 +44,18 @@
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.6);
 
-  --sidebar-bg: #09090b;
-  --sidebar-border: #18181b;
-  --sidebar-text: #a1a1aa;
-  --sidebar-text-active: #f4f4f5;
-  --sidebar-hover: rgba(255, 255, 255, 0.035);
-  --sidebar-active: rgba(255, 255, 255, 0.06);
+  --sidebar-bg: #29282D;
+  --sidebar-border: #35342B;
+  --sidebar-text: #B5B3AA;
+  --sidebar-text-active: #E8E4DC;
+  --sidebar-hover: rgba(212, 160, 74, 0.08);
+  --sidebar-active: rgba(184, 130, 46, 0.30);
 
-  --topbar-bg: rgba(17, 17, 19, 0.72);
+  --topbar-bg: #29282D;
   --topbar-border: rgba(255, 255, 255, 0.05);
 
-  --card-bg: #111113;
-  --card-border: #1f1f23;
+  --card-bg: #29282D;
+  --card-border: #35342B;
 
   --badge-healthy: var(--green);
   --badge-healthy-bg: var(--green-bg);
@@ -67,10 +68,10 @@
   --badge-deadletter: var(--orange);
   --badge-deadletter-bg: var(--orange-bg);
 
-  --node-bg: #151517;
-  --node-border: #26262a;
-  --node-text: #f4f4f5;
-  --edge-color: #2a2a2e;
-  --edge-stroke: #71717a;
-  --graph-grid: rgba(255, 255, 255, 0.03);
+  --node-bg: #29282D;
+  --node-border: #35342B;
+  --node-text: #E8E4DC;
+  --edge-color: #35342B;
+  --edge-stroke: rgba(212, 160, 74, 0.3);
+  --graph-grid: rgba(212, 160, 74, 0.02);
 }

--- a/frontend/src/styles/theme-light.css
+++ b/frontend/src/styles/theme-light.css
@@ -5,7 +5,7 @@
   --bg-secondary: #ffffff;
   --bg-tertiary: #f4f4f5;
   --bg-surface: #ffffff;
-  --bg-hover: rgba(0, 0, 0, 0.03);
+  --bg-hover: rgba(214, 137, 48, 0.04);
   --bg-input: #ffffff;
   --bg-overlay: rgba(0, 0, 0, 0.4);
 
@@ -18,16 +18,17 @@
   --border-subtle: rgba(0, 0, 0, 0.06);
   --border-strong: #a1a1aa;
 
-  --accent: #16a34a;
-  --accent-hover: #15803d;
-  --accent-alpha: rgba(22, 163, 74, 0.12);
-  --accent-text: #15803d;
-  --accent-glow: 0 0 0 1px rgba(22, 163, 74, 0.35), 0 0 20px rgba(22, 163, 74, 0.15);
+  --accent: #D68930;
+  --accent-hover: #B8721A;
+  --accent-alpha: rgba(214, 137, 48, 0.12);
+  --accent-text: #B8721A;
+  --accent-glow: 0 0 0 1px rgba(214, 137, 48, 0.35), 0 0 20px rgba(214, 137, 48, 0.15);
+  --accent-blue: #4C6EF5;
 
   --blue: #2563eb;
   --blue-bg: rgba(37, 99, 235, 0.08);
-  --green: #16a34a;
-  --green-bg: rgba(22, 163, 74, 0.08);
+  --green: #2E7D32;
+  --green-bg: rgba(46, 125, 50, 0.08);
   --yellow: #ca8a04;
   --yellow-bg: rgba(202, 138, 4, 0.08);
   --orange: #ea580c;
@@ -47,8 +48,8 @@
   --sidebar-border: #e4e4e7;
   --sidebar-text: #52525b;
   --sidebar-text-active: #18181b;
-  --sidebar-hover: rgba(0, 0, 0, 0.04);
-  --sidebar-active: rgba(0, 0, 0, 0.06);
+  --sidebar-hover: rgba(214, 137, 48, 0.06);
+  --sidebar-active: rgba(214, 137, 48, 0.1);
 
   --topbar-bg: rgba(255, 255, 255, 0.78);
   --topbar-border: rgba(0, 0, 0, 0.06);
@@ -71,6 +72,6 @@
   --node-border: #e4e4e7;
   --node-text: #18181b;
   --edge-color: #a1a1aa;
-  --edge-stroke: #a1a1aa;
-  --graph-grid: rgba(0, 0, 0, 0.04);
+  --edge-stroke: rgba(214, 137, 48, 0.5);
+  --graph-grid: rgba(214, 137, 48, 0.04);
 }


### PR DESCRIPTION
Rewrite the main dashboard to match the new gold/bronze design system with a System Health Rollup banner, Active Tasks table (capped at 15), and a Bento Sidebar showing grouped resource counts. Replace the static Gantt chart in TaskTraceTimeline with a live event feed showing the last 5 trace events with slide-in animations. Unify the health horizon component across dashboard and system detail pages. Fix topology background to use var(--card-bg) instead of hardcoded black.


