### PR TITLE
feat(a2a): add A2A protocol support with per-system auth and security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **A2A protocol support**: expose agents as discoverable A2A agents via Agent Cards, accept inbound A2A task requests (JSON-RPC), call external A2A agents as `type: a2a` tools, and maintain a configured registry of remote agents. Includes Agent Card generation from agents/systems, `POST /a2a` and per-agent `POST /v1/agents/{name}/a2a` JSON-RPC endpoints, `GET /.well-known/agent-card.json` discovery, `GET /v1/a2a/agents` registry endpoint, Orloj/A2A task state mapping, outbound A2A client with SSRF protection, A2A-specific Prometheus metrics, `orlojctl a2a card` and `orlojctl a2a test` CLI commands, React SPA A2A Registry page, Helm chart `a2a.*` values, and comprehensive documentation.
+- **A2A protocol support**: expose selected AgentSystems as discoverable A2A agents via `spec.a2a.enabled`, accept inbound A2A task requests (JSON-RPC), call external A2A agents as `type: a2a` tools, and maintain a configured registry of remote agents. Includes Agent Card generation from systems, `POST /a2a` and per-system `POST /v1/agent-systems/{name}/a2a` JSON-RPC endpoints, `GET /.well-known/agent-card.json` discovery, auth-filtered `GET /v1/a2a/agents` registry endpoint, scoped API-token role `a2a`, Orloj/A2A task state mapping, outbound A2A client with SSRF protection, A2A-specific Prometheus metrics, `orlojctl a2a card` and `orlojctl a2a test` CLI commands, React SPA A2A Registry page, Helm chart `a2a.*` values, and comprehensive documentation.
+- **Per-system A2A invoke auth**: new `spec.a2a.auth` field on AgentSystem (`"public"` or `"bearer"`, default `"bearer"`) allows individual systems to accept unauthenticated A2A invoke while the control plane remains token-protected. Public systems' Agent Cards omit `authentication.schemes`, and the A2A registry shows public systems to unauthenticated callers.
+
+### Fixed
+
+- **A2A: `tasks/get` and `tasks/cancel` auth bypass on bearer systems**: unauthenticated callers could read task output and cancel tasks on `spec.a2a.auth: bearer` systems if they knew the A2A task ID. The permissive `a2aIdentityAllowsSystem` gate now enforces the same bearer requirement as `tasks/send` and `tasks/sendSubscribe`.
+- **A2A: `tasks/sendSubscribe` namespace mismatch**: subscribe created tasks in the request query-param namespace (defaulting to `"default"`) instead of using the target AgentSystem's namespace, causing task lookup misses for non-default namespaces.
+- **A2A: `--api-key` flag not wired into authorizer**: running `orlojd --api-key secret` without the `ORLOJ_API_TOKEN` env var left auth open while Agent Cards advertised bearer. The flag value is now propagated to the env before server init.
+- **A2A: `tasks/get`/`tasks/cancel` cross-system task ID collision**: `findTaskByA2AID` searched all tasks globally by label. When invoked via a per-system URL (`/v1/agent-systems/{name}/a2a`), the lookup is now scoped to the target system.
+- **A2A: `tasks/get`/`tasks/cancel` missing task ID validation**: get and cancel accepted empty `params.id`. Empty IDs are now rejected consistently across all four JSON-RPC methods.
+- **A2A: subscribe SSE write errors ignored**: heartbeat and status writes did not check for errors, allowing the poll loop to spin briefly after client disconnect. Write failures now terminate the stream immediately and record `client_disconnected` in telemetry.
+- **A2A: cancel reason unbounded**: `params.reason` on `tasks/cancel` had no length limit and was stored verbatim. Now capped at 1024 characters with rune-safe truncation.
+- **Helm CRD drift**: `charts/orloj/templates/operator-crds.yaml` was missing the `spec.a2a.auth` field present in `config/crd/bases/orloj.dev_agentsystems.yaml`.
+- **CLI: `orlojctl a2a card` ignored `--namespace` flag**: the namespace flag was not applied to the card fetch URL. Non-default namespace systems now resolve correctly.
+- **Docs: stale A2A security description**: `docs/pages/concepts/a2a-interoperability.md` incorrectly stated that JSON-RPC endpoints require global bearer auth; updated to describe per-system `spec.a2a.auth` model.
 
 ### Changed
 

--- a/api/a2a.go
+++ b/api/a2a.go
@@ -1,21 +1,25 @@
 package api
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/OrlojHQ/orloj/resources"
 	"github.com/OrlojHQ/orloj/runtime/a2a"
+	"github.com/OrlojHQ/orloj/store"
 	"github.com/OrlojHQ/orloj/telemetry"
 )
 
 // A2AConfig holds server-side A2A configuration.
 type A2AConfig struct {
-	Enabled                bool
 	PublicBaseURL          string
 	ProtocolVersion        string
 	StreamingEnabled       bool
@@ -31,25 +35,24 @@ func (s *Server) handleWellKnownAgentCard(w http.ResponseWriter, r *http.Request
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if s.a2aConfig == nil || !s.a2aConfig.Enabled {
-		http.Error(w, "A2A protocol is not enabled", http.StatusNotFound)
-		return
-	}
-
-	agents, err := s.stores.Agents.List(r.Context())
+	systems, err := s.a2aEnabledSystems(r)
 	if err != nil {
-		http.Error(w, "failed to list agents", http.StatusInternalServerError)
+		http.Error(w, "failed to list agent systems", http.StatusInternalServerError)
 		return
 	}
-	if len(agents) == 0 {
-		http.Error(w, "no agents configured", http.StatusNotFound)
+	if len(systems) != 1 {
+		http.Error(w, "A2A root card is available only when exactly one AgentSystem is enabled", http.StatusNotFound)
 		return
 	}
 
 	tools, _ := s.stores.Tools.List(r.Context())
+	agents, _ := s.stores.Agents.List(r.Context())
 
-	config := s.buildCardConfig()
-	card := a2a.GenerateAgentCard(agents[0], tools, config)
+	config := s.buildCardConfig(systems[0].Metadata.Namespace)
+	if systems[0].Spec.A2A.Auth == resources.A2AAuthPublic {
+		config.AuthSchemes = nil
+	}
+	card := a2a.GenerateSystemCard(systems[0], agentsForSystem(systems[0], agents), tools, config)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=300")
@@ -62,71 +65,31 @@ func (s *Server) handleAgentCard(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if s.a2aConfig == nil || !s.a2aConfig.Enabled {
-		http.Error(w, "A2A protocol is not enabled", http.StatusNotFound)
-		return
-	}
-
 	path := r.URL.Path
-	name := extractAgentNameFromCardPath(path)
+	name := extractA2ASystemNameFromPath(path)
 	if name == "" {
-		http.Error(w, "agent name required", http.StatusBadRequest)
+		http.Error(w, "agentsystem name required", http.StatusBadRequest)
 		return
 	}
 
-	agents, err := s.stores.Agents.List(r.Context())
+	system, ok, err := s.a2aEnabledSystemByName(r, name)
 	if err != nil {
-		http.Error(w, "failed to list agents", http.StatusInternalServerError)
+		http.Error(w, "failed to get agentsystem", http.StatusInternalServerError)
 		return
 	}
-
-	var agent *resources.Agent
-	for i := range agents {
-		if agents[i].Metadata.Name == name {
-			agent = &agents[i]
-			break
-		}
-	}
-
-	if agent == nil {
-		systems, err := s.stores.AgentSystems.List(r.Context())
-		if err == nil {
-			for _, sys := range systems {
-				if sys.Metadata.Name == name {
-					tools, _ := s.stores.Tools.List(r.Context())
-					var sysAgents []resources.Agent
-					for _, agentName := range sys.Spec.Agents {
-						for i := range agents {
-							if agents[i].Metadata.Name == agentName {
-								sysAgents = append(sysAgents, agents[i])
-							}
-						}
-					}
-					config := s.buildCardConfig()
-					card := a2a.GenerateSystemCard(sys, sysAgents, tools, config)
-					w.Header().Set("Content-Type", "application/json")
-					w.Header().Set("Cache-Control", "public, max-age=300")
-					json.NewEncoder(w).Encode(card)
-					return
-				}
-			}
-		}
-		http.Error(w, "agent not found", http.StatusNotFound)
+	if !ok {
+		http.Error(w, "agentsystem not found", http.StatusNotFound)
 		return
 	}
 
 	tools, _ := s.stores.Tools.List(r.Context())
-	var agentTools []resources.Tool
-	for _, t := range tools {
-		for _, tn := range agent.Spec.Tools {
-			if t.Metadata.Name == tn {
-				agentTools = append(agentTools, t)
-			}
-		}
-	}
+	agents, _ := s.stores.Agents.List(r.Context())
 
-	config := s.buildCardConfig()
-	card := a2a.GenerateAgentCard(*agent, agentTools, config)
+	config := s.buildCardConfig(system.Metadata.Namespace)
+	if system.Spec.A2A.Auth == resources.A2AAuthPublic {
+		config.AuthSchemes = nil
+	}
+	card := a2a.GenerateSystemCard(system, agentsForSystem(system, agents), tools, config)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=300")
@@ -139,11 +102,6 @@ func (s *Server) handleA2AJSONRPC(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if s.a2aConfig == nil || !s.a2aConfig.Enabled {
-		writeA2AError(w, nil, a2a.ErrCodeInternal, "A2A protocol is not enabled")
-		return
-	}
-
 	if s.a2aRateLimiter != nil && !s.a2aRateLimiter.Allow(r) {
 		writeA2AError(w, nil, a2a.ErrCodeInternal, "rate limit exceeded")
 		return
@@ -166,27 +124,27 @@ func (s *Server) handleA2AJSONRPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	agentName := extractAgentNameFromA2APath(r.URL.Path)
+	systemName := extractA2ASystemNameFromPath(r.URL.Path)
 
 	switch req.Method {
 	case a2a.MethodTaskSend:
-		s.handleA2ATaskSend(w, r, req, agentName)
+		s.handleA2ATaskSend(w, r, req, systemName)
 	case a2a.MethodTaskGet:
-		s.handleA2ATaskGet(w, r, req)
+		s.handleA2ATaskGet(w, r, req, systemName)
 	case a2a.MethodTaskCancel:
-		s.handleA2ATaskCancel(w, r, req)
+		s.handleA2ATaskCancel(w, r, req, systemName)
 	case a2a.MethodTaskSubscribe:
-		s.handleA2ATaskSubscribe(w, r, req, agentName)
+		s.handleA2ATaskSubscribe(w, r, req, systemName)
 	default:
 		writeA2AError(w, req.ID, a2a.ErrCodeMethodNotFound, fmt.Sprintf("unknown method: %s", req.Method))
 	}
 }
 
-func (s *Server) handleA2ATaskSend(w http.ResponseWriter, r *http.Request, req a2a.JSONRPCRequest, agentName string) {
+func (s *Server) handleA2ATaskSend(w http.ResponseWriter, r *http.Request, req a2a.JSONRPCRequest, systemName string) {
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		telemetry.RecordA2AInbound(a2a.MethodTaskSend, status, agentName, time.Since(start).Seconds())
+		telemetry.RecordA2AInbound(a2a.MethodTaskSend, status, systemName, time.Since(start).Seconds())
 	}()
 
 	paramsBytes, err := json.Marshal(req.Params)
@@ -209,7 +167,7 @@ func (s *Server) handleA2ATaskSend(w http.ResponseWriter, r *http.Request, req a
 		return
 	}
 
-	system := agentName
+	system := strings.TrimSpace(systemName)
 	if system == "" {
 		if params.Metadata != nil {
 			if agent, ok := params.Metadata["agent"]; ok {
@@ -220,19 +178,41 @@ func (s *Server) handleA2ATaskSend(w http.ResponseWriter, r *http.Request, req a
 		}
 	}
 	if system == "" {
-		agents, err := s.stores.Agents.List(r.Context())
-		if err == nil && len(agents) == 1 {
-			system = agents[0].Metadata.Name
+		defaultSystem, ok, err := s.defaultA2ASystem(r)
+		if err != nil {
+			status = "error"
+			writeA2AError(w, req.ID, a2a.ErrCodeInternal, "failed to resolve target agentsystem")
+			return
+		}
+		if ok {
+			system = defaultSystem.Metadata.Name
 		}
 	}
 	if system == "" {
 		status = "error"
-		writeA2AError(w, req.ID, a2a.ErrCodeInvalidParams, "target agent must be specified via URL path or request metadata")
+		writeA2AError(w, req.ID, a2a.ErrCodeInvalidParams, "target AgentSystem must be specified via URL path or request metadata")
 		return
 	}
 
-	namespace := resolveNamespace(r)
-	task := a2a.CreateOrlojTaskFromA2A(params, system, namespace)
+	target, ok, err := s.a2aEnabledSystemByName(r, system)
+	if err != nil {
+		status = "error"
+		writeA2AError(w, req.ID, a2a.ErrCodeInternal, "failed to resolve target agentsystem")
+		return
+	}
+	if !ok {
+		status = "error"
+		writeA2AError(w, req.ID, a2a.ErrCodeAgentNotFound, "target AgentSystem is not A2A-enabled")
+		return
+	}
+	if !a2aAuthorizeInvoke(w, r, req.ID, target) {
+		status = "error"
+		return
+	}
+
+	namespace := resources.NormalizeNamespace(target.Metadata.Namespace)
+	task := a2a.CreateOrlojTaskFromA2A(params, target.Metadata.Name, namespace)
+	task.Metadata.Name = a2aInternalTaskName(target, params.ID)
 
 	if _, err := s.stores.Tasks.Upsert(r.Context(), task); err != nil {
 		status = "error"
@@ -244,11 +224,11 @@ func (s *Server) handleA2ATaskSend(w http.ResponseWriter, r *http.Request, req a
 	writeA2AResult(w, req.ID, result)
 }
 
-func (s *Server) handleA2ATaskGet(w http.ResponseWriter, r *http.Request, req a2a.JSONRPCRequest) {
+func (s *Server) handleA2ATaskGet(w http.ResponseWriter, r *http.Request, req a2a.JSONRPCRequest, systemName string) {
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		telemetry.RecordA2AInbound(a2a.MethodTaskGet, status, "", time.Since(start).Seconds())
+		telemetry.RecordA2AInbound(a2a.MethodTaskGet, status, systemName, time.Since(start).Seconds())
 	}()
 
 	paramsBytes, err := json.Marshal(req.Params)
@@ -265,8 +245,19 @@ func (s *Server) handleA2ATaskGet(w http.ResponseWriter, r *http.Request, req a2
 		return
 	}
 
-	task, err := s.findTaskByA2AID(r, params.ID)
+	if params.ID == "" {
+		status = "error"
+		writeA2AError(w, req.ID, a2a.ErrCodeInvalidParams, "task id is required")
+		return
+	}
+
+	task, err := s.findTaskByA2AID(r, params.ID, systemName)
 	if err != nil {
+		status = "error"
+		writeA2AError(w, req.ID, a2a.ErrCodeTaskNotFound, "task not found")
+		return
+	}
+	if !s.a2aIdentityAllowsTask(r, task) {
 		status = "error"
 		writeA2AError(w, req.ID, a2a.ErrCodeTaskNotFound, "task not found")
 		return
@@ -276,11 +267,11 @@ func (s *Server) handleA2ATaskGet(w http.ResponseWriter, r *http.Request, req a2
 	writeA2AResult(w, req.ID, result)
 }
 
-func (s *Server) handleA2ATaskCancel(w http.ResponseWriter, r *http.Request, req a2a.JSONRPCRequest) {
+func (s *Server) handleA2ATaskCancel(w http.ResponseWriter, r *http.Request, req a2a.JSONRPCRequest, systemName string) {
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		telemetry.RecordA2AInbound(a2a.MethodTaskCancel, status, "", time.Since(start).Seconds())
+		telemetry.RecordA2AInbound(a2a.MethodTaskCancel, status, systemName, time.Since(start).Seconds())
 	}()
 
 	paramsBytes, err := json.Marshal(req.Params)
@@ -297,8 +288,19 @@ func (s *Server) handleA2ATaskCancel(w http.ResponseWriter, r *http.Request, req
 		return
 	}
 
-	task, err := s.findTaskByA2AID(r, params.ID)
+	if params.ID == "" {
+		status = "error"
+		writeA2AError(w, req.ID, a2a.ErrCodeInvalidParams, "task id is required")
+		return
+	}
+
+	task, err := s.findTaskByA2AID(r, params.ID, systemName)
 	if err != nil {
+		status = "error"
+		writeA2AError(w, req.ID, a2a.ErrCodeTaskNotFound, "task not found")
+		return
+	}
+	if !s.a2aIdentityAllowsTask(r, task) {
 		status = "error"
 		writeA2AError(w, req.ID, a2a.ErrCodeTaskNotFound, "task not found")
 		return
@@ -307,6 +309,12 @@ func (s *Server) handleA2ATaskCancel(w http.ResponseWriter, r *http.Request, req
 	reason := params.Reason
 	if reason == "" {
 		reason = "cancelled via A2A"
+	}
+	if len(reason) > 1024 {
+		reason = reason[:1024]
+		for !utf8.ValidString(reason) {
+			reason = reason[:len(reason)-1]
+		}
 	}
 
 	if task.Metadata.Labels == nil {
@@ -327,11 +335,11 @@ func (s *Server) handleA2ATaskCancel(w http.ResponseWriter, r *http.Request, req
 	writeA2AResult(w, req.ID, result)
 }
 
-func (s *Server) handleA2ATaskSubscribe(w http.ResponseWriter, r *http.Request, req a2a.JSONRPCRequest, agentName string) {
+func (s *Server) handleA2ATaskSubscribe(w http.ResponseWriter, r *http.Request, req a2a.JSONRPCRequest, systemName string) {
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		telemetry.RecordA2AInbound(a2a.MethodTaskSubscribe, status, agentName, time.Since(start).Seconds())
+		telemetry.RecordA2AInbound(a2a.MethodTaskSubscribe, status, systemName, time.Since(start).Seconds())
 	}()
 
 	paramsBytes, err := json.Marshal(req.Params)
@@ -348,7 +356,13 @@ func (s *Server) handleA2ATaskSubscribe(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	system := agentName
+	if params.ID == "" {
+		status = "error"
+		writeA2AError(w, req.ID, a2a.ErrCodeInvalidParams, "task id is required")
+		return
+	}
+
+	system := strings.TrimSpace(systemName)
 	if system == "" && params.Metadata != nil {
 		if agent, ok := params.Metadata["agent"]; ok {
 			system = agent
@@ -357,14 +371,35 @@ func (s *Server) handleA2ATaskSubscribe(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 	if system == "" {
-		agents, err := s.stores.Agents.List(r.Context())
-		if err == nil && len(agents) == 1 {
-			system = agents[0].Metadata.Name
+		defaultSystem, ok, err := s.defaultA2ASystem(r)
+		if err != nil {
+			status = "error"
+			writeA2AError(w, req.ID, a2a.ErrCodeInternal, "failed to resolve target agentsystem")
+			return
+		}
+		if ok {
+			system = defaultSystem.Metadata.Name
 		}
 	}
 	if system == "" {
 		status = "error"
-		writeA2AError(w, req.ID, a2a.ErrCodeInvalidParams, "target agent required")
+		writeA2AError(w, req.ID, a2a.ErrCodeInvalidParams, "target AgentSystem required")
+		return
+	}
+
+	target, ok, err := s.a2aEnabledSystemByName(r, system)
+	if err != nil {
+		status = "error"
+		writeA2AError(w, req.ID, a2a.ErrCodeInternal, "failed to resolve target agentsystem")
+		return
+	}
+	if !ok {
+		status = "error"
+		writeA2AError(w, req.ID, a2a.ErrCodeAgentNotFound, "target AgentSystem is not A2A-enabled")
+		return
+	}
+	if !a2aAuthorizeInvoke(w, r, req.ID, target) {
+		status = "error"
 		return
 	}
 
@@ -394,8 +429,9 @@ func (s *Server) handleA2ATaskSubscribe(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	namespace := resolveNamespace(r)
-	task := a2a.CreateOrlojTaskFromA2A(params, system, namespace)
+	namespace := resources.NormalizeNamespace(target.Metadata.Namespace)
+	task := a2a.CreateOrlojTaskFromA2A(params, target.Metadata.Name, namespace)
+	task.Metadata.Name = a2aInternalTaskName(target, params.ID)
 
 	if _, err := s.stores.Tasks.Upsert(r.Context(), task); err != nil {
 		status = "error"
@@ -407,11 +443,14 @@ func (s *Server) handleA2ATaskSubscribe(w http.ResponseWriter, r *http.Request, 
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
-	telemetry.A2AActiveSubscriptions.WithLabelValues(agentName).Inc()
-	defer telemetry.A2AActiveSubscriptions.WithLabelValues(agentName).Dec()
+	telemetry.A2AActiveSubscriptions.WithLabelValues(target.Metadata.Name).Inc()
+	defer telemetry.A2AActiveSubscriptions.WithLabelValues(target.Metadata.Name).Dec()
 
 	initialResult := a2a.OrlojTaskToA2AResult(task)
-	sendSSEEvent(w, flusher, "status", initialResult)
+	if sendSSEEvent(w, flusher, "status", initialResult) != nil {
+		status = "client_disconnected"
+		return
+	}
 
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
@@ -422,9 +461,13 @@ func (s *Server) handleA2ATaskSubscribe(w http.ResponseWriter, r *http.Request, 
 	for {
 		select {
 		case <-r.Context().Done():
+			status = "client_disconnected"
 			return
 		case <-heartbeat.C:
-			fmt.Fprintf(w, ": heartbeat\n\n")
+			if _, err := fmt.Fprintf(w, ": heartbeat\n\n"); err != nil {
+				status = "client_disconnected"
+				return
+			}
 			flusher.Flush()
 		case <-ticker.C:
 			current, ok, err := s.stores.Tasks.Get(r.Context(), taskKey)
@@ -432,7 +475,10 @@ func (s *Server) handleA2ATaskSubscribe(w http.ResponseWriter, r *http.Request, 
 				return
 			}
 			result := a2a.OrlojTaskToA2AResult(current)
-			sendSSEEvent(w, flusher, "status", result)
+			if sendSSEEvent(w, flusher, "status", result) != nil {
+				status = "client_disconnected"
+				return
+			}
 			if a2a.IsTerminal(result.Status.State) {
 				return
 			}
@@ -446,33 +492,38 @@ func (s *Server) handleA2ARegistry(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if s.a2aConfig == nil || !s.a2aConfig.Enabled {
-		http.Error(w, "A2A protocol is not enabled", http.StatusNotFound)
-		return
-	}
-
 	var localCards []a2a.AgentCard
 
-	agents, err := s.stores.Agents.List(r.Context())
-	if err == nil {
+	systems, err := s.a2aEnabledSystems(r)
+	if err != nil {
+		http.Error(w, "failed to list agent systems", http.StatusInternalServerError)
+		return
+	}
+	if len(systems) > 0 {
+		agents, _ := s.stores.Agents.List(r.Context())
 		tools, _ := s.stores.Tools.List(r.Context())
-		config := s.buildCardConfig()
-		for _, agent := range agents {
-			var agentTools []resources.Tool
-			for _, t := range tools {
-				for _, tn := range agent.Spec.Tools {
-					if t.Metadata.Name == tn {
-						agentTools = append(agentTools, t)
-					}
-				}
+
+		identity, hasIdentity := AuthIdentityFromRequest(r)
+		unauthenticated := !hasIdentity || (strings.EqualFold(identity.Method, "none") && !identity.AuthDisabled)
+
+		for _, system := range systems {
+			if unauthenticated && system.Spec.A2A.Auth != resources.A2AAuthPublic {
+				continue
 			}
-			card := a2a.GenerateAgentCard(agent, agentTools, config)
+			if !unauthenticated && !a2aIdentityAllowsSystem(r, system) && system.Spec.A2A.Auth != resources.A2AAuthPublic {
+				continue
+			}
+			config := s.buildCardConfig(system.Metadata.Namespace)
+			if system.Spec.A2A.Auth == resources.A2AAuthPublic {
+				config.AuthSchemes = nil
+			}
+			card := a2a.GenerateSystemCard(system, agentsForSystem(system, agents), tools, config)
 			localCards = append(localCards, card)
 		}
 	}
 
 	var remoteAgents []a2a.RemoteAgentEntry
-	if s.a2aConfig.Registry != nil {
+	if s.a2aConfig != nil && s.a2aConfig.Registry != nil {
 		remoteAgents = s.a2aConfig.Registry.List()
 	}
 
@@ -484,47 +535,217 @@ func (s *Server) handleA2ARegistry(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (s *Server) buildCardConfig() a2a.CardGeneratorConfig {
+func (s *Server) buildCardConfig(namespace string) a2a.CardGeneratorConfig {
 	if s.a2aConfig == nil {
-		return a2a.CardGeneratorConfig{}
+		return a2a.CardGeneratorConfig{Namespace: resources.NormalizeNamespace(namespace)}
 	}
 	return a2a.CardGeneratorConfig{
 		PublicBaseURL:    s.a2aConfig.PublicBaseURL,
-		ProtocolVersion: s.a2aConfig.ProtocolVersion,
+		ProtocolVersion:  s.a2aConfig.ProtocolVersion,
 		StreamingEnabled: s.a2aConfig.StreamingEnabled,
-		AuthSchemes:     s.a2aConfig.AuthSchemes,
+		AuthSchemes:      s.a2aConfig.AuthSchemes,
+		Namespace:        resources.NormalizeNamespace(namespace),
 	}
 }
 
-func (s *Server) findTaskByA2AID(r *http.Request, a2aTaskID string) (resources.Task, error) {
+func (s *Server) a2aEnabledSystems(r *http.Request) ([]resources.AgentSystem, error) {
+	systems, err := s.stores.AgentSystems.List(r.Context())
+	if err != nil {
+		return nil, err
+	}
+	namespace := requestNamespace(r)
+	out := make([]resources.AgentSystem, 0, len(systems))
+	for _, system := range systems {
+		if !system.Spec.A2A.Enabled {
+			continue
+		}
+		if !strings.EqualFold(resources.NormalizeNamespace(system.Metadata.Namespace), namespace) {
+			continue
+		}
+		out = append(out, system)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return store.ScopedName(out[i].Metadata.Namespace, out[i].Metadata.Name) < store.ScopedName(out[j].Metadata.Namespace, out[j].Metadata.Name)
+	})
+	return out, nil
+}
+
+func (s *Server) a2aEnabledSystemByName(r *http.Request, name string) (resources.AgentSystem, bool, error) {
+	ref := scopedNameForRequest(r, name)
+	if strings.Contains(strings.TrimSpace(name), "/") {
+		parts := strings.SplitN(strings.TrimSpace(name), "/", 2)
+		ref = store.ScopedName(parts[0], parts[1])
+	}
+	system, ok, err := s.stores.AgentSystems.Get(r.Context(), ref)
+	if err != nil || !ok {
+		return resources.AgentSystem{}, false, err
+	}
+	if !system.Spec.A2A.Enabled {
+		return resources.AgentSystem{}, false, nil
+	}
+	return system, true, nil
+}
+
+func (s *Server) defaultA2ASystem(r *http.Request) (resources.AgentSystem, bool, error) {
+	systems, err := s.a2aEnabledSystems(r)
+	if err != nil || len(systems) != 1 {
+		return resources.AgentSystem{}, false, err
+	}
+	return systems[0], true, nil
+}
+
+func agentsForSystem(system resources.AgentSystem, agents []resources.Agent) []resources.Agent {
+	agentsByName := make(map[string]resources.Agent, len(agents))
+	for _, agent := range agents {
+		agentsByName[store.ScopedName(agent.Metadata.Namespace, agent.Metadata.Name)] = agent
+	}
+	out := make([]resources.Agent, 0, len(system.Spec.Agents))
+	for _, agentName := range system.Spec.Agents {
+		key := store.ScopedName(system.Metadata.Namespace, agentName)
+		if agent, ok := agentsByName[key]; ok {
+			out = append(out, agent)
+			continue
+		}
+		key = store.ScopedName(resources.DefaultNamespace, agentName)
+		if agent, ok := agentsByName[key]; ok {
+			out = append(out, agent)
+		}
+	}
+	return out
+}
+
+// a2aAuthorizeInvoke is the single centralized auth gate for A2A invoke.
+// It checks the system's auth policy and, for bearer-required systems,
+// validates the caller's identity and scope. Returns true if the request
+// is authorized; writes an appropriate JSON-RPC error and returns false
+// otherwise.
+func a2aAuthorizeInvoke(w http.ResponseWriter, r *http.Request, reqID any, system resources.AgentSystem) bool {
+	if system.Spec.A2A.Auth == resources.A2AAuthPublic {
+		return true
+	}
+	identity, ok := AuthIdentityFromRequest(r)
+	if !ok {
+		writeA2AError(w, reqID, a2a.ErrCodeAgentNotFound, "target AgentSystem is not available")
+		return false
+	}
+	if identity.AuthDisabled {
+		return true
+	}
+	if strings.EqualFold(identity.Method, "none") {
+		writeA2AError(w, reqID, a2a.ErrCodeAgentNotFound, "target AgentSystem is not available")
+		return false
+	}
+	if !strings.EqualFold(identity.Method, "bearer") {
+		writeA2AError(w, reqID, a2a.ErrCodeAgentNotFound, "target AgentSystem is not available")
+		return false
+	}
+	if !a2aIdentityAllowsSystem(r, system) {
+		writeA2AError(w, reqID, a2a.ErrCodeAgentNotFound, "target AgentSystem is not available")
+		return false
+	}
+	return true
+}
+
+func a2aIdentityAllowsSystem(r *http.Request, system resources.AgentSystem) bool {
+	identity, ok := AuthIdentityFromRequest(r)
+	if !ok {
+		return system.Spec.A2A.Auth == resources.A2AAuthPublic
+	}
+	if strings.EqualFold(identity.Method, "none") {
+		return identity.AuthDisabled || system.Spec.A2A.Auth == resources.A2AAuthPublic
+	}
+	if strings.EqualFold(identity.Role, "admin") || strings.EqualFold(identity.Role, "writer") {
+		return true
+	}
+	if !strings.EqualFold(identity.Role, "a2a") {
+		return false
+	}
+	target := strings.ToLower(store.ScopedName(system.Metadata.Namespace, system.Metadata.Name))
+	for _, allowed := range normalizeA2AAgentSystemRefs(identity.A2AAgentSystems) {
+		if strings.ToLower(allowed) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Server) a2aIdentityAllowsTask(r *http.Request, task resources.Task) bool {
+	system, ok, err := s.stores.AgentSystems.Get(r.Context(), store.ScopedName(task.Metadata.Namespace, task.Spec.System))
+	if err != nil || !ok || !system.Spec.A2A.Enabled {
+		return false
+	}
+	if system.Spec.A2A.Auth == resources.A2AAuthPublic {
+		return true
+	}
+	return a2aIdentityAllowsSystem(r, system)
+}
+
+func a2aInternalTaskName(system resources.AgentSystem, externalID string) string {
+	ref := store.ScopedName(system.Metadata.Namespace, system.Metadata.Name)
+	sum := sha256.Sum256([]byte(ref + "\x00" + externalID))
+	suffix := sanitizeA2ANamePart(externalID)
+	if suffix == "" {
+		suffix = "task"
+	}
+	if len(suffix) > 48 {
+		suffix = suffix[:48]
+	}
+	return fmt.Sprintf("a2a-%x-%s", sum[:6], suffix)
+}
+
+func sanitizeA2ANamePart(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func (s *Server) findTaskByA2AID(r *http.Request, a2aTaskID string, systemFilter ...string) (resources.Task, error) {
 	tasks, err := s.stores.Tasks.List(r.Context())
 	if err != nil {
 		return resources.Task{}, err
 	}
+	filter := ""
+	if len(systemFilter) > 0 {
+		filter = strings.TrimSpace(systemFilter[0])
+	}
 	for _, task := range tasks {
 		if task.Metadata.Labels != nil && task.Metadata.Labels[a2a.LabelA2ATaskID] == a2aTaskID {
-			return task, nil
+			if filter != "" && task.Spec.System != filter {
+				continue
+			}
+			if s.a2aIdentityAllowsTask(r, task) {
+				return task, nil
+			}
 		}
 	}
 	return resources.Task{}, fmt.Errorf("task not found")
 }
 
-func extractAgentNameFromCardPath(path string) string {
-	path = strings.TrimPrefix(path, "/v1/agents/")
-	parts := strings.SplitN(path, "/", 2)
-	if len(parts) > 0 {
-		return strings.TrimSpace(parts[0])
-	}
-	return ""
-}
-
-func extractAgentNameFromA2APath(path string) string {
-	if !strings.HasPrefix(path, "/v1/agents/") {
-		return ""
-	}
-	path = strings.TrimPrefix(path, "/v1/agents/")
-	if idx := strings.Index(path, "/a2a"); idx >= 0 {
-		return strings.TrimSpace(path[:idx])
+func extractA2ASystemNameFromPath(path string) string {
+	for _, prefix := range []string{"/v1/agent-systems/", "/v1/agents/"} {
+		if strings.HasPrefix(path, prefix) {
+			path = strings.TrimPrefix(path, prefix)
+			parts := strings.SplitN(path, "/", 2)
+			if len(parts) > 0 {
+				if decoded, err := url.PathUnescape(parts[0]); err == nil {
+					return strings.TrimSpace(decoded)
+				}
+				return strings.TrimSpace(parts[0])
+			}
+		}
 	}
 	return ""
 }
@@ -560,11 +781,14 @@ func writeA2AResult(w http.ResponseWriter, id any, result any) {
 	json.NewEncoder(w).Encode(resp)
 }
 
-func sendSSEEvent(w http.ResponseWriter, flusher http.Flusher, eventType string, data any) {
+func sendSSEEvent(w http.ResponseWriter, flusher http.Flusher, eventType string, data any) error {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		return
+		return err
 	}
-	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, string(jsonData))
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, string(jsonData)); err != nil {
+		return err
+	}
 	flusher.Flush()
+	return nil
 }

--- a/api/a2a_test.go
+++ b/api/a2a_test.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/OrlojHQ/orloj/api"
@@ -34,8 +36,7 @@ func newA2ATestServer(t *testing.T, enabled bool) (*httptest.Server, api.Stores)
 	server := api.NewServerWithOptions(stores, agentruntime.NewManager(logger), logger, api.ServerOptions{})
 	if enabled {
 		server.SetA2AConfig(&api.A2AConfig{
-			Enabled:          true,
-			PublicBaseURL:     "https://test.example.com",
+			PublicBaseURL:    "https://test.example.com",
 			ProtocolVersion:  "1.0",
 			StreamingEnabled: true,
 			AuthSchemes:      []string{"bearer"},
@@ -46,12 +47,17 @@ func newA2ATestServer(t *testing.T, enabled bool) (*httptest.Server, api.Stores)
 
 func seedAgent(t *testing.T, stores api.Stores, name, prompt string, tools []string) {
 	t.Helper()
+	seedAgentInNamespace(t, stores, "default", name, prompt, tools)
+}
+
+func seedAgentInNamespace(t *testing.T, stores api.Stores, namespace, name, prompt string, tools []string) {
+	t.Helper()
 	agent := resources.Agent{
 		APIVersion: "orloj.dev/v1",
 		Kind:       "Agent",
 		Metadata: resources.ObjectMeta{
 			Name:      name,
-			Namespace: "default",
+			Namespace: namespace,
 			Annotations: map[string]string{
 				"orloj.dev/description": "Test agent " + name,
 			},
@@ -64,6 +70,24 @@ func seedAgent(t *testing.T, stores api.Stores, name, prompt string, tools []str
 	}
 	if _, err := stores.Agents.Upsert(context.Background(), agent); err != nil {
 		t.Fatalf("failed to seed agent %s: %v", name, err)
+	}
+	system := resources.AgentSystem{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "AgentSystem",
+		Metadata: resources.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"orloj.dev/description": "Test agent " + name,
+			},
+		},
+		Spec: resources.AgentSystemSpec{
+			Agents: []string{name},
+			A2A:    resources.AgentSystemA2ASpec{Enabled: true},
+		},
+	}
+	if _, err := stores.AgentSystems.Upsert(context.Background(), system); err != nil {
+		t.Fatalf("failed to seed agentsystem %s: %v", name, err)
 	}
 }
 
@@ -88,6 +112,11 @@ func seedTool(t *testing.T, stores api.Stores, name, description string) {
 
 func postA2AJSONRPC(t *testing.T, url, method string, params any) *http.Response {
 	t.Helper()
+	return postA2AJSONRPCWithToken(t, url, method, params, "")
+}
+
+func postA2AJSONRPCWithToken(t *testing.T, url, method string, params any, token string) *http.Response {
+	t.Helper()
 	rpcReq := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -98,11 +127,104 @@ func postA2AJSONRPC(t *testing.T, url, method string, params any) *http.Response
 	if err != nil {
 		t.Fatalf("marshal JSON-RPC request: %v", err)
 	}
-	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new POST %s failed: %v", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("POST %s failed: %v", url, err)
 	}
 	return resp
+}
+
+func newA2AAuthTestServer(t *testing.T) (*httptest.Server, api.Stores) {
+	t.Helper()
+	t.Setenv("ORLOJ_API_TOKENS", "client:client-token:a2a:default/allowed|team/allowed,writer:writer-token:writer")
+	t.Setenv("ORLOJ_API_TOKEN", "")
+	logger := log.New(io.Discard, "", 0)
+	stores := api.Stores{
+		Agents:       store.NewAgentStore(),
+		AgentSystems: store.NewAgentSystemStore(),
+		Tools:        store.NewToolStore(),
+		Tasks:        store.NewTaskStore(),
+		Workers:      store.NewWorkerStore(),
+		Memories:     store.NewMemoryStore(),
+		Policies:     store.NewAgentPolicyStore(),
+	}
+	server := api.NewServerWithOptions(stores, agentruntime.NewManager(logger), logger, api.ServerOptions{})
+	server.SetA2AConfig(&api.A2AConfig{
+		PublicBaseURL:    "https://test.example.com",
+		ProtocolVersion:  "1.0",
+		StreamingEnabled: true,
+		AuthSchemes:      []string{"bearer"},
+	})
+	return httptest.NewServer(server.Handler()), stores
+}
+
+// newA2AExplicitAuthModeOffTestServer mirrors orlojd with --auth-mode=off set
+// explicitly. Token auth must stay active when env or DB tokens are configured.
+// Callers must configure ORLOJ_API_TOKEN / ORLOJ_API_TOKENS before invoking.
+func newA2AExplicitAuthModeOffTestServer(t *testing.T) (*httptest.Server, api.Stores) {
+	t.Helper()
+	logger := log.New(io.Discard, "", 0)
+	stores := api.Stores{
+		Agents:       store.NewAgentStore(),
+		AgentSystems: store.NewAgentSystemStore(),
+		Tools:        store.NewToolStore(),
+		Tasks:        store.NewTaskStore(),
+		Workers:      store.NewWorkerStore(),
+		Memories:     store.NewMemoryStore(),
+		Policies:     store.NewAgentPolicyStore(),
+		APITokens:    store.NewAPITokenStore(),
+	}
+	server := api.NewServerWithOptions(stores, agentruntime.NewManager(logger), logger, api.ServerOptions{
+		AuthMode: api.AuthModeOff,
+	})
+	server.SetA2AConfig(&api.A2AConfig{
+		PublicBaseURL:    "https://test.example.com",
+		ProtocolVersion:  "1.0",
+		StreamingEnabled: true,
+		AuthSchemes:      []string{"bearer"},
+	})
+	return httptest.NewServer(server.Handler()), stores
+}
+
+func newA2ANativeAuthTestServer(t *testing.T) (*httptest.Server, api.Stores) {
+	t.Helper()
+	t.Setenv("ORLOJ_API_TOKENS", "")
+	t.Setenv("ORLOJ_API_TOKEN", "")
+	logger := log.New(io.Discard, "", 0)
+	stores := api.Stores{
+		Agents:       store.NewAgentStore(),
+		AgentSystems: store.NewAgentSystemStore(),
+		Tools:        store.NewToolStore(),
+		Tasks:        store.NewTaskStore(),
+		Workers:      store.NewWorkerStore(),
+		Memories:     store.NewMemoryStore(),
+		Policies:     store.NewAgentPolicyStore(),
+		LocalAdmins:  store.NewLocalAdminStore(),
+		AuthSessions: store.NewAuthSessionStore(),
+	}
+	hash, err := store.GeneratePasswordHash("very-strong-pass")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	if _, err := stores.LocalAdmins.CreateUser("admin", hash, "admin"); err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+	server := api.NewServerWithOptions(stores, agentruntime.NewManager(logger), logger, api.ServerOptions{AuthMode: api.AuthModeNative})
+	server.SetA2AConfig(&api.A2AConfig{
+		PublicBaseURL:    "https://test.example.com",
+		ProtocolVersion:  "1.0",
+		StreamingEnabled: true,
+		AuthSchemes:      []string{"bearer"},
+	})
+	return httptest.NewServer(server.Handler()), stores
 }
 
 type jsonrpcResponse struct {
@@ -180,7 +302,7 @@ func TestWellKnownAgentCard_EnabledReturnsCard(t *testing.T) {
 	if len(card.Skills) != 1 || card.Skills[0].ID != "search" {
 		t.Errorf("expected 1 skill 'search', got %+v", card.Skills)
 	}
-	if card.URL != "https://test.example.com/v1/agents/assistant/a2a" {
+	if card.URL != "https://test.example.com/v1/agent-systems/assistant/a2a" {
 		t.Errorf("unexpected card URL: %s", card.URL)
 	}
 }
@@ -265,8 +387,8 @@ func TestA2AJSONRPC_DisabledReturnsError(t *testing.T) {
 	if rpcResp.Error == nil {
 		t.Fatal("expected error when A2A disabled")
 	}
-	if rpcResp.Error.Code != a2a.ErrCodeInternal {
-		t.Errorf("expected error code %d, got %d", a2a.ErrCodeInternal, rpcResp.Error.Code)
+	if rpcResp.Error.Code != a2a.ErrCodeInvalidParams {
+		t.Errorf("expected error code %d, got %d", a2a.ErrCodeInvalidParams, rpcResp.Error.Code)
 	}
 }
 
@@ -566,7 +688,7 @@ func TestA2AJSONRPC_GETMethodNotAllowed(t *testing.T) {
 
 // --- Registry endpoint ---
 
-func TestA2ARegistry_DisabledReturns404(t *testing.T) {
+func TestA2ARegistry_NoEnabledSystemsReturnsEmptyList(t *testing.T) {
 	ts, _ := newA2ATestServer(t, false)
 	defer ts.Close()
 
@@ -575,8 +697,15 @@ func TestA2ARegistry_DisabledReturns404(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var registry a2a.RegistryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&registry); err != nil {
+		t.Fatalf("decode registry: %v", err)
+	}
+	if len(registry.LocalAgents) != 0 {
+		t.Fatalf("expected no local agents, got %d", len(registry.LocalAgents))
 	}
 }
 
@@ -628,8 +757,9 @@ func TestA2ARegistry_EnabledReturnsLocalCardsAndEmptyRemote(t *testing.T) {
 // --- Capabilities ---
 
 func TestCapabilities_A2AEnabledIncludesA2AEntries(t *testing.T) {
-	ts, _ := newA2ATestServer(t, true)
+	ts, stores := newA2ATestServer(t, true)
 	defer ts.Close()
+	seedAgent(t, stores, "capability-system", "capability test", nil)
 
 	resp, err := http.Get(ts.URL + "/v1/capabilities")
 	if err != nil {
@@ -713,6 +843,706 @@ func TestA2AJSONRPC_TaskSendWithoutTargetSingleAgentDefault(t *testing.T) {
 	}
 }
 
+func TestA2AJSONRPC_ScopedTokenCanOnlyInvokeAllowedSystem(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "allowed", "allowed system", nil)
+	seedAgent(t, stores, "blocked", "blocked system", nil)
+
+	params := map[string]any{
+		"id": "task-scoped",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	resp := postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/send", params, "client-token")
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("expected allowed system invocation to succeed, got %+v", rpcResp.Error)
+	}
+
+	resp = postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/blocked/a2a", "tasks/send", params, "client-token")
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error == nil {
+		t.Fatal("expected scoped token to be denied for blocked system")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/tools", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer client-token")
+	toolsResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer toolsResp.Body.Close()
+	if toolsResp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(toolsResp.Body)
+		t.Fatalf("expected a2a token GET /v1/tools to be forbidden, got %d: %s", toolsResp.StatusCode, body)
+	}
+}
+
+func TestA2AJSONRPC_TaskSendMetadataTargetCanUseScopedSystem(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgentInNamespace(t, stores, "team", "allowed", "allowed team system", nil)
+
+	params := map[string]any{
+		"id": "task-team-scoped",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+		"metadata": map[string]string{"target": "team/allowed"},
+	}
+
+	resp := postA2AJSONRPCWithToken(t, ts.URL+"/a2a", "tasks/send", params, "client-token")
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("expected scoped metadata target invocation to succeed, got %+v", rpcResp.Error)
+	}
+
+	tasks, err := stores.Tasks.List(context.Background())
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task in store, got %d", len(tasks))
+	}
+	if tasks[0].Metadata.Namespace != "team" {
+		t.Fatalf("expected task namespace team, got %q", tasks[0].Metadata.Namespace)
+	}
+	if tasks[0].Spec.System != "allowed" {
+		t.Fatalf("expected task system allowed, got %q", tasks[0].Spec.System)
+	}
+}
+
+func TestA2ARegistry_WithAuthFiltersScope(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "allowed", "allowed system", nil)
+	seedAgent(t, stores, "blocked", "blocked system", nil)
+
+	// Unauthenticated: sees no systems (none are public)
+	resp, err := http.Get(ts.URL + "/v1/a2a/agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected unauthenticated registry request to get 200, got %d: %s", resp.StatusCode, body)
+	}
+	var unauthRegistry a2a.RegistryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&unauthRegistry); err != nil {
+		t.Fatalf("decode registry: %v", err)
+	}
+	if len(unauthRegistry.LocalAgents) != 0 {
+		t.Fatalf("expected unauthenticated registry to show 0 systems, got %d", len(unauthRegistry.LocalAgents))
+	}
+
+	// Scoped token: sees only allowed system
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/a2a/agents", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer client-token")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("expected scoped registry request to get 200, got %d: %s", resp2.StatusCode, body)
+	}
+	var registry a2a.RegistryResponse
+	if err := json.NewDecoder(resp2.Body).Decode(&registry); err != nil {
+		t.Fatalf("decode registry: %v", err)
+	}
+	if len(registry.LocalAgents) != 1 || registry.LocalAgents[0].Name != "allowed" {
+		t.Fatalf("expected registry to include only allowed system, got %+v", registry.LocalAgents)
+	}
+}
+
+func TestA2AJSONRPC_NativeSessionCookieRejected(t *testing.T) {
+	ts, stores := newA2ANativeAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "native-system", "native system", nil)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+	loginBody := []byte(`{"username":"admin","password":"very-strong-pass"}`)
+	resp, err := client.Post(ts.URL+"/v1/auth/login", "application/json", bytes.NewReader(loginBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected login 200, got %d", resp.StatusCode)
+	}
+
+	rpcReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  a2a.MethodTaskSend,
+		"params": map[string]any{
+			"id": "session-task",
+			"message": map[string]any{
+				"role":  "user",
+				"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+			},
+		},
+	}
+	body, err := json.Marshal(rpcReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/agent-systems/native-system/a2a", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected native session A2A request to be rejected with 401, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func seedPublicAgent(t *testing.T, stores api.Stores, name, prompt string) {
+	t.Helper()
+	agent := resources.Agent{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "Agent",
+		Metadata: resources.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Annotations: map[string]string{
+				"orloj.dev/description": "Test agent " + name,
+			},
+		},
+		Spec: resources.AgentSpec{
+			ModelRef: "test-model",
+			Prompt:   prompt,
+		},
+	}
+	if _, err := stores.Agents.Upsert(context.Background(), agent); err != nil {
+		t.Fatalf("failed to seed agent %s: %v", name, err)
+	}
+	system := resources.AgentSystem{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "AgentSystem",
+		Metadata: resources.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Annotations: map[string]string{
+				"orloj.dev/description": "Test agent " + name,
+			},
+		},
+		Spec: resources.AgentSystemSpec{
+			Agents: []string{name},
+			A2A:    resources.AgentSystemA2ASpec{Enabled: true, Auth: resources.A2AAuthPublic},
+		},
+	}
+	if _, err := stores.AgentSystems.Upsert(context.Background(), system); err != nil {
+		t.Fatalf("failed to seed agentsystem %s: %v", name, err)
+	}
+}
+
+func TestA2A_PublicSystemInvokeWithoutToken(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedPublicAgent(t, stores, "public-sys", "public system")
+
+	params := map[string]any{
+		"id": "task-public",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	// No token — should succeed because system is public
+	resp := postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/public-sys/a2a", "tasks/send", params)
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("expected public system invoke without token to succeed, got %+v", rpcResp.Error)
+	}
+}
+
+func TestA2A_PublicSystemInvokeWithValidToken(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedPublicAgent(t, stores, "public-sys", "public system")
+
+	params := map[string]any{
+		"id": "task-public-auth",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	// Valid token — should also succeed
+	resp := postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/public-sys/a2a", "tasks/send", params, "writer-token")
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("expected public system invoke with valid token to succeed, got %+v", rpcResp.Error)
+	}
+}
+
+func TestA2A_PublicSystemInvokeWithInvalidToken(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedPublicAgent(t, stores, "public-sys", "public system")
+
+	params := map[string]any{
+		"id": "task-bad-token",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	// Bad token — should be rejected at middleware (401)
+	resp := postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/public-sys/a2a", "tasks/send", params, "bad-token-xyz")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected invalid token to get 401, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestA2A_BearerSystemInvokeWithoutTokenDenied(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "bearer-sys", "bearer system", nil)
+
+	params := map[string]any{
+		"id": "task-bearer-notoken",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	// No token on a bearer-required system — denied via JSON-RPC error
+	resp := postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/bearer-sys/a2a", "tasks/send", params)
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error == nil {
+		t.Fatal("expected bearer system invoke without token to be denied")
+	}
+}
+
+func TestA2A_MixedPublicAndBearerSystems(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedPublicAgent(t, stores, "open-sys", "open system")
+	seedAgent(t, stores, "allowed", "bearer system", nil)
+
+	params := map[string]any{
+		"id": "task-mixed",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	// Public system — no token needed
+	resp := postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/open-sys/a2a", "tasks/send", params)
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("public system invoke failed: %+v", rpcResp.Error)
+	}
+
+	// Bearer system — no token → denied
+	params["id"] = "task-mixed-bearer"
+	resp = postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/send", params)
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error == nil {
+		t.Fatal("expected bearer system invoke without token to be denied")
+	}
+
+	// Bearer system — scoped token → succeeds
+	params["id"] = "task-mixed-bearer-auth"
+	resp = postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/send", params, "client-token")
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("bearer system invoke with valid token failed: %+v", rpcResp.Error)
+	}
+}
+
+func TestA2A_BearerGetDeniedWithoutToken(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "allowed", "bearer system", nil)
+
+	sendParams := map[string]any{
+		"id": "task-bearer-get-auth",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	resp := postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/send", sendParams, "client-token")
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("send with valid token failed: %+v", rpcResp.Error)
+	}
+
+	getParams := map[string]any{"id": "task-bearer-get-auth"}
+	resp = postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/get", getParams)
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error == nil {
+		t.Fatal("expected bearer system get without token to be denied")
+	}
+	if rpcResp.Error.Code != a2a.ErrCodeTaskNotFound {
+		t.Errorf("expected error code %d (TaskNotFound), got %d", a2a.ErrCodeTaskNotFound, rpcResp.Error.Code)
+	}
+}
+
+func TestA2A_BearerCancelDeniedWithoutToken(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "allowed", "bearer system", nil)
+
+	sendParams := map[string]any{
+		"id": "task-bearer-cancel-auth",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	resp := postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/send", sendParams, "client-token")
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("send with valid token failed: %+v", rpcResp.Error)
+	}
+
+	cancelParams := map[string]any{"id": "task-bearer-cancel-auth", "reason": "test"}
+	resp = postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/cancel", cancelParams)
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error == nil {
+		t.Fatal("expected bearer system cancel without token to be denied")
+	}
+	if rpcResp.Error.Code != a2a.ErrCodeTaskNotFound {
+		t.Errorf("expected error code %d (TaskNotFound), got %d", a2a.ErrCodeTaskNotFound, rpcResp.Error.Code)
+	}
+}
+
+func TestA2A_BearerGetAllowedWithScopedToken(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "allowed", "bearer system", nil)
+
+	sendParams := map[string]any{
+		"id": "task-bearer-get-scoped",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	resp := postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/send", sendParams, "client-token")
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("send with valid token failed: %+v", rpcResp.Error)
+	}
+
+	getParams := map[string]any{"id": "task-bearer-get-scoped"}
+	resp = postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/get", getParams, "client-token")
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("get with valid scoped token failed: %+v", rpcResp.Error)
+	}
+
+	var result a2a.TaskResult
+	if err := json.Unmarshal(rpcResp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.ID != "task-bearer-get-scoped" {
+		t.Errorf("expected task ID 'task-bearer-get-scoped', got %q", result.ID)
+	}
+}
+
+func TestA2A_PublicGetAllowedWithoutToken(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedPublicAgent(t, stores, "public-get-sys", "public system")
+
+	sendParams := map[string]any{
+		"id": "task-public-get",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	resp := postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/public-get-sys/a2a", "tasks/send", sendParams)
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("public send failed: %+v", rpcResp.Error)
+	}
+
+	getParams := map[string]any{"id": "task-public-get"}
+	resp = postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/public-get-sys/a2a", "tasks/get", getParams)
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("public get without token failed: %+v", rpcResp.Error)
+	}
+}
+
+// Regression: with auth-mode explicitly off (orlojd default), env/DB tokens must
+// still be resolved for A2A invoke — otherwise bearer systems reject all callers.
+func TestA2A_ExplicitAuthModeOff_BearerInvokeRequiresTokenResolution(t *testing.T) {
+	taskParams := map[string]any{
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	t.Run("env scoped token", func(t *testing.T) {
+		t.Setenv("ORLOJ_API_TOKENS", "lessee:lessee-token:a2a:default/premium")
+		t.Setenv("ORLOJ_API_TOKEN", "")
+
+		ts, stores := newA2AExplicitAuthModeOffTestServer(t)
+		defer ts.Close()
+		seedAgent(t, stores, "premium", "premium bearer system", nil)
+
+		params := copyA2ATaskParams(taskParams, "task-env-notoken")
+		resp := postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/premium/a2a", "tasks/send", params)
+		rpcResp := decodeJSONRPCResponse(t, resp)
+		if rpcResp.Error == nil {
+			t.Fatal("expected bearer system invoke without token to be denied")
+		}
+
+		params = copyA2ATaskParams(taskParams, "task-env-scoped")
+		resp = postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/premium/a2a", "tasks/send", params, "lessee-token")
+		rpcResp = decodeJSONRPCResponse(t, resp)
+		if rpcResp.Error != nil {
+			t.Fatalf("expected scoped env token invoke to succeed, got %+v", rpcResp.Error)
+		}
+	})
+
+	t.Run("db minted token", func(t *testing.T) {
+		t.Setenv("ORLOJ_API_TOKENS", "")
+		t.Setenv("ORLOJ_API_TOKEN", "ops-admin-token")
+
+		ts, stores := newA2AExplicitAuthModeOffTestServer(t)
+		defer ts.Close()
+		seedAgent(t, stores, "premium", "premium bearer system", nil)
+
+		createBody := []byte(`{"name":"lessee-db","role":"a2a","a2a_agent_systems":["premium"]}`)
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", bytes.NewReader(createBody))
+		if err != nil {
+			t.Fatalf("build mint request: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer ops-admin-token")
+		req.Header.Set("Content-Type", "application/json")
+		mintResp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("mint token request failed: %v", err)
+		}
+		if mintResp.StatusCode != http.StatusCreated {
+			body, _ := io.ReadAll(mintResp.Body)
+			mintResp.Body.Close()
+			t.Fatalf("expected 201 mint token, got %d: %s", mintResp.StatusCode, body)
+		}
+		var minted map[string]any
+		if err := json.NewDecoder(mintResp.Body).Decode(&minted); err != nil {
+			mintResp.Body.Close()
+			t.Fatalf("decode mint response: %v", err)
+		}
+		mintResp.Body.Close()
+		subscriptionToken, _ := minted["token"].(string)
+		if strings.TrimSpace(subscriptionToken) == "" {
+			t.Fatal("expected subscription token secret in mint response")
+		}
+
+		params := copyA2ATaskParams(taskParams, "task-db-notoken")
+		resp := postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/premium/a2a", "tasks/send", params)
+		rpcResp := decodeJSONRPCResponse(t, resp)
+		if rpcResp.Error == nil {
+			t.Fatal("expected bearer system invoke without token to be denied")
+		}
+
+		params = copyA2ATaskParams(taskParams, "task-db-scoped")
+		resp = postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/premium/a2a", "tasks/send", params, subscriptionToken)
+		rpcResp = decodeJSONRPCResponse(t, resp)
+		if rpcResp.Error != nil {
+			t.Fatalf("expected DB-minted scoped token invoke to succeed, got %+v", rpcResp.Error)
+		}
+	})
+}
+
+func copyA2ATaskParams(base map[string]any, taskID string) map[string]any {
+	out := make(map[string]any, len(base)+1)
+	for k, v := range base {
+		out[k] = v
+	}
+	out["id"] = taskID
+	return out
+}
+
+func TestA2A_ExplicitAuthModeOff_NoTokens_AllowsPublicDeniesBearer(t *testing.T) {
+	t.Setenv("ORLOJ_API_TOKENS", "")
+	t.Setenv("ORLOJ_API_TOKEN", "")
+
+	ts, stores := newA2AExplicitAuthModeOffTestServer(t)
+	defer ts.Close()
+
+	seedPublicAgent(t, stores, "pub-off", "public system")
+	seedAgent(t, stores, "bearer-off", "bearer system", nil)
+
+	params := map[string]any{
+		"id": "task-off-public",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	resp := postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/pub-off/a2a", "tasks/send", params)
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("public system invoke on explicit auth-off should succeed: %+v", rpcResp.Error)
+	}
+
+	params["id"] = "task-off-bearer"
+	resp = postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/bearer-off/a2a", "tasks/send", params)
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error == nil {
+		t.Fatal("expected bearer system invoke without token to be denied on explicit auth-off with no tokens")
+	}
+}
+
+func TestA2A_PublicSystemCardOmitsAuthSchemes(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedPublicAgent(t, stores, "public-card-sys", "public card system")
+
+	resp, err := http.Get(ts.URL + "/v1/agent-systems/public-card-sys/.well-known/agent-card.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var card a2a.AgentCard
+	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+		t.Fatalf("decode card: %v", err)
+	}
+	if card.Authentication != nil && len(card.Authentication.Schemes) > 0 {
+		t.Fatalf("expected public system card to omit auth schemes, got %v", card.Authentication.Schemes)
+	}
+}
+
+func TestA2A_BearerSystemCardIncludesAuthSchemes(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "bearer-card-sys", "bearer card system", nil)
+
+	resp, err := http.Get(ts.URL + "/v1/agent-systems/bearer-card-sys/.well-known/agent-card.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var card a2a.AgentCard
+	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+		t.Fatalf("decode card: %v", err)
+	}
+	if card.Authentication == nil || len(card.Authentication.Schemes) == 0 {
+		t.Fatal("expected bearer system card to include auth schemes")
+	}
+}
+
+func TestA2ARegistry_PublicSystemsVisibleWithoutAuth(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedPublicAgent(t, stores, "pub-sys", "public system")
+	seedAgent(t, stores, "allowed", "bearer system", nil)
+
+	// Unauthenticated: sees only the public system
+	resp, err := http.Get(ts.URL + "/v1/a2a/agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var registry a2a.RegistryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&registry); err != nil {
+		t.Fatalf("decode registry: %v", err)
+	}
+	if len(registry.LocalAgents) != 1 || registry.LocalAgents[0].Name != "pub-sys" {
+		names := make([]string, len(registry.LocalAgents))
+		for i, c := range registry.LocalAgents {
+			names[i] = c.Name
+		}
+		t.Fatalf("expected only pub-sys in unauthenticated registry, got %v", names)
+	}
+
+	// Authenticated with scoped token: sees public system + scoped system
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/a2a/agents", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer client-token")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	var authRegistry a2a.RegistryResponse
+	if err := json.NewDecoder(resp2.Body).Decode(&authRegistry); err != nil {
+		t.Fatalf("decode registry: %v", err)
+	}
+	if len(authRegistry.LocalAgents) != 2 {
+		names := make([]string, len(authRegistry.LocalAgents))
+		for i, c := range authRegistry.LocalAgents {
+			names[i] = c.Name
+		}
+		t.Fatalf("expected 2 systems in authenticated registry, got %v", names)
+	}
+}
+
 func TestCapabilities_A2ADisabledOmitsA2AEntries(t *testing.T) {
 	ts, _ := newA2ATestServer(t, false)
 	defer ts.Close()
@@ -736,5 +1566,130 @@ func TestCapabilities_A2ADisabledOmitsA2AEntries(t *testing.T) {
 		if cap.ID == "a2a" || cap.ID == "a2a.streaming" || cap.ID == "a2a.registry" {
 			t.Errorf("unexpected A2A capability when disabled: %+v", cap)
 		}
+	}
+}
+
+func TestA2A_BearerSubscribeDeniedWithoutToken(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "allowed", "bearer system", nil)
+
+	params := map[string]any{
+		"id": "task-subscribe-notoken",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	resp := postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/sendSubscribe", params)
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error == nil {
+		t.Fatal("expected bearer system subscribe without token to be denied")
+	}
+	if rpcResp.Error.Code != a2a.ErrCodeAgentNotFound {
+		t.Errorf("expected error code %d (AgentNotFound), got %d", a2a.ErrCodeAgentNotFound, rpcResp.Error.Code)
+	}
+}
+
+func TestA2A_BearerCancelAllowedWithScopedToken(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "allowed", "bearer system", nil)
+
+	sendParams := map[string]any{
+		"id": "task-bearer-cancel-scoped",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	resp := postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/send", sendParams, "client-token")
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("send with valid token failed: %+v", rpcResp.Error)
+	}
+
+	cancelParams := map[string]any{"id": "task-bearer-cancel-scoped", "reason": "done"}
+	resp = postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/cancel", cancelParams, "client-token")
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("cancel with valid scoped token failed: %+v", rpcResp.Error)
+	}
+
+	var result a2a.TaskResult
+	if err := json.Unmarshal(rpcResp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.ID != "task-bearer-cancel-scoped" {
+		t.Errorf("expected task ID 'task-bearer-cancel-scoped', got %q", result.ID)
+	}
+	if result.Status.State != "canceled" {
+		t.Errorf("expected cancelled task state 'canceled', got %q", result.Status.State)
+	}
+}
+
+func TestA2A_PublicCancelAllowedWithoutToken(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedPublicAgent(t, stores, "public-cancel-sys", "public system")
+
+	sendParams := map[string]any{
+		"id": "task-public-cancel",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	resp := postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/public-cancel-sys/a2a", "tasks/send", sendParams)
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("public send failed: %+v", rpcResp.Error)
+	}
+
+	cancelParams := map[string]any{"id": "task-public-cancel", "reason": "test"}
+	resp = postA2AJSONRPC(t, ts.URL+"/v1/agent-systems/public-cancel-sys/a2a", "tasks/cancel", cancelParams)
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("public cancel without token failed: %+v", rpcResp.Error)
+	}
+}
+
+func TestA2A_OutOfScopeTokenGetDenied(t *testing.T) {
+	ts, stores := newA2AAuthTestServer(t)
+	defer ts.Close()
+
+	seedAgent(t, stores, "allowed", "bearer system", nil)
+	seedAgent(t, stores, "blocked", "blocked system", nil)
+
+	sendParams := map[string]any{
+		"id": "task-scope-test",
+		"message": map[string]any{
+			"role":  "user",
+			"parts": []map[string]any{{"type": "text", "text": "Hello"}},
+		},
+	}
+
+	// Create a task on "allowed" (in scope for client-token)
+	resp := postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/allowed/a2a", "tasks/send", sendParams, "client-token")
+	rpcResp := decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error != nil {
+		t.Fatalf("send to allowed system failed: %+v", rpcResp.Error)
+	}
+
+	// Try to get via "blocked" system URL with client-token (not scoped for "blocked")
+	getParams := map[string]any{"id": "task-scope-test"}
+	resp = postA2AJSONRPCWithToken(t, ts.URL+"/v1/agent-systems/blocked/a2a", "tasks/get", getParams, "client-token")
+	rpcResp = decodeJSONRPCResponse(t, resp)
+	if rpcResp.Error == nil {
+		t.Fatal("expected out-of-scope token get to be denied")
+	}
+	if rpcResp.Error.Code != a2a.ErrCodeTaskNotFound {
+		t.Errorf("expected error code %d (TaskNotFound), got %d", a2a.ErrCodeTaskNotFound, rpcResp.Error.Code)
 	}
 }

--- a/api/auth_admin_handlers.go
+++ b/api/auth_admin_handlers.go
@@ -14,21 +14,24 @@ import (
 )
 
 type createTokenRequest struct {
-	Name string `json:"name"`
-	Role string `json:"role"`
+	Name            string   `json:"name"`
+	Role            string   `json:"role"`
+	A2AAgentSystems []string `json:"a2a_agent_systems,omitempty"`
 }
 
 type tokenMetadataResponse struct {
-	Name      string `json:"name"`
-	Role      string `json:"role"`
-	CreatedAt string `json:"created_at"`
+	Name            string   `json:"name"`
+	Role            string   `json:"role"`
+	CreatedAt       string   `json:"created_at"`
+	A2AAgentSystems []string `json:"a2a_agent_systems,omitempty"`
 }
 
 type tokenCreateResponse struct {
-	Name      string `json:"name"`
-	Role      string `json:"role"`
-	CreatedAt string `json:"created_at"`
-	Token     string `json:"token"`
+	Name            string   `json:"name"`
+	Role            string   `json:"role"`
+	CreatedAt       string   `json:"created_at"`
+	Token           string   `json:"token"`
+	A2AAgentSystems []string `json:"a2a_agent_systems,omitempty"`
 }
 
 type tokenListResponse struct {
@@ -70,9 +73,10 @@ func (s *Server) handleTokens(w http.ResponseWriter, r *http.Request) {
 		resp := tokenListResponse{Items: make([]tokenMetadataResponse, 0, len(records))}
 		for _, record := range records {
 			resp.Items = append(resp.Items, tokenMetadataResponse{
-				Name:      record.Name,
-				Role:      record.Role,
-				CreatedAt: record.CreatedAt,
+				Name:            record.Name,
+				Role:            record.Role,
+				CreatedAt:       record.CreatedAt,
+				A2AAgentSystems: record.A2AAgentSystems,
 			})
 		}
 		writeJSON(w, http.StatusOK, resp)
@@ -96,7 +100,8 @@ func (s *Server) handleTokens(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "failed to generate token", http.StatusInternalServerError)
 			return
 		}
-		record, err := s.stores.APITokens.Create(req.Name, hashToken(rawToken), req.Role, time.Now().UTC())
+		a2aAgentSystems := normalizeA2AAgentSystemRefs(req.A2AAgentSystems)
+		record, err := s.stores.APITokens.CreateWithA2AAgentSystems(req.Name, hashToken(rawToken), req.Role, a2aAgentSystems, time.Now().UTC())
 		if err != nil {
 			switch {
 			case errors.Is(err, store.ErrAPITokenExists):
@@ -110,10 +115,11 @@ func (s *Server) handleTokens(w http.ResponseWriter, r *http.Request) {
 		}
 		s.emitAdminAudit(auditReq, "token.create", "api-token", record.Name, fmt.Sprintf("created API token %q with role %s", record.Name, record.Role))
 		writeJSON(w, http.StatusCreated, tokenCreateResponse{
-			Name:      record.Name,
-			Role:      record.Role,
-			CreatedAt: record.CreatedAt,
-			Token:     rawToken,
+			Name:            record.Name,
+			Role:            record.Role,
+			CreatedAt:       record.CreatedAt,
+			Token:           rawToken,
+			A2AAgentSystems: record.A2AAgentSystems,
 		})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/api/auth_context.go
+++ b/api/auth_context.go
@@ -10,9 +10,11 @@ type authContextKey struct{}
 // AuthIdentity carries the authenticated caller's identity through the
 // request context for audit logging and downstream authorization.
 type AuthIdentity struct {
-	Name   string // token name (bearer) or username (session)
-	Role   string
-	Method string // "bearer", "session", "none"
+	Name            string // token name (bearer) or username (session)
+	Role            string
+	Method          string // "bearer", "session", "none"
+	A2AAgentSystems []string
+	AuthDisabled    bool // true when no auth is configured instance-wide
 }
 
 func withAuthIdentity(ctx context.Context, id AuthIdentity) context.Context {

--- a/api/authz.go
+++ b/api/authz.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -36,8 +37,9 @@ type IdentityAuthorizer interface {
 }
 
 type tokenPrincipal struct {
-	Name string
-	Role string
+	Name            string
+	Role            string
+	A2AAgentSystems []string
 }
 
 type authConfig struct {
@@ -63,11 +65,47 @@ func normalizeAPIRole(role, fallback string) (string, bool) {
 		r = strings.ToLower(strings.TrimSpace(fallback))
 	}
 	switch r {
-	case "admin", "writer", "reader", "controller":
+	case "admin", "writer", "reader", "controller", "a2a":
 		return r, true
 	default:
 		return "", false
 	}
+}
+
+func normalizeA2AAgentSystemRefs(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		v := strings.TrimSpace(value)
+		if v == "" {
+			continue
+		}
+		if strings.Contains(v, "/") {
+			parts := strings.SplitN(v, "/", 2)
+			v = store.ScopedName(parts[0], parts[1])
+		} else {
+			v = store.ScopedName(resources.DefaultNamespace, v)
+		}
+		key := strings.ToLower(v)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func parseA2AAgentSystemRefs(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '|' || r == ';'
+	})
+	return normalizeA2AAgentSystemRefs(fields)
 }
 
 func parseTokenEnvConfig() map[string]tokenPrincipal {
@@ -84,9 +122,10 @@ func parseTokenEnvConfig() map[string]tokenPrincipal {
 			}
 			parts := strings.Split(raw, ":")
 			var (
-				name  string
-				token string
-				role  string
+				name            string
+				token           string
+				role            string
+				a2aAgentSystems []string
 			)
 			switch len(parts) {
 			case 2:
@@ -96,6 +135,15 @@ func parseTokenEnvConfig() map[string]tokenPrincipal {
 				name = strings.TrimSpace(parts[0])
 				token = strings.TrimSpace(parts[1])
 				role = strings.TrimSpace(parts[2])
+				if name == "" {
+					skipped++
+					continue
+				}
+			case 4:
+				name = strings.TrimSpace(parts[0])
+				token = strings.TrimSpace(parts[1])
+				role = strings.TrimSpace(parts[2])
+				a2aAgentSystems = parseA2AAgentSystemRefs(parts[3])
 				if name == "" {
 					skipped++
 					continue
@@ -113,10 +161,14 @@ func parseTokenEnvConfig() map[string]tokenPrincipal {
 				skipped++
 				continue
 			}
-			tokens[hashToken(token)] = tokenPrincipal{Name: name, Role: normalizedRole}
+			if normalizedRole == "a2a" && len(a2aAgentSystems) == 0 {
+				skipped++
+				continue
+			}
+			tokens[hashToken(token)] = tokenPrincipal{Name: name, Role: normalizedRole, A2AAgentSystems: a2aAgentSystems}
 		}
 		if skipped > 0 {
-			log.Printf("WARNING: ORLOJ_API_TOKENS: %d malformed entries skipped (expected token:role or name:token:role)", skipped)
+			log.Printf("WARNING: ORLOJ_API_TOKENS: %d malformed entries skipped (expected token:role, name:token:role, or name:token:a2a:namespace/name|other)", skipped)
 		}
 		if len(tokens) == 0 && len(pairs) > 0 {
 			log.Fatalf("ORLOJ_API_TOKENS is set but all %d entries are malformed — refusing to start with auth disabled", len(pairs))
@@ -178,7 +230,11 @@ func (a tokenAuthorizer) resolveTokenPrincipal(token string) (tokenPrincipal, bo
 	if !valid {
 		return tokenPrincipal{}, false, http.StatusInternalServerError, "auth store role invalid"
 	}
-	return tokenPrincipal{Name: strings.TrimSpace(record.Name), Role: role}, true, 0, ""
+	return tokenPrincipal{
+		Name:            strings.TrimSpace(record.Name),
+		Role:            role,
+		A2AAgentSystems: normalizeA2AAgentSystemRefs(record.A2AAgentSystems),
+	}, true, 0, ""
 }
 
 // NewAPIKeyAuthorizer returns an authorizer that validates a single API key
@@ -197,6 +253,39 @@ func NewAPIKeyAuthorizer(key string) RequestAuthorizer {
 func (a tokenAuthorizer) Authorize(r *http.Request, requiredRole string) (bool, int, string) {
 	allowed, statusCode, message, _ := a.AuthorizeWithIdentity(r, requiredRole)
 	return allowed, statusCode, message
+}
+
+// TryResolveIdentity attempts to extract and validate a bearer token from the
+// request without rejecting missing tokens. Returns the resolved identity
+// (Method:"bearer") when a valid token is present, a "none" identity when no
+// token is sent or auth is globally disabled, and an error status when a token
+// is present but invalid. Used by A2A invoke/registry paths where the handler
+// decides per-system policy.
+func (a tokenAuthorizer) TryResolveIdentity(r *http.Request) (AuthIdentity, int, string) {
+	enabled, statusCode, message := a.authEnabled()
+	if statusCode > 0 {
+		return AuthIdentity{}, statusCode, message
+	}
+	if !enabled {
+		return AuthIdentity{Method: "none", AuthDisabled: true}, 0, ""
+	}
+	token := bearerToken(r.Header.Get("Authorization"))
+	if token == "" {
+		return AuthIdentity{Method: "none"}, 0, ""
+	}
+	principal, ok, pStatus, pMessage := a.resolveTokenPrincipal(token)
+	if pStatus > 0 {
+		return AuthIdentity{}, pStatus, pMessage
+	}
+	if !ok {
+		return AuthIdentity{}, http.StatusUnauthorized, "invalid token"
+	}
+	return AuthIdentity{
+		Name:            principal.Name,
+		Role:            principal.Role,
+		Method:          "bearer",
+		A2AAgentSystems: principal.A2AAgentSystems,
+	}, 0, ""
 }
 
 func (a tokenAuthorizer) AuthorizeWithIdentity(r *http.Request, requiredRole string) (bool, int, string, AuthIdentity) {
@@ -225,9 +314,10 @@ func (a tokenAuthorizer) AuthorizeWithIdentity(r *http.Request, requiredRole str
 		return false, http.StatusForbidden, "forbidden", AuthIdentity{}
 	}
 	return true, 0, "", AuthIdentity{
-		Name:   principal.Name,
-		Role:   principal.Role,
-		Method: "bearer",
+		Name:            principal.Name,
+		Role:            principal.Role,
+		Method:          "bearer",
+		A2AAgentSystems: principal.A2AAgentSystems,
 	}
 }
 
@@ -261,6 +351,38 @@ func (s *Server) withAuth(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+
+		// A2A invoke and registry paths use optional auth: resolve identity
+		// if a token is present, but don't reject missing tokens. The handler
+		// enforces per-system policy (public vs bearer).
+		if required == "a2a_invoke" {
+			authorizer := s.authorizer
+			if authorizer == nil {
+				authorizer = newTokenAuthorizerWithStoreFromEnv(s.stores.APITokens)
+			}
+			if ta, ok := authorizer.(tokenAuthorizer); ok {
+				identity, statusCode, message := ta.TryResolveIdentity(r)
+				if statusCode > 0 {
+					http.Error(w, strings.TrimSpace(message), statusCode)
+					return
+				}
+				if identity.Method != "bearer" && identity.Method != "none" {
+					http.Error(w, "A2A requires bearer token authentication", http.StatusUnauthorized)
+					return
+				}
+				ctx := withAuthIdentity(r.Context(), identity)
+				rw := &statusCaptureResponseWriter{ResponseWriter: w}
+				next.ServeHTTP(rw, r.WithContext(ctx))
+				if rw.statusCode == 0 {
+					rw.statusCode = http.StatusOK
+				}
+				s.emitBearerRequestAudit(r.WithContext(ctx), rw.statusCode, identity)
+				return
+			}
+			// Fallback for non-tokenAuthorizer: use standard "a2a" role check.
+			required = "a2a"
+		}
+
 		authorizer := s.authorizer
 		if authorizer == nil {
 			authorizer = newTokenAuthorizerWithStoreFromEnv(s.stores.APITokens)
@@ -290,11 +412,13 @@ func (s *Server) withAuth(next http.Handler) http.Handler {
 		if strings.TrimSpace(identity.Method) == "" {
 			identity.Method = "bearer"
 		}
+		if isA2AInvokeRequest(r.URL.Path, r.Method) && !strings.EqualFold(identity.Method, "bearer") && !strings.EqualFold(identity.Method, "none") {
+			http.Error(w, "A2A requires bearer token authentication", http.StatusUnauthorized)
+			return
+		}
 
 		ctx := withAuthIdentity(r.Context(), identity)
 		reqWithIdentity := r.WithContext(ctx)
-		// Extension point: a custom authorizer can enforce per-namespace,
-		// per-resource, or per-user policies here. Nil by default.
 		if s.resourceAuthorizer != nil {
 			ns := requestNamespace(reqWithIdentity)
 			resType, resName := resourceInfoFromPath(reqWithIdentity.URL.Path)
@@ -389,6 +513,12 @@ func requiredRoleForRequest(r *http.Request, uiBasePath string) string {
 	if path == "/metrics" {
 		return "reader"
 	}
+	if isA2ACardPath(path, method) {
+		return ""
+	}
+	if isA2ARegistryPath(path, method) || isA2AInvokeRequest(path, method) {
+		return "a2a_invoke"
+	}
 	if isUIPath(path, uiBasePath) {
 		return ""
 	}
@@ -425,6 +555,38 @@ func requiredRoleForRequest(r *http.Request, uiBasePath string) string {
 		}
 	}
 	return "writer"
+}
+
+func isA2ARegistryPath(path, method string) bool {
+	return strings.EqualFold(method, http.MethodGet) && strings.TrimSpace(path) == "/v1/a2a/agents"
+}
+
+func isA2ACardPath(path, method string) bool {
+	if !strings.EqualFold(method, http.MethodGet) && !strings.EqualFold(method, http.MethodHead) {
+		return false
+	}
+	path = strings.TrimSpace(path)
+	if path == "/.well-known/agent-card.json" || path == "/.well-known/agent.json" {
+		return true
+	}
+	if strings.HasPrefix(path, "/v1/agents/") || strings.HasPrefix(path, "/v1/agent-systems/") {
+		return strings.Contains(path, "/.well-known/agent-card.json") || strings.HasSuffix(path, "/.well-known/agent.json")
+	}
+	return false
+}
+
+func isA2AInvokeRequest(path, method string) bool {
+	if !strings.EqualFold(method, http.MethodPost) {
+		return false
+	}
+	path = strings.TrimSpace(path)
+	if path == "/a2a" {
+		return true
+	}
+	if strings.HasPrefix(path, "/v1/agents/") || strings.HasPrefix(path, "/v1/agent-systems/") {
+		return strings.HasSuffix(path, "/a2a")
+	}
+	return false
 }
 
 // toolMutationRequiresAdmin inspects an in-flight /v1/tools mutation body and
@@ -483,7 +645,8 @@ func toolMutationRequiresAdmin(r *http.Request) bool {
 //
 // Role hierarchy (highest to lowest):
 //   - admin:      full access to all endpoints
-//   - writer:     read + write (satisfies both "reader" and "writer" requirements)
+//   - writer:     read + write + A2A invoke
+//   - a2a:        A2A invoke only
 //   - controller: read + status-patch (satisfies "reader" and "controller" requirements)
 //   - reader:     read-only (satisfies only "reader" requirements)
 //
@@ -502,6 +665,8 @@ func roleAllows(actual, required string) bool {
 		return actual == "writer"
 	case "controller":
 		return actual == "controller"
+	case "a2a":
+		return actual == "a2a" || actual == "writer"
 	default:
 		return false
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"sync/atomic"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -27,13 +27,13 @@ import (
 
 // Stores groups typed state stores used by the API server.
 type Stores struct {
-	Agents        *store.AgentStore
-	AgentSystems  *store.AgentSystemStore
-	ModelEPs      *store.ModelEndpointStore
-	Tools         *store.ToolStore
-	Secrets       *store.SecretStore
-	SealedSecrets *store.SealedSecretStore
-	SealingKeys   *store.SealingKeyStore
+	Agents          *store.AgentStore
+	AgentSystems    *store.AgentSystemStore
+	ModelEPs        *store.ModelEndpointStore
+	Tools           *store.ToolStore
+	Secrets         *store.SecretStore
+	SealedSecrets   *store.SealedSecretStore
+	SealingKeys     *store.SealingKeyStore
 	Memories        *store.MemoryStore
 	ContextAdapters *store.ContextAdapterStore
 	Policies        *store.AgentPolicyStore
@@ -44,51 +44,51 @@ type Stores struct {
 	Tasks           *store.TaskStore
 	TaskSchedules   *store.TaskScheduleStore
 	TaskWebhooks    *store.TaskWebhookStore
-	WebhookDedupe *store.WebhookDedupeStore
-	Workers       *store.WorkerStore
-	McpServers    *store.McpServerStore
-	EvalDatasets  *store.EvalDatasetStore
-	EvalRuns      *store.EvalRunStore
-	LocalAdmins   *store.LocalAdminStore
-	APITokens     *store.APITokenStore
-	AuthSessions  *store.AuthSessionStore
+	WebhookDedupe   *store.WebhookDedupeStore
+	Workers         *store.WorkerStore
+	McpServers      *store.McpServerStore
+	EvalDatasets    *store.EvalDatasetStore
+	EvalRuns        *store.EvalRunStore
+	LocalAdmins     *store.LocalAdminStore
+	APITokens       *store.APITokenStore
+	AuthSessions    *store.AuthSessionStore
 }
 
 // ServerOptions configures optional extension points.
 type ServerOptions struct {
-	Authorizer         RequestAuthorizer
-	ResourceAuthorizer ResourceAuthorizer // optional authorization hook
-	Extensions         agentruntime.Extensions
-	AuthMode           AuthMode
-	SessionTTL         time.Duration
-	UIBasePath         string // URL path prefix for the web console (default "/")
-	TrustedProxies     string // comma-separated CIDRs whose forwarding headers are trusted
+	Authorizer               RequestAuthorizer
+	ResourceAuthorizer       ResourceAuthorizer // optional authorization hook
+	Extensions               agentruntime.Extensions
+	AuthMode                 AuthMode
+	SessionTTL               time.Duration
+	UIBasePath               string // URL path prefix for the web console (default "/")
+	TrustedProxies           string // comma-separated CIDRs whose forwarding headers are trusted
 	ContainerResourceCeiling resources.ContainerResourceCeiling
-	CRDConflictPolicy  string // "off", "warn" (default), or "reject"
+	CRDConflictPolicy        string // "off", "warn" (default), or "reject"
 }
 
 // Server exposes CRUD endpoints for control plane resources.
 type Server struct {
-	stores             Stores
-	runtime            *agentruntime.Manager
-	logger             *log.Logger
-	mux                *http.ServeMux
-	authorizer         RequestAuthorizer
-	resourceAuthorizer ResourceAuthorizer // optional authorization hook
-	authMode           AuthMode
-	sessionTTL         time.Duration
-	bus                eventbus.Bus
-	extensions         agentruntime.Extensions
-	memoryBackends     *agentruntime.PersistentMemoryBackendRegistry
-	authRateLimiter    *authRateLimiter
-	requestRateLimiter *rate.Limiter // per-server; avoids test suites sharing one process-global bucket
-	trustedProxies     []*net.IPNet
-	uiBasePath         string
+	stores                   Stores
+	runtime                  *agentruntime.Manager
+	logger                   *log.Logger
+	mux                      *http.ServeMux
+	authorizer               RequestAuthorizer
+	resourceAuthorizer       ResourceAuthorizer // optional authorization hook
+	authMode                 AuthMode
+	sessionTTL               time.Duration
+	bus                      eventbus.Bus
+	extensions               agentruntime.Extensions
+	memoryBackends           *agentruntime.PersistentMemoryBackendRegistry
+	authRateLimiter          *authRateLimiter
+	requestRateLimiter       *rate.Limiter // per-server; avoids test suites sharing one process-global bucket
+	trustedProxies           []*net.IPNet
+	uiBasePath               string
 	containerResourceCeiling resources.ContainerResourceCeiling
-	crdConflictPolicy  string
-	a2aConfig           *A2AConfig
-	a2aRateLimiter      *ipRateLimiter
-	a2aSubscribeCount   atomic.Int32
+	crdConflictPolicy        string
+	a2aConfig                *A2AConfig
+	a2aRateLimiter           *ipRateLimiter
+	a2aSubscribeCount        atomic.Int32
 }
 
 func NewServer(stores Stores, runtime *agentruntime.Manager, logger *log.Logger) *Server {
@@ -159,10 +159,23 @@ func NewServerWithOptions(stores Stores, runtime *agentruntime.Manager, logger *
 	}
 	extensions := agentruntime.NormalizeExtensions(opts.Extensions)
 	authorizer := opts.Authorizer
-	if authMode == AuthModeOff && authModeExplicit {
-		authorizer = noAuthAuthorizer{}
-	} else if authorizer == nil {
-		authorizer = newTokenAuthorizerWithStoreFromEnv(stores.APITokens)
+	if authorizer == nil {
+		if authMode == AuthModeOff && authModeExplicit {
+			// auth-mode=off with no injected authorizer: stay open unless env/DB
+			// tokens are configured (ORLOJ_API_TOKEN, ORLOJ_API_TOKENS, /v1/tokens).
+			tokenAuth := newTokenAuthorizerWithStoreFromEnv(stores.APITokens)
+			if ta, ok := tokenAuth.(tokenAuthorizer); ok {
+				if enabled, statusCode, _ := ta.authEnabled(); enabled && statusCode == 0 {
+					authorizer = tokenAuth
+				} else {
+					authorizer = noAuthAuthorizer{}
+				}
+			} else {
+				authorizer = noAuthAuthorizer{}
+			}
+		} else {
+			authorizer = newTokenAuthorizerWithStoreFromEnv(stores.APITokens)
+		}
 	}
 	if authMode == AuthModeNative {
 		authorizer = newNativeModeAuthorizer(authorizer, stores.LocalAdmins, stores.AuthSessions, sessionTTL)
@@ -186,11 +199,11 @@ func NewServerWithOptions(stores Stores, runtime *agentruntime.Manager, logger *
 		authRateLimiter:    newAuthRateLimiter(trustedProxies, logger),
 		// 500 r/s sustained, burst 100 — same as previous package-global limiter, but per Server instance
 		// so concurrent httptest servers in tests do not share one token bucket.
-		requestRateLimiter: rate.NewLimiter(rate.Limit(500), 100),
-		trustedProxies:             trustedProxies,
-		uiBasePath:                 uiBase,
-		containerResourceCeiling:   opts.ContainerResourceCeiling,
-		crdConflictPolicy:          normalizeCRDConflictPolicy(opts.CRDConflictPolicy),
+		requestRateLimiter:       rate.NewLimiter(rate.Limit(500), 100),
+		trustedProxies:           trustedProxies,
+		uiBasePath:               uiBase,
+		containerResourceCeiling: opts.ContainerResourceCeiling,
+		crdConflictPolicy:        normalizeCRDConflictPolicy(opts.CRDConflictPolicy),
 	}
 	s.routes()
 	return s
@@ -449,7 +462,8 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	if strings.TrimSpace(snapshot.GeneratedAt) == "" {
 		snapshot.GeneratedAt = time.Now().UTC().Format(time.RFC3339Nano)
 	}
-	if s.a2aConfig != nil && s.a2aConfig.Enabled {
+	a2aSystems, _ := s.a2aEnabledSystems(r)
+	if s.a2aConfig != nil && len(a2aSystems) > 0 {
 		snapshot.Capabilities = append(snapshot.Capabilities,
 			agentruntime.Capability{ID: "a2a", Enabled: true, Description: "A2A protocol interoperability", Source: "config"},
 			agentruntime.Capability{ID: "a2a.streaming", Enabled: s.a2aConfig.StreamingEnabled, Description: "A2A streaming subscribe support", Source: "config"},
@@ -864,6 +878,14 @@ func (s *Server) handleAgentSystemByName(w http.ResponseWriter, r *http.Request)
 	name := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v1/agent-systems/"), "/")
 	if name == "" {
 		http.Error(w, "agentsystem name is required", http.StatusBadRequest)
+		return
+	}
+	if strings.Contains(r.URL.Path, "/.well-known/agent-card.json") || strings.HasSuffix(r.URL.Path, "/.well-known/agent.json") {
+		s.handleAgentCard(w, r)
+		return
+	}
+	if strings.HasSuffix(r.URL.Path, "/a2a") {
+		s.handleA2AJSONRPC(w, r)
 		return
 	}
 	if strings.HasSuffix(name, "/status") {

--- a/charts/orloj/README.md
+++ b/charts/orloj/README.md
@@ -87,7 +87,6 @@ helm upgrade orloj ./charts/orloj \
 
 | Value | Default | Description |
 |---|---|---|
-| `a2a.enabled` | `false` | Enable A2A protocol endpoints and tool type |
 | `a2a.publicBaseURL` | `""` | Public URL for Agent Card `url` fields |
 | `a2a.protocolVersion` | `""` | A2A protocol version to advertise |
 | `a2a.cardCacheTTL` | `"5m"` | TTL for cached remote Agent Cards |

--- a/charts/orloj/templates/NOTES.txt
+++ b/charts/orloj/templates/NOTES.txt
@@ -41,11 +41,11 @@ CLI quickstart:
   orlojctl init my-first-system
   orlojctl apply -f my-first-system/ --run
   orlojctl trace my-first-system-task
-{{- if .Values.a2a.enabled }}
+{{- if .Values.a2a.publicBaseURL }}
 
-A2A Protocol is enabled.
+A2A Protocol endpoints are configured. AgentSystems are exposed only when spec.a2a.enabled is true.
 - Agent Card: {{ .Values.a2a.publicBaseURL }}/.well-known/agent-card.json
-- Per-agent cards: {{ .Values.a2a.publicBaseURL }}/v1/agents/<name>/.well-known/agent-card.json
+- Per-system cards: {{ .Values.a2a.publicBaseURL }}/v1/agent-systems/<name>/.well-known/agent-card.json
 - JSON-RPC endpoint: {{ .Values.a2a.publicBaseURL }}/a2a
 - Registry: {{ .Values.a2a.publicBaseURL }}/v1/a2a/agents
 

--- a/charts/orloj/templates/ingress.yaml
+++ b/charts/orloj/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- if $.Values.a2a.enabled }}
+          {{- if $.Values.a2a.publicBaseURL }}
           - path: /.well-known
             pathType: Prefix
             backend:

--- a/charts/orloj/templates/operator-crds.yaml
+++ b/charts/orloj/templates/operator-crds.yaml
@@ -285,6 +285,13 @@ spec:
             type: object
           spec:
             properties:
+              a2a:
+                properties:
+                  auth:
+                    type: string
+                  enabled:
+                    type: boolean
+                type: object
               agents:
                 items:
                   type: string

--- a/charts/orloj/templates/server-deployment.yaml
+++ b/charts/orloj/templates/server-deployment.yaml
@@ -180,11 +180,10 @@ spec:
               value: {{ .Values.cliToolAllowedCommands | quote }}
             {{- end }}
             # --- A2A Protocol ---
-            {{- if .Values.a2a.enabled }}
-            - name: ORLOJ_A2A_ENABLED
-              value: "true"
+            {{- if .Values.a2a.publicBaseURL }}
             - name: ORLOJ_A2A_PUBLIC_BASE_URL
               value: {{ .Values.a2a.publicBaseURL | quote }}
+            {{- end }}
             {{- if .Values.a2a.protocolVersion }}
             - name: ORLOJ_A2A_PROTOCOL_VERSION
               value: {{ .Values.a2a.protocolVersion | quote }}
@@ -203,7 +202,6 @@ spec:
               value: {{ .Values.a2a.rateLimit.requestsPerMinute | quote }}
             - name: ORLOJ_A2A_RATE_LIMIT_MAX_SUBSCRIBE
               value: {{ .Values.a2a.rateLimit.maxConcurrentSubscriptions | quote }}
-            {{- end }}
             # --- CRD conflict policy ---
             - name: ORLOJ_CRD_CONFLICT_POLICY
               value: {{ .Values.crdConflictPolicy | default "warn" | quote }}

--- a/charts/orloj/values.yaml
+++ b/charts/orloj/values.yaml
@@ -288,8 +288,6 @@ worker:
 # A2A Protocol interoperability
 # ---------------------------------------------------------------------------
 a2a:
-  # -- Enable A2A protocol endpoints and tool type
-  enabled: false
   # -- Public base URL for Agent Card `url` fields (required when enabled)
   # Must be reachable by external A2A clients. Example: https://orloj.example.com
   publicBaseURL: ""
@@ -307,11 +305,11 @@ a2a:
   #   secretRef: partner-token
   # -- Rate limiting for A2A endpoints
   rateLimit:
-    # -- Enable rate limiting on A2A endpoints (default true when a2a.enabled)
+    # -- Enable rate limiting on A2A endpoints
     enabled: true
     # -- Requests per minute for unauthenticated callers
     requestsPerMinute: 30
-    # -- Max concurrent SSE subscribe connections per client
+    # -- Max concurrent SSE subscribe connections globally (server-wide)
     maxConcurrentSubscriptions: 10
 
 # ---------------------------------------------------------------------------

--- a/cli/a2a.go
+++ b/cli/a2a.go
@@ -27,17 +27,21 @@ func newA2ACommand() *cobra.Command {
 
 func newA2ACardCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "card <agent-name>",
-		Short: "Preview the generated Agent Card for an agent",
+		Use:   "card <agent-system-name>",
+		Short: "Preview the generated Agent Card for an AgentSystem",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			server := resolveServer(cmd)
 			name := strings.TrimSpace(args[0])
 			if name == "" {
-				return errors.New("agent name is required")
+				return errors.New("agentsystem name is required")
 			}
 
-			cardURL := strings.TrimRight(server, "/") + "/v1/agents/" + url.PathEscape(name) + "/.well-known/agent-card.json"
+			if ns := resolveNamespace(cmd); ns != "" && !strings.Contains(name, "/") {
+				name = ns + "/" + name
+			}
+
+			cardURL := strings.TrimRight(server, "/") + "/v1/agent-systems/" + url.PathEscape(name) + "/.well-known/agent-card.json"
 			resp, err := http.Get(cardURL)
 			if err != nil {
 				return fmt.Errorf("fetch agent card failed: %w", err)

--- a/cmd/orlojd/main.go
+++ b/cmd/orlojd/main.go
@@ -77,7 +77,6 @@ func main() {
 	toolWASMCacheDir := flag.String("tool-wasm-cache-dir", env("ORLOJ_TOOL_WASM_CACHE_DIR", ""), "disk cache directory for remote WASM modules (default: ~/.orloj/wasm-cache)")
 	cliToolAllowedCommands := flag.String("cli-tool-allowed-commands", env("ORLOJ_CLI_TOOL_ALLOWED_COMMANDS", ""), "comma-separated allowlist of commands for CLI tools (empty allows all)")
 	cliToolMaxArgvLength := flag.Int("cli-tool-max-argv-length", envInt("ORLOJ_CLI_TOOL_MAX_ARGV_LENGTH", 4096), "max total argv byte length for CLI tool invocations")
-	a2aEnabled := flag.Bool("a2a-enabled", envBool("ORLOJ_A2A_ENABLED", false), "enable A2A protocol endpoints and tool type (env: ORLOJ_A2A_ENABLED)")
 	a2aPublicBaseURL := flag.String("a2a-public-base-url", env("ORLOJ_A2A_PUBLIC_BASE_URL", ""), "public base URL for A2A Agent Cards (env: ORLOJ_A2A_PUBLIC_BASE_URL)")
 	a2aProtocolVersion := flag.String("a2a-protocol-version", env("ORLOJ_A2A_PROTOCOL_VERSION", ""), "A2A protocol version to advertise (env: ORLOJ_A2A_PROTOCOL_VERSION)")
 	a2aCardCacheTTL := flag.Duration("a2a-card-cache-ttl", envDuration("ORLOJ_A2A_CARD_CACHE_TTL", 5*time.Minute), "TTL for cached remote Agent Cards (env: ORLOJ_A2A_CARD_CACHE_TTL)")
@@ -85,7 +84,7 @@ func main() {
 	a2aRemoteAgents := flag.String("a2a-remote-agents", env("ORLOJ_A2A_REMOTE_AGENTS", ""), "JSON-encoded array of remote A2A agent configs (env: ORLOJ_A2A_REMOTE_AGENTS)")
 	a2aRateLimitEnabled := flag.Bool("a2a-rate-limit-enabled", envBool("ORLOJ_A2A_RATE_LIMIT_ENABLED", true), "enable per-IP rate limiting on A2A endpoints (env: ORLOJ_A2A_RATE_LIMIT_ENABLED)")
 	a2aRateLimitRPM := flag.Int("a2a-rate-limit-rpm", envInt("ORLOJ_A2A_RATE_LIMIT_RPM", 30), "A2A requests per minute per IP (env: ORLOJ_A2A_RATE_LIMIT_RPM)")
-	a2aRateLimitMaxSubscribe := flag.Int("a2a-rate-limit-max-subscribe", envInt("ORLOJ_A2A_RATE_LIMIT_MAX_SUBSCRIBE", 10), "max concurrent A2A SSE subscriptions per IP (env: ORLOJ_A2A_RATE_LIMIT_MAX_SUBSCRIBE)")
+	a2aRateLimitMaxSubscribe := flag.Int("a2a-rate-limit-max-subscribe", envInt("ORLOJ_A2A_RATE_LIMIT_MAX_SUBSCRIBE", 10), "max concurrent A2A SSE subscriptions globally (env: ORLOJ_A2A_RATE_LIMIT_MAX_SUBSCRIBE)")
 	toolK8sEnabled := flag.Bool("tool-k8s-enabled", envBool("ORLOJ_TOOL_K8S_ENABLED", false), "enable kubernetes tool isolation runtime for isolation_mode=kubernetes tools")
 	toolK8sNamespace := flag.String("tool-k8s-namespace", env("ORLOJ_TOOL_K8S_NAMESPACE", ""), "namespace for kubernetes tool isolation Jobs (default: pod namespace or 'default')")
 	toolK8sServiceAccount := flag.String("tool-k8s-service-account", env("ORLOJ_TOOL_K8S_SERVICE_ACCOUNT", ""), "service account for kubernetes tool isolation Pods")
@@ -119,6 +118,10 @@ func main() {
 	if *showVersion {
 		fmt.Println(version.String())
 		os.Exit(0)
+	}
+
+	if v := strings.TrimSpace(*apiKey); v != "" && os.Getenv("ORLOJ_API_TOKEN") == "" {
+		os.Setenv("ORLOJ_API_TOKEN", v)
 	}
 
 	resolvedLogLevel := *logLevelRaw
@@ -307,12 +310,12 @@ func main() {
 	taskController.SetMcpRuntime(mcpSessionManager, stores.McpServers)
 	if *toolK8sEnabled {
 		k8sRT, k8sErr := startup.NewKubernetesToolRuntime(startup.KubernetesToolRuntimeConfig{
-			Namespace:      *toolK8sNamespace,
-			ServiceAccount: *toolK8sServiceAccount,
-			JobTTLSeconds:  int32(*toolK8sJobTTL),
-			DefaultImage:   *toolK8sDefaultImage,
+			Namespace:       *toolK8sNamespace,
+			ServiceAccount:  *toolK8sServiceAccount,
+			JobTTLSeconds:   int32(*toolK8sJobTTL),
+			DefaultImage:    *toolK8sDefaultImage,
 			SecretEnvPrefix: *toolSecretEnvPrefix,
-			Secrets:        stores.Secrets,
+			Secrets:         stores.Secrets,
 		}, logger)
 		if k8sErr != nil {
 			fatalLogger.Fatalf("failed to configure kubernetes tool runtime: %v", k8sErr)
@@ -352,41 +355,37 @@ func main() {
 	taskController.SetA2AToolRuntime(a2aToolRT)
 
 	// A2A inbound protocol (API endpoints, registry, agent cards)
-	var a2aConfig *api.A2AConfig
 	var a2aRegistry *a2a.Registry
-	if *a2aEnabled {
-		var remoteAgentConfigs []a2a.RemoteAgentConfig
-		if raw := strings.TrimSpace(*a2aRemoteAgents); raw != "" {
-			if err := json.Unmarshal([]byte(raw), &remoteAgentConfigs); err != nil {
-				logger.Printf("WARNING: failed to parse ORLOJ_A2A_REMOTE_AGENTS: %v", err)
-			}
+	var remoteAgentConfigs []a2a.RemoteAgentConfig
+	if raw := strings.TrimSpace(*a2aRemoteAgents); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &remoteAgentConfigs); err != nil {
+			logger.Printf("WARNING: failed to parse ORLOJ_A2A_REMOTE_AGENTS: %v", err)
 		}
+	}
 
-		if len(remoteAgentConfigs) > 0 {
-			a2aRegistry = a2a.NewRegistry(a2aClient, remoteAgentConfigs, *a2aCardCacheTTL, logger)
-		}
+	if len(remoteAgentConfigs) > 0 {
+		a2aRegistry = a2a.NewRegistry(a2aClient, remoteAgentConfigs, *a2aCardCacheTTL, logger)
+	}
 
-		authSchemes := []string{}
-		if authMode != api.AuthModeOff {
-			authSchemes = append(authSchemes, "bearer")
-		}
+	authSchemes := []string{}
+	if authMode != api.AuthModeOff || strings.TrimSpace(*apiKey) != "" || strings.TrimSpace(os.Getenv("ORLOJ_API_TOKENS")) != "" {
+		authSchemes = append(authSchemes, "bearer")
+	}
 
-		rateLimitRPM := 0
-		maxConcurrentSubscribe := 0
-		if *a2aRateLimitEnabled {
-			rateLimitRPM = *a2aRateLimitRPM
-			maxConcurrentSubscribe = *a2aRateLimitMaxSubscribe
-		}
-		a2aConfig = &api.A2AConfig{
-			Enabled:                true,
-			PublicBaseURL:          strings.TrimSpace(*a2aPublicBaseURL),
-			ProtocolVersion:       strings.TrimSpace(*a2aProtocolVersion),
-			StreamingEnabled:      true,
-			AuthSchemes:           authSchemes,
-			Registry:              a2aRegistry,
-			RateLimitRPM:          rateLimitRPM,
-			MaxConcurrentSubscribe: maxConcurrentSubscribe,
-		}
+	rateLimitRPM := 0
+	maxConcurrentSubscribe := 0
+	if *a2aRateLimitEnabled {
+		rateLimitRPM = *a2aRateLimitRPM
+		maxConcurrentSubscribe = *a2aRateLimitMaxSubscribe
+	}
+	a2aConfig := &api.A2AConfig{
+		PublicBaseURL:          strings.TrimSpace(*a2aPublicBaseURL),
+		ProtocolVersion:        strings.TrimSpace(*a2aProtocolVersion),
+		StreamingEnabled:       true,
+		AuthSchemes:            authSchemes,
+		Registry:               a2aRegistry,
+		RateLimitRPM:           rateLimitRPM,
+		MaxConcurrentSubscribe: maxConcurrentSubscribe,
 	}
 
 	debugLogger.Printf(
@@ -409,10 +408,8 @@ func main() {
 		"bridge",
 	)
 
-	var requestAuthorizer api.RequestAuthorizer
-	if strings.TrimSpace(*apiKey) != "" {
-		requestAuthorizer = api.NewAPIKeyAuthorizer(*apiKey)
-	}
+	// Token auth (ORLOJ_API_TOKEN, ORLOJ_API_TOKENS, DB minted tokens) is wired
+	// via newTokenAuthorizerWithStoreFromEnv inside NewServerWithOptions.
 	server := api.NewServerWithOptions(api.Stores{
 		Agents:          stores.Agents,
 		AgentSystems:    stores.AgentSystems,
@@ -440,7 +437,6 @@ func main() {
 		APITokens:       stores.APITokens,
 		AuthSessions:    stores.AuthSessions,
 	}, runtime, logger, api.ServerOptions{
-		Authorizer:     requestAuthorizer,
 		Extensions:     extensions,
 		AuthMode:       authMode,
 		SessionTTL:     *authSessionTTL,
@@ -468,10 +464,8 @@ func main() {
 	}
 	server.SetEventBus(bus)
 	server.SetMemoryBackends(memoryBackendRegistry)
-	if a2aConfig != nil {
-		server.SetA2AConfig(a2aConfig)
-		logger.Printf("A2A protocol enabled base_url=%s protocol_version=%s", a2aConfig.PublicBaseURL, a2aConfig.ProtocolVersion)
-	}
+	server.SetA2AConfig(a2aConfig)
+	logger.Printf("A2A protocol configured base_url=%s protocol_version=%s", a2aConfig.PublicBaseURL, a2aConfig.ProtocolVersion)
 	taskController.SetEventBus(bus)
 	taskController.SetAgentMessageBus(agentMessageBus)
 	taskSchedulerController.SetEventBus(bus)

--- a/config/crd/bases/orloj.dev_agentsystems.yaml
+++ b/config/crd/bases/orloj.dev_agentsystems.yaml
@@ -46,6 +46,13 @@ spec:
             type: object
           spec:
             properties:
+              a2a:
+                properties:
+                  auth:
+                    type: string
+                  enabled:
+                    type: boolean
+                type: object
               agents:
                 items:
                   type: string

--- a/docs/design/a2a-auth-and-enablement.md
+++ b/docs/design/a2a-auth-and-enablement.md
@@ -1,0 +1,291 @@
+# A2A Authentication and Per-System Enablement
+
+**Status:** Draft  
+**Date:** 2026-05-23  
+**Authors:** Jon Mandraki
+
+## Problem
+
+Orloj has implemented the A2A protocol, but the auth model doesn't support the primary use case: an operator running an Orloj instance wants to expose specific AgentSystems to external callers via A2A, optionally behind authentication, without giving those callers access to the Orloj control plane.
+
+Today, A2A is a global server-level flag (`--a2a-enabled`). When it's on, every agent is on the A2A surface. There is no way to expose one AgentSystem while keeping others internal. And when auth is enabled, external callers need a token with the `writer` role — which also grants them full mutation access to agents, tools, secrets, and other Orloj resources.
+
+## Background
+
+### How A2A works in Orloj today
+
+A2A is a system-to-system protocol. An external agent system discovers an Orloj system via its Agent Card, then sends tasks via JSON-RPC. Orloj internally routes to the appropriate agent(s). The external caller doesn't address individual agents — the AgentSystem is the A2A boundary.
+
+Current A2A routes:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/.well-known/agent-card.json` | GET | System-level agent card (serves first agent) |
+| `/a2a` | POST | Top-level JSON-RPC endpoint |
+| `/v1/agents/{name}/.well-known/agent-card.json` | GET | Per-system agent card |
+| `/v1/agents/{name}/a2a` | POST | Per-system JSON-RPC endpoint |
+| `/v1/a2a/agents` | GET | Registry listing all agents |
+
+All routes go through `withAuth` middleware. There is no special handling for A2A paths in the authorization layer.
+
+### Current auth model
+
+`requiredRoleForRequest()` in `api/authz.go` assigns roles by HTTP method and path. A2A has no explicit entries — POST to `/a2a` falls through to the default `return "writer"` (line 427). GET to agent cards falls through to `return "reader"` (line 410).
+
+Available roles and their hierarchy:
+
+| Role | Satisfies | Purpose |
+|------|-----------|---------|
+| `admin` | everything | Full control-plane access |
+| `writer` | writer, reader | Resource mutation + read |
+| `controller` | controller, reader | Status patches + read |
+| `reader` | reader | Read-only |
+
+Token sources:
+
+- `ORLOJ_API_TOKEN` — single env token, defaults to **admin** role
+- `ORLOJ_API_TOKENS` — comma-separated `name:token:role` entries
+- `POST /v1/tokens` — admin-only; creates named tokens in Postgres
+
+### What's wrong
+
+1. **No per-system A2A toggle.** The global `--a2a-enabled` flag is all-or-nothing. An operator with multiple AgentSystems cannot expose some via A2A while keeping others internal.
+
+2. **No A2A-appropriate role.** External callers need `writer` to POST to A2A endpoints. But `writer` also grants access to create/update/delete agents, tools, secrets, MCP servers, and other resources. There is no role that means "can invoke A2A but nothing else."
+
+3. **Discovery requires auth when auth is on.** In production, auth is always enabled. Currently, agent card GET requires `reader` role — so external systems can't even discover the agent card without a token. In the A2A model, discovery should be public for A2A-enabled systems.
+
+4. **Agent card may not advertise auth requirements.** Auth schemes in the card are only set when `authMode != AuthModeOff` (in `cmd/orlojd/main.go`). With `auth-mode=off` + `ORLOJ_API_TOKEN` set, auth is enforced but the card omits the `authentication` block. External systems doing spec-compliant discovery won't know auth is required.
+
+5. **Global flag is redundant if per-system enablement exists.** If each AgentSystem declares whether it's on the A2A surface, the global `--a2a-enabled` flag adds no value and creates a potential misconfiguration (system has `a2a.enabled: true` but global flag is off).
+
+## Design
+
+### Per-system A2A enablement
+
+Add an A2A configuration block to `AgentSystemSpec`:
+
+```go
+type AgentSystemA2ASpec struct {
+    Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+}
+```
+
+```go
+type AgentSystemSpec struct {
+    Agents           []string              `json:"agents,omitempty" yaml:"agents,omitempty"`
+    Graph            map[string]GraphEdge  `json:"graph,omitempty" yaml:"graph,omitempty"`
+    // ... existing fields ...
+    A2A              AgentSystemA2ASpec    `json:"a2a,omitempty" yaml:"a2a,omitempty"`
+}
+```
+
+Operator manifest:
+
+```yaml
+apiVersion: orloj.dev/v1
+kind: AgentSystem
+metadata:
+  name: legal-vault
+  annotations:
+    orloj.dev/description: "Legal research and case law analysis"
+spec:
+  agents: [legal-research-agent, case-summary-agent]
+  a2a:
+    enabled: true
+```
+
+The `a2a.enabled` field replaces the global `--a2a-enabled` server flag. A2A routes are active when at least one AgentSystem has `a2a.enabled: true`. The global flag is removed.
+
+### New `a2a` role
+
+Add a new role to the authorization model that permits A2A invoke and read access but denies control-plane mutations.
+
+Updated role hierarchy:
+
+| Role | Satisfies | Purpose |
+|------|-----------|---------|
+| `admin` | everything | Full control-plane access |
+| `writer` | writer, a2a, reader | Resource mutation + A2A + read |
+| `a2a` | a2a, reader | A2A invoke + read |
+| `controller` | controller, reader | Status patches + read |
+| `reader` | reader | Read-only |
+
+`writer` and `admin` both satisfy `a2a` for backward compatibility — existing tokens continue to work.
+
+### A2A path routing
+
+Update `requiredRoleForRequest()` to explicitly handle A2A paths instead of falling through to `writer`:
+
+| Path | Method | Required role |
+|------|--------|--------------|
+| `/.well-known/agent-card.json` | GET | `""` (public, for a2a-enabled systems) |
+| `/v1/agents/{name}/.well-known/agent-card.json` | GET | `""` (public, for a2a-enabled systems) |
+| `/v1/a2a/agents` | GET | `""` (public registry of a2a-enabled systems) |
+| `/a2a` | POST | `a2a` |
+| `/v1/agents/{name}/a2a` | POST | `a2a` |
+
+Discovery endpoints (GET) are public — this is how external systems find you. The A2A handlers themselves check whether the target AgentSystem has `a2a.enabled: true` and return 404 if not, so unenabled systems are not discoverable even though the route is unauthenticated.
+
+Invoke endpoints (POST) require the `a2a` role when auth is active.
+
+### Agent card auth advertisement
+
+Fix the agent card generation to accurately reflect auth requirements. Currently in `cmd/orlojd/main.go`:
+
+```go
+if authMode != api.AuthModeOff {
+    authSchemes = append(authSchemes, "bearer")
+}
+```
+
+This should reflect whether token auth is actually active (tokens configured), not just whether `auth-mode` is explicitly set. When auth is active, the card advertises `authentication.schemes: ["bearer"]` so the calling system knows to send a token for invoke.
+
+### Handler changes
+
+Update A2A handlers in `api/a2a.go`:
+
+- **`handleWellKnownAgentCard`** — instead of serving `agents[0]`, find the first AgentSystem with `a2a.enabled: true` and serve its system card. Return 404 if none found.
+- **`handleAgentCard`** — look up AgentSystem by name. Return 404 if not found or not a2a-enabled.
+- **`handleA2AJSONRPC`** — resolve target system. Reject with error if the target AgentSystem doesn't have `a2a.enabled: true`.
+- **`handleA2ARegistry`** — only list AgentSystems with `a2a.enabled: true`.
+
+## Operator workflow
+
+### Open A2A (no auth)
+
+For dev, demos, or intentionally public systems:
+
+```yaml
+# Auth is off (default), system is A2A-enabled
+kind: AgentSystem
+metadata:
+  name: public-assistant
+spec:
+  agents: [helper-agent]
+  a2a:
+    enabled: true
+```
+
+Anyone can discover and invoke. No tokens needed.
+
+### Authenticated A2A (production)
+
+```yaml
+# System is A2A-enabled
+kind: AgentSystem
+metadata:
+  name: legal-vault
+spec:
+  agents: [legal-research-agent, case-summary-agent]
+  a2a:
+    enabled: true
+```
+
+```bash
+# Operator enables auth (always on in production)
+# and mints an a2a-role token for the external caller
+curl -X POST /v1/tokens \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -d '{"name": "acme-corp", "role": "a2a"}'
+# Returns a token that can ONLY invoke A2A and read agent cards
+```
+
+External caller:
+
+```bash
+# Discovery — no token needed
+curl GET /.well-known/agent-card.json
+# → Returns legal-vault card with authentication.schemes: ["bearer"]
+
+# Invoke — requires a2a token
+curl -X POST /v1/agents/legal-vault/a2a \
+  -H "Authorization: Bearer $A2A_TOKEN" \
+  -d '{"jsonrpc":"2.0","method":"tasks/send",...}'
+# → 200 OK
+
+# Control plane — blocked
+curl -X POST /v1/agents \
+  -H "Authorization: Bearer $A2A_TOKEN" \
+  -d '...'
+# → 403 Forbidden
+```
+
+### Mixed systems (some A2A, some internal)
+
+```yaml
+# Exposed via A2A
+kind: AgentSystem
+metadata:
+  name: legal-vault
+spec:
+  agents: [legal-research-agent, case-summary-agent]
+  a2a:
+    enabled: true
+---
+# Internal only — not on A2A surface
+kind: AgentSystem
+metadata:
+  name: internal-ops
+spec:
+  agents: [monitoring-agent, alerting-agent]
+  # no a2a block, or a2a.enabled: false
+```
+
+`internal-ops` is invisible to A2A — no card, no invoke, doesn't appear in the registry. But it's fully usable internally via the Orloj control plane.
+
+## Implementation plan
+
+### Files to change
+
+#### 1. Add `a2a` role
+
+- **`store/auth_store.go`** — add `"a2a"` to `allowedAuthRoleValues` map
+- **`api/authz.go`** — add `"a2a"` to `normalizeAPIRole` switch; update `roleAllows` so `a2a` satisfies `reader` and `a2a`, `writer`/`admin` satisfy `a2a`
+
+#### 2. Route A2A paths
+
+- **`api/authz.go`** — add explicit cases in `requiredRoleForRequest()` for A2A paths: POST to `/a2a` and paths ending in `/a2a` return `"a2a"`; GET to well-known and registry paths return `""` (public)
+
+#### 3. Add A2A spec to AgentSystem
+
+- **`resources/resource_types.go`** — add `AgentSystemA2ASpec` struct and `A2A` field to `AgentSystemSpec`
+
+#### 4. Remove global A2A flag
+
+- **`cmd/orlojd/main.go`** — remove `--a2a-enabled` flag; derive A2A availability from stored AgentSystem specs
+- **`api/server.go`** — update `A2AConfig` to remove the `Enabled` field; the handlers check per-system enablement instead
+
+#### 5. Update A2A handlers
+
+- **`api/a2a.go`** — update all handlers to check `AgentSystem.Spec.A2A.Enabled` instead of `s.a2aConfig.Enabled`; filter registry to only a2a-enabled systems; make discovery endpoints serve only a2a-enabled systems
+
+#### 6. Fix agent card auth advertisement
+
+- **`cmd/orlojd/main.go`** — set auth schemes when token auth is active, not just when `authMode != off`
+
+#### 7. Generated artifacts
+
+- Run `make generate-crds` — commit updated YAML under `config/crd/bases/`
+- Sync Helm chart at `charts/orloj/templates/operator-crds.yaml`
+- Update OpenAPI schemas under `openapi/` — add `a2a` to role enum, add A2A spec to AgentSystem schema
+- Run `npx --yes @redocly/cli@1.28.5 lint openapi/openapi.yaml`
+
+#### 8. Tests
+
+- `roleAllows` — `a2a` satisfies `reader`/`a2a` but not `writer`; `writer`/`admin` satisfy `a2a`
+- `requiredRoleForRequest` — returns `"a2a"` for POST to A2A paths; returns `""` for GET to discovery paths
+- AgentSystem with `a2a.enabled: true` is discoverable and invokable
+- AgentSystem without `a2a.enabled` returns 404 on card and rejects invoke
+- `a2a`-role token cannot POST to `/v1/agents` or `/v1/tools`
+
+#### 9. Changelog
+
+- Add entries under `## [Unreleased]` → `Added`
+
+## Out of scope (future work)
+
+- **Per-system token scoping** — restricting an `a2a` token to specific AgentSystems. Currently an `a2a` token can invoke any a2a-enabled system on the instance. For multi-tenant scenarios where different customers should only access their system, token scoping or the `ResourceAuthorizer` extension point could be used. Not needed when the instance runs a single a2a-enabled system.
+- **Per-subscriber rate limiting** — current A2A rate limiting is IP-based. Per-token rate limiting would require identity-aware rate limiting.
+- **OAuth / mTLS auth schemes** — the card can advertise additional auth schemes beyond `bearer`. Supporting these requires integration with external identity providers.
+- **Lessee self-service** — token rotation, usage dashboards, etc. Currently all token management is admin-only via `/v1/tokens`.

--- a/docs/pages/concepts/a2a-interoperability.md
+++ b/docs/pages/concepts/a2a-interoperability.md
@@ -15,7 +15,7 @@ A2A support in Orloj has two directions:
 ```
 A2A Client
   → GET /.well-known/agent-card.json  (discovery)
-  → POST /a2a  or  /v1/agents/{name}/a2a  (JSON-RPC)
+  → POST /a2a  or  /v1/agent-systems/{name}/a2a  (JSON-RPC)
     → Orloj creates a Task, runs the AgentSystem
     → Returns A2A status updates and artifacts
 ```
@@ -35,18 +35,18 @@ Both directions reuse existing Orloj infrastructure: Tasks, auth, governance, we
 
 ## Agent Cards
 
-Every Orloj agent exposed via A2A publishes an **Agent Card** -- a JSON document describing the agent's name, capabilities, skills, authentication requirements, and endpoint URL.
+Every Orloj AgentSystem exposed via A2A publishes an **Agent Card** -- a JSON document describing the system's name, capabilities, skills, authentication requirements, and endpoint URL.
 
 Cards are generated automatically from the agent's metadata, tools, and runtime configuration:
 
-- **Name** and **description** come from `metadata.name` and `metadata.annotations["orloj.dev/description"]`.
+- **Name** and **description** come from the AgentSystem `metadata.name` and `metadata.annotations["orloj.dev/description"]`.
 - **Skills** are derived from the agent's attached tools, including each tool's `description` and `input_schema`.
 - **Capabilities** reflect runtime support: streaming (from task trace SSE), push notifications (from TaskWebhook support), and state transition history.
 - **Authentication** reflects the server's configured auth mode.
 
 Cards are served at:
-- `GET /.well-known/agent-card.json` -- default agent
-- `GET /v1/agents/{name}/.well-known/agent-card.json` -- specific agent
+- `GET /.well-known/agent-card.json` -- only when exactly one AgentSystem is A2A-enabled
+- `GET /v1/agent-systems/{name}/.well-known/agent-card.json` -- specific AgentSystem
 
 ## State Mapping
 
@@ -68,8 +68,8 @@ Orloj task output is converted to A2A artifacts, and trace/watch events are conv
 
 Two routing modes are supported for inbound A2A requests:
 
-1. **Per-agent endpoints** (recommended): `POST /v1/agents/{name}/a2a` -- the agent name is in the URL path. Each agent's card `url` field points to its per-agent endpoint.
-2. **Shared endpoint**: `POST /a2a` -- the target is resolved from request params. When a single agent system is configured, this endpoint defaults to it.
+1. **Per-system endpoints** (recommended): `POST /v1/agent-systems/{name}/a2a` -- the AgentSystem name is in the URL path. Each system's card `url` field points to its per-system endpoint.
+2. **Shared endpoint**: `POST /a2a` -- the target is resolved from request params. When a single AgentSystem is A2A-enabled, this endpoint defaults to it.
 
 ## Outbound: A2A Tools
 
@@ -82,17 +82,17 @@ Existing `spec.auth` profiles (bearer, API key, basic, OAuth2) work for authenti
 A2A endpoints participate in Orloj's existing security model:
 
 - **Agent Card discovery** endpoints are public (no auth required) -- cards contain only metadata, not secrets.
-- **JSON-RPC endpoints** require authentication (bearer token or session cookie), same as other API endpoints.
+- **JSON-RPC endpoints** enforce per-system auth via `spec.a2a.auth` (`"bearer"` by default, or `"public"` for unauthenticated access). All four methods (`tasks/send`, `tasks/get`, `tasks/cancel`, `tasks/sendSubscribe`) require a valid bearer token on `auth: bearer` systems. Native-auth browser sessions are not accepted for A2A invocation.
+- **Scoped `a2a` tokens** can invoke only the AgentSystems listed in their `a2a_agent_systems` scope and cannot read or mutate control-plane resources.
 - **Outbound calls** to remote agents use tool-level auth (`spec.auth`) and are subject to governance (AgentRole, ToolPermission, AgentPolicy).
 - **Private endpoint protection**: by default, outbound A2A calls to private/internal endpoints are blocked (`a2a.allowPrivateEndpoints` defaults to `false`).
 
 ## Configuration
 
-A2A is enabled via server configuration:
+A2A is enabled per AgentSystem with `spec.a2a.enabled: true`. Server configuration controls advertised URLs and outbound registry behavior:
 
 | Setting | Description |
 |---------|-------------|
-| `a2a.enabled` | Enable A2A protocol support |
 | `a2a.publicBaseURL` | Public base URL for Agent Card endpoint URLs |
 | `a2a.protocolVersion` | A2A protocol version to advertise |
 | `a2a.remoteAgents[]` | Pre-configured remote A2A agents for the registry |

--- a/docs/pages/deploy/kubernetes.md
+++ b/docs/pages/deploy/kubernetes.md
@@ -292,11 +292,10 @@ Agent Jobs use deterministic names based on the task, agent, and attempt number.
 
 ## A2A Protocol
 
-To enable A2A protocol support in a Helm deployment, set the `a2a.*` values:
+To configure public A2A Agent Card URLs in a Helm deployment, set the A2A public base URL. Individual AgentSystems are exposed with `spec.a2a.enabled: true`.
 
 ```bash
 helm upgrade orloj ./charts/orloj --namespace orloj --reuse-values \
-  --set a2a.enabled=true \
   --set a2a.publicBaseURL=https://orloj.example.com
 ```
 

--- a/docs/pages/guides/a2a-expose-agents.md
+++ b/docs/pages/guides/a2a-expose-agents.md
@@ -1,6 +1,6 @@
-# Expose Agents via A2A
+# Expose AgentSystems via A2A
 
-This guide walks through enabling A2A protocol support so external A2A clients can discover and interact with your Orloj agents.
+This guide walks through exposing selected Orloj AgentSystems to external A2A clients.
 
 ## Prerequisites
 
@@ -10,28 +10,31 @@ This guide walks through enabling A2A protocol support so external A2A clients c
 
 If you have not set up Orloj yet, follow the [Install](../getting-started/install.md) and [Quickstart](../getting-started/quickstart.md) guides first.
 
-## Step 1: Enable A2A
+## Step 1: Expose an AgentSystem
 
-Enable A2A support and set the public base URL that external clients will use to reach your Orloj instance.
+Add `spec.a2a.enabled: true` to each AgentSystem that should be reachable through A2A. Systems without this block remain internal.
 
-With server flags:
-
-```bash
-orlojd --a2a-enabled --a2a-public-base-url https://orloj.example.com
+```yaml
+apiVersion: orloj.dev/v1
+kind: AgentSystem
+metadata:
+  name: research-system
+spec:
+  agents:
+    - research-agent
+  a2a:
+    enabled: true
 ```
 
-Or via environment variables:
+Set the public base URL so generated Agent Cards point at the externally reachable host:
 
 ```bash
-export ORLOJ_A2A_ENABLED=true
-export ORLOJ_A2A_PUBLIC_BASE_URL=https://orloj.example.com
+orlojd --a2a-public-base-url https://orloj.example.com
 ```
-
-The `publicBaseURL` is used to construct the `url` field in generated Agent Cards. It must be reachable by external A2A clients.
 
 ## Step 2: Verify the Default Agent Card
 
-Once A2A is enabled, the server exposes Agent Cards at well-known URLs. Verify with curl:
+If exactly one AgentSystem is A2A-enabled, the root well-known URL returns its card:
 
 ```bash
 curl -s http://localhost:8080/.well-known/agent-card.json | jq .
@@ -41,9 +44,9 @@ Expected output:
 
 ```json
 {
-  "name": "my-agent",
+  "name": "research-system",
   "description": "Research assistant with web search capabilities",
-  "url": "https://orloj.example.com/v1/agents/my-agent/a2a",
+  "url": "https://orloj.example.com/v1/agent-systems/research-system/a2a",
   "protocolVersion": "0.2",
   "capabilities": {
     "streaming": true,
@@ -64,10 +67,10 @@ Expected output:
 }
 ```
 
-For a specific agent:
+For a specific AgentSystem:
 
 ```bash
-curl -s http://localhost:8080/v1/agents/research-agent/.well-known/agent-card.json | jq .
+curl -s http://localhost:8080/v1/agent-systems/research-system/.well-known/agent-card.json | jq .
 ```
 
 ## Step 3: Test Inbound Task Creation
@@ -75,7 +78,7 @@ curl -s http://localhost:8080/v1/agents/research-agent/.well-known/agent-card.js
 Send an A2A `tasks/send` request to create a task:
 
 ```bash
-curl -s -X POST http://localhost:8080/a2a \
+curl -s -X POST http://localhost:8080/v1/agent-systems/research-system/a2a \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $ORLOJ_TOKEN" \
   -d '{
@@ -117,16 +120,16 @@ The response contains an A2A task with a status:
 }
 ```
 
-## Step 4: Per-Agent Endpoints
+## Step 4: Multiple Systems
 
-For multi-agent deployments, use per-agent A2A endpoints. Each agent gets its own card and JSON-RPC endpoint:
+For deployments with multiple exposed systems, use per-system cards and endpoints:
 
 ```bash
 # Discovery
-curl -s http://localhost:8080/v1/agents/research-agent/.well-known/agent-card.json
+curl -s http://localhost:8080/v1/agent-systems/research-system/.well-known/agent-card.json
 
 # Task submission
-curl -s -X POST http://localhost:8080/v1/agents/research-agent/a2a \
+curl -s -X POST http://localhost:8080/v1/agent-systems/research-system/a2a \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $ORLOJ_TOKEN" \
   -d '{
@@ -143,14 +146,14 @@ curl -s -X POST http://localhost:8080/v1/agents/research-agent/a2a \
   }'
 ```
 
-The per-agent card's `url` field points to `https://orloj.example.com/v1/agents/research-agent/a2a`, so A2A clients that discover the card know where to send requests.
+The per-system card's `url` field points to `https://orloj.example.com/v1/agent-systems/research-system/a2a`, so A2A clients that discover the card know where to send requests.
 
 ## Step 5: Streaming Subscribe
 
 For long-running tasks, use `tasks/sendSubscribe` to receive streaming updates via SSE:
 
 ```bash
-curl -s -N -X POST http://localhost:8080/v1/agents/research-agent/a2a \
+curl -s -N -X POST http://localhost:8080/v1/agent-systems/research-system/a2a \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $ORLOJ_TOKEN" \
   -d '{
@@ -174,30 +177,51 @@ The server responds with a stream of SSE events containing status updates and ar
 When an A2A request arrives:
 
 1. The JSON-RPC method is parsed and validated.
-2. The target agent is resolved from the URL path (per-agent) or request params (shared endpoint).
+2. The target AgentSystem is resolved from the URL path or request params (shared endpoint).
 3. An Orloj Task is created with A2A metadata labels.
 4. The AgentSystem executes the task using the normal Orloj pipeline.
 5. Task status transitions are mapped to A2A states and returned in the response.
 6. For `tasks/sendSubscribe`, the task's trace/watch SSE stream is converted to A2A streaming events.
 
-## Agent Card Customization
+## Per-System Auth Policy
 
-Agent Cards are auto-generated, but you can influence the output with annotations:
+By default, A2A invoke requires a bearer token when instance-wide auth is configured. To allow unauthenticated callers to invoke a specific system, set `spec.a2a.auth: public`:
 
 ```yaml
 apiVersion: orloj.dev/v1
-kind: Agent
+kind: AgentSystem
 metadata:
-  name: research-agent
+  name: public-assistant
+spec:
+  agents:
+    - assistant-agent
+  a2a:
+    enabled: true
+    auth: public
+```
+
+This is useful when you want admin tokens for the control plane (`/v1/agents`, `/v1/tools`, etc.) but need a public-facing A2A endpoint for external clients. Invalid tokens are still rejected — only missing tokens are permitted on public systems.
+
+Public systems' Agent Cards omit `authentication.schemes`, so A2A clients that discover the card know not to send tokens. The A2A registry (`GET /v1/a2a/agents`) shows public systems to unauthenticated callers.
+
+To require auth (the default), omit `auth` or set `spec.a2a.auth: bearer`.
+
+## Agent Card Customization
+
+Agent Cards are auto-generated from the AgentSystem and its agents, but you can influence the output with annotations:
+
+```yaml
+apiVersion: orloj.dev/v1
+kind: AgentSystem
+metadata:
+  name: research-system
   annotations:
     orloj.dev/description: "AI research assistant specializing in academic papers"
 spec:
-  model_ref: openai-default
-  prompt: |
-    You are a research assistant. Search for and summarize academic papers.
-  tools:
-    - web_search
-    - arxiv_search
+  agents:
+    - research-agent
+  a2a:
+    enabled: true
 ```
 
 The `orloj.dev/description` annotation overrides the description in the generated card.

--- a/docs/pages/guides/a2a-remote-agents.md
+++ b/docs/pages/guides/a2a-remote-agents.md
@@ -4,7 +4,7 @@ This guide walks through configuring Orloj to call external A2A agents as tools.
 
 ## Prerequisites
 
-- Orloj server (`orlojd`) running with A2A enabled (`--a2a-enabled`)
+- Orloj server (`orlojd`) running, with any inbound A2A exposure enabled per AgentSystem when needed
 - `orlojctl` available
 - A remote A2A agent endpoint (any A2A-compliant agent)
 
@@ -168,7 +168,7 @@ Response:
   "localAgents": [
     {
       "name": "research-agent",
-      "url": "https://orloj.example.com/v1/agents/research-agent/a2a",
+      "url": "https://orloj.example.com/v1/agent-systems/research-system/a2a",
       "capabilities": { "streaming": true }
     }
   ],

--- a/docs/pages/operations/configuration.md
+++ b/docs/pages/operations/configuration.md
@@ -76,7 +76,6 @@ Example:
 
 | Variable | Used By | Flag Overrides | Purpose / Conditions |
 |---|---|---|---|
-| `ORLOJ_A2A_ENABLED` | `orlojd` | `--a2a-enabled` | Enable A2A protocol endpoints and `a2a` tool type. Default: `false`. |
 | `ORLOJ_A2A_PUBLIC_BASE_URL` | `orlojd` | `--a2a-public-base-url` | Public base URL used in Agent Card `url` fields. Required for externally-reachable cards. |
 | `ORLOJ_A2A_PROTOCOL_VERSION` | `orlojd` | `--a2a-protocol-version` | A2A protocol version string to advertise in Agent Cards. |
 | `ORLOJ_A2A_CARD_CACHE_TTL` | `orlojd`, `orlojworker` | `--a2a-card-cache-ttl` | Cache TTL for fetched remote Agent Cards. Default: `5m`. |

--- a/docs/pages/operations/security.md
+++ b/docs/pages/operations/security.md
@@ -54,7 +54,7 @@ For **multiple** distinct tokens with different roles (reader vs admin-style acc
 export ORLOJ_API_TOKENS='reader-bot:reader-token-here:reader,automation-bot:automation-token-here:admin'
 ```
 
-Format is comma-separated `name:token:role` entries. Legacy `token:role` entries are still accepted for backward compatibility. When `ORLOJ_API_TOKENS` is set, it populates the token map and a single `ORLOJ_API_TOKEN` is only used if that list is empty (see `loadAuthConfig` in `api/authz.go`).
+Format is comma-separated `name:token:role` entries. Legacy `token:role` entries are still accepted for backward compatibility. A2A invoke-only tokens use `name:token:a2a:namespace/system|other-system` and can invoke only those A2A-enabled AgentSystems. When `ORLOJ_API_TOKENS` is set, it populates the token map and a single `ORLOJ_API_TOKEN` is only used if that list is empty (see `loadAuthConfig` in `api/authz.go`).
 
 For runtime-managed tokens (no server restart required), use:
 
@@ -63,6 +63,8 @@ orlojctl create token <name> --role <role>
 orlojctl get tokens
 orlojctl delete token <name>
 ```
+
+When creating an `a2a` role token through the API, include `a2a_agent_systems` with the allowed AgentSystem refs. Native-auth browser sessions are not accepted for A2A JSON-RPC; external A2A callers must use bearer tokens.
 
 ### 3. Configure clients (`orlojctl` and automation)
 
@@ -129,7 +131,14 @@ Outbound A2A requests (fetching remote Agent Cards and sending JSON-RPC calls) u
 
 ### Auth Enforcement
 
-Inbound A2A JSON-RPC requests are subject to the same authentication and authorization checks as other API endpoints. When `--auth-mode=native` is enabled, A2A callers must provide a valid bearer token.
+Inbound A2A JSON-RPC requests are subject to authentication based on the target AgentSystem's `spec.a2a.auth` policy:
+
+- **`bearer`** (default): requires a valid bearer token with `a2a`, `writer`, or `admin` role. Scoped `a2a` tokens can only invoke systems listed in their `a2a_agent_systems`. This is the same enforcement as other protected API endpoints.
+- **`public`**: allows unauthenticated A2A invoke for that specific system, even when instance-wide auth is configured. Control-plane APIs (`/v1/agents`, `/v1/tools`, etc.) remain protected. Invalid tokens are still rejected (401) — only missing tokens are permitted.
+
+This enables a common production pattern: admin secret for `orlojctl` / control-plane APIs, plus public unauthenticated A2A invoke for selected systems, all on the same `orlojd` instance.
+
+Agent Card discovery (GET) is always public regardless of `spec.a2a.auth`. Public systems' Agent Cards omit `authentication.schemes` so A2A clients know not to send tokens. The A2A registry (`GET /v1/a2a/agents`) shows only public systems to unauthenticated callers and all accessible systems to authenticated callers.
 
 ### Private Endpoint Risks
 

--- a/docs/pages/reference/a2a-jsonrpc.md
+++ b/docs/pages/reference/a2a-jsonrpc.md
@@ -8,8 +8,10 @@ Orloj exposes A2A functionality via JSON-RPC 2.0 over HTTP. All requests are `PO
 
 | Endpoint | Auth | Description |
 |----------|------|-------------|
-| `POST /a2a` | Required | Shared JSON-RPC endpoint. Resolves target from params or defaults to the single configured agent. |
-| `POST /v1/agents/{name}/a2a` | Required | Per-agent JSON-RPC endpoint. Agent name in the path determines routing. |
+| `POST /a2a` | Bearer token when auth is enabled | Shared JSON-RPC endpoint. Resolves target from params or defaults to the single A2A-enabled AgentSystem. |
+| `POST /v1/agent-systems/{name}/a2a` | Bearer token when auth is enabled | Per-system JSON-RPC endpoint. AgentSystem name in the path determines routing. |
+
+Legacy `/v1/agents/{name}/a2a` paths are accepted as aliases for AgentSystem names.
 
 ## Request Format
 

--- a/docs/pages/reference/api.md
+++ b/docs/pages/reference/api.md
@@ -258,13 +258,13 @@ Returns a server-sent event stream of resource changes. Events include the resou
 
 ## A2A Endpoints
 
-When A2A protocol support is enabled (`--a2a-enabled`), the following endpoints are available:
+AgentSystems opt in to inbound A2A with `spec.a2a.enabled: true`. Enabled systems are available through:
 
-- `GET /.well-known/agent-card.json` — System-wide Agent Card describing all published agents.
-- `GET /v1/agents/{name}/.well-known/agent-card.json` — Per-agent Agent Card.
-- `POST /a2a` — Shared JSON-RPC 2.0 endpoint for A2A task operations.
-- `POST /v1/agents/{name}/a2a` — Per-agent JSON-RPC endpoint scoped to a single agent.
-- `GET /v1/a2a/agents` — Registry listing of all A2A-capable agents (local and remote).
+- `GET /.well-known/agent-card.json` — root Agent Card when exactly one AgentSystem is A2A-enabled.
+- `GET /v1/agent-systems/{name}/.well-known/agent-card.json` — per-system Agent Card.
+- `POST /a2a` — shared JSON-RPC 2.0 endpoint for A2A task operations.
+- `POST /v1/agent-systems/{name}/a2a` — JSON-RPC endpoint scoped to one AgentSystem.
+- `GET /v1/a2a/agents` — registry listing A2A-enabled systems visible to the bearer token plus remote entries.
 
 See [A2A Interoperability](../concepts/a2a-interoperability.md) for protocol details.
 

--- a/docs/pages/reference/resources/agent-card.md
+++ b/docs/pages/reference/resources/agent-card.md
@@ -2,7 +2,7 @@
 
 > **Stability: beta** -- Agent Cards are generated resources that follow the [A2A specification](https://github.com/a2aproject/A2A). The schema may evolve as the A2A spec matures.
 
-An Agent Card is a JSON document that describes an Orloj agent's A2A identity, capabilities, skills, and endpoint. Cards are auto-generated from agent metadata and served at well-known discovery URLs.
+An Agent Card is a JSON document that describes an Orloj AgentSystem's A2A identity, capabilities, skills, and endpoint. Cards are auto-generated from AgentSystem metadata and its agents' tools.
 
 Agent Cards are not stored resources -- they are computed on request from the agent's current state.
 
@@ -10,8 +10,8 @@ Agent Cards are not stored resources -- they are computed on request from the ag
 
 | URL | Description |
 |-----|-------------|
-| `GET /.well-known/agent-card.json` | Default agent card |
-| `GET /v1/agents/{name}/.well-known/agent-card.json` | Card for a specific agent |
+| `GET /.well-known/agent-card.json` | Root card when exactly one AgentSystem is A2A-enabled |
+| `GET /v1/agent-systems/{name}/.well-known/agent-card.json` | Card for a specific AgentSystem |
 
 Both endpoints are public (no authentication required). Cards contain only metadata, not secrets.
 
@@ -21,7 +21,7 @@ Both endpoints are public (no authentication required). Cards contain only metad
 |-------|------|----------|-------------|
 | `name` | string | Yes | Human-readable agent name. Derived from `metadata.name`. |
 | `description` | string | No | Agent description. From `metadata.annotations["orloj.dev/description"]` or a prompt summary. |
-| `url` | string (URI) | Yes | A2A JSON-RPC endpoint URL. Constructed from `a2a.publicBaseURL` + agent path. |
+| `url` | string (URI) | Yes | A2A JSON-RPC endpoint URL. Constructed from `a2a.publicBaseURL` + AgentSystem path. |
 | `version` | string | No | Agent version. From `metadata.labels["orloj.dev/version"]` if present. |
 | `protocolVersion` | string | No | A2A protocol version. From `a2a.protocolVersion` config. |
 | `capabilities` | object | No | See [Capabilities](#capabilities). |
@@ -70,7 +70,7 @@ How Orloj resources map to Agent Card fields:
 |------------|--------|
 | `name` | `Agent.metadata.name` |
 | `description` | `Agent.metadata.annotations["orloj.dev/description"]`, or prompt excerpt |
-| `url` | `a2a.publicBaseURL` + `/v1/agents/{name}/a2a` |
+| `url` | `a2a.publicBaseURL` + `/v1/agent-systems/{name}/a2a` |
 | `protocolVersion` | `a2a.protocolVersion` server config |
 | `capabilities.streaming` | Server SSE support enabled |
 | `capabilities.pushNotifications` | TaskWebhook controller active |
@@ -81,29 +81,29 @@ How Orloj resources map to Agent Card fields:
 
 ## Example Card
 
-For an agent defined as:
+For an AgentSystem defined as:
 
 ```yaml
 apiVersion: orloj.dev/v1
-kind: Agent
+kind: AgentSystem
 metadata:
-  name: research-agent
+  name: research-system
   annotations:
     orloj.dev/description: "AI research assistant for academic papers"
 spec:
-  model_ref: openai-default
-  tools:
-    - web_search
-    - arxiv_search
+  agents:
+    - research-agent
+  a2a:
+    enabled: true
 ```
 
-The generated card (at `GET /v1/agents/research-agent/.well-known/agent-card.json`):
+The generated card (at `GET /v1/agent-systems/research-system/.well-known/agent-card.json`):
 
 ```json
 {
-  "name": "research-agent",
+  "name": "research-system",
   "description": "AI research assistant for academic papers",
-  "url": "https://orloj.example.com/v1/agents/research-agent/a2a",
+  "url": "https://orloj.example.com/v1/agent-systems/research-system/a2a",
   "protocolVersion": "0.2",
   "capabilities": {
     "streaming": true,

--- a/docs/pages/reference/resources/agent-system.md
+++ b/docs/pages/reference/resources/agent-system.md
@@ -8,6 +8,8 @@
 - `graph` (map[string]GraphEdge): per-node routing.
 - `context_adapter` (string): optional reference to a [ContextAdapter](./context-adapter.md) resource. When set, the adapter's tool sanitizes raw task input before the first agent runs.
 - `completion_review` (ReviewCheckpoint): optional final human review before the task is marked `Succeeded`.
+- `a2a.enabled` (bool): expose this AgentSystem through inbound A2A Agent Card discovery and JSON-RPC invocation. Omitted or `false` keeps the system off the A2A surface.
+- `a2a.auth` (string: `"public"` | `"bearer"`): controls whether A2A invoke requires authentication for this system. `"public"` allows unauthenticated callers; `"bearer"` (default when omitted) requires a valid API token when instance-wide auth is enabled. Public systems' Agent Cards omit `authentication.schemes` so A2A clients know not to send tokens.
 
 `GraphEdge` fields:
 

--- a/docs/pages/reference/server-flags.md
+++ b/docs/pages/reference/server-flags.md
@@ -41,7 +41,6 @@ go run ./cmd/orlojd -h
 
 | Flag | Default | Description | Condition / Notes |
 |---|---|---|---|
-| `--a2a-enabled` | `false` | Enable A2A protocol endpoints and tool type. | Env `ORLOJ_A2A_ENABLED`. |
 | `--a2a-public-base-url` | empty | Public base URL for Agent Card `url` fields. | Env `ORLOJ_A2A_PUBLIC_BASE_URL`. Required for externally-reachable Agent Cards. |
 | `--a2a-protocol-version` | empty | A2A protocol version to advertise. | Env `ORLOJ_A2A_PROTOCOL_VERSION`. |
 | `--a2a-card-cache-ttl` | `5m` | TTL for cached remote Agent Cards. | Env `ORLOJ_A2A_CARD_CACHE_TTL`. |
@@ -49,7 +48,7 @@ go run ./cmd/orlojd -h
 | `--a2a-remote-agents` | empty | JSON-encoded list of static remote A2A agents. | Env `ORLOJ_A2A_REMOTE_AGENTS`. |
 | `--a2a-rate-limit-enabled` | `true` | Enable per-IP rate limiting for A2A endpoints. | Env `ORLOJ_A2A_RATE_LIMIT_ENABLED`. |
 | `--a2a-rate-limit-rpm` | `30` | Max A2A JSON-RPC requests per minute per IP. | Env `ORLOJ_A2A_RATE_LIMIT_RPM`. |
-| `--a2a-rate-limit-max-subscribe` | `10` | Max concurrent SSE subscribe connections. | Env `ORLOJ_A2A_RATE_LIMIT_MAX_SUBSCRIBE`. |
+| `--a2a-rate-limit-max-subscribe` | `10` | Max concurrent SSE subscribe connections globally (server-wide). | Env `ORLOJ_A2A_RATE_LIMIT_MAX_SUBSCRIBE`. |
 
 ### CRD conflict policy
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -398,7 +398,7 @@ export async function getA2AAgents(): Promise<import("./types").A2ARegistryRespo
 export async function getAgentCard(name: string): Promise<import("./types").AgentCard> {
   const { apiBase } = getConnection();
   const base = apiBase.replace(/\/$/, "");
-  return request<import("./types").AgentCard>(`${base}/v1/agents/${encodeURIComponent(name)}/.well-known/agent-card.json`);
+  return request<import("./types").AgentCard>(`${base}/v1/agent-systems/${encodeURIComponent(name)}/.well-known/agent-card.json`);
 }
 
 export async function changeLocalAuthPassword(

--- a/openapi/build_openapi.py
+++ b/openapi/build_openapi.py
@@ -27,6 +27,7 @@ SEC_READER = [{"bearerAuth": []}, {"sessionCookie": []}]
 SEC_WRITER = [{"bearerAuth": []}, {"sessionCookie": []}]
 SEC_ADMIN = [{"bearerAuth": []}, {"sessionCookie": []}]
 SEC_CTRL = [{"bearerAuth": []}, {"sessionCookie": []}]
+SEC_A2A = [{"bearerAuth": []}]
 
 
 def list_op(tag: str, list_ref: str) -> dict:
@@ -957,24 +958,25 @@ def build() -> dict:
             "tags": ["a2a"],
             "summary": "Get the default Agent Card",
             "description": (
-                "Returns the A2A Agent Card for the default agent or agent system. "
-                "Used by A2A clients for agent discovery."
+                "Returns the A2A Agent Card when exactly one AgentSystem has "
+                "spec.a2a.enabled=true. Use the registry or per-system card URLs when "
+                "multiple systems are exposed."
             ),
             "security": [],
             "responses": {
                 "200": {"description": "OK", "content": json_body(a2a_card_ref)},
-                "404": {"description": "No default agent configured", "content": text_plain_error()},
+                "404": {"description": "No single default AgentSystem available", "content": text_plain_error()},
                 "default": {"description": "Error", "content": text_plain_error()},
             },
         }
     }
-    paths["/v1/agents/{name}/.well-known/agent-card.json"] = {
+    system_card_get = {
         "get": {
             "tags": ["a2a"],
-            "summary": "Get Agent Card for a specific agent",
+            "summary": "Get Agent Card for a specific AgentSystem",
             "description": (
-                "Returns the A2A Agent Card for the named agent, including derived skills "
-                "and capabilities."
+                "Returns the A2A Agent Card for the named AgentSystem when "
+                "spec.a2a.enabled=true."
             ),
             "parameters": [
                 {
@@ -987,9 +989,17 @@ def build() -> dict:
             "security": [],
             "responses": {
                 "200": {"description": "OK", "content": json_body(a2a_card_ref)},
-                "404": {"description": "Agent not found", "content": text_plain_error()},
+                "404": {"description": "AgentSystem not found or not A2A-enabled", "content": text_plain_error()},
                 "default": {"description": "Error", "content": text_plain_error()},
             },
+        }
+    }
+    paths["/v1/agent-systems/{name}/.well-known/agent-card.json"] = system_card_get
+    paths["/v1/agents/{name}/.well-known/agent-card.json"] = {
+        "get": {
+            **system_card_get["get"],
+            "summary": "Get Agent Card for a specific AgentSystem (legacy path)",
+            "description": "Legacy alias for /v1/agent-systems/{name}/.well-known/agent-card.json.",
         }
     }
 
@@ -1000,7 +1010,7 @@ def build() -> dict:
             "JSON-RPC 2.0 endpoint implementing the A2A protocol. Supports methods: "
             "tasks/send, tasks/get, tasks/cancel, tasks/sendSubscribe."
         ),
-        "security": SEC_WRITER,
+        "security": SEC_A2A,
         "requestBody": {"required": True, "content": json_body(a2a_req_ref)},
         "responses": {
             "200": {"description": "JSON-RPC response", "content": json_body(a2a_resp_ref)},
@@ -1009,12 +1019,12 @@ def build() -> dict:
         },
     }
     paths["/a2a"] = {"post": a2a_rpc_post}
-    paths["/v1/agents/{name}/a2a"] = {
+    system_a2a_post = {
         "post": {
             **a2a_rpc_post,
-            "summary": "A2A JSON-RPC endpoint for a specific agent",
+            "summary": "A2A JSON-RPC endpoint for a specific AgentSystem",
             "description": (
-                "JSON-RPC 2.0 endpoint for the named agent. The agent name in the path "
+                "JSON-RPC 2.0 endpoint for the named AgentSystem. The system name in the path "
                 "determines routing; no target field is needed in request params."
             ),
             "parameters": [
@@ -1027,16 +1037,24 @@ def build() -> dict:
             ],
         }
     }
+    paths["/v1/agent-systems/{name}/a2a"] = system_a2a_post
+    paths["/v1/agents/{name}/a2a"] = {
+        "post": {
+            **system_a2a_post["post"],
+            "summary": "A2A JSON-RPC endpoint for a specific AgentSystem (legacy path)",
+            "description": "Legacy alias for /v1/agent-systems/{name}/a2a.",
+        }
+    }
 
     paths["/v1/a2a/agents"] = {
         "get": {
             "tags": ["a2a"],
             "summary": "List A2A agent registry",
             "description": (
-                "Returns locally exposed Agent Cards and configured remote agent entries "
-                "with cache metadata."
+                "Returns locally exposed A2A-enabled AgentSystem cards visible to the "
+                "bearer token plus configured remote agent entries with cache metadata."
             ),
-            "security": SEC_READER,
+            "security": SEC_A2A,
             "responses": {
                 "200": {"description": "OK", "content": json_body(a2a_registry_ref)},
                 "default": {"description": "Error", "content": text_plain_error()},

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -5781,8 +5781,8 @@ paths:
       tags:
       - a2a
       summary: Get the default Agent Card
-      description: Returns the A2A Agent Card for the default agent or agent system.
-        Used by A2A clients for agent discovery.
+      description: Returns the A2A Agent Card when exactly one AgentSystem has spec.a2a.enabled=true.
+        Use the registry or per-system card URLs when multiple systems are exposed.
       security: []
       responses:
         '200':
@@ -5792,7 +5792,7 @@ paths:
               schema:
                 "$ref": "./schemas/a2a.yaml#/components/schemas/AgentCard"
         '404':
-          description: No default agent configured
+          description: No single default AgentSystem available
           content:
             text/plain:
               schema:
@@ -5803,13 +5803,12 @@ paths:
             text/plain:
               schema:
                 "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
-  "/v1/agents/{name}/.well-known/agent-card.json":
+  "/v1/agent-systems/{name}/.well-known/agent-card.json":
     get:
       tags:
       - a2a
-      summary: Get Agent Card for a specific agent
-      description: Returns the A2A Agent Card for the named agent, including derived
-        skills and capabilities.
+      summary: Get Agent Card for a specific AgentSystem
+      description: Returns the A2A Agent Card for the named AgentSystem when spec.a2a.enabled=true.
       parameters:
       - name: name
         in: path
@@ -5825,7 +5824,39 @@ paths:
               schema:
                 "$ref": "./schemas/a2a.yaml#/components/schemas/AgentCard"
         '404':
-          description: Agent not found
+          description: AgentSystem not found or not A2A-enabled
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agents/{name}/.well-known/agent-card.json":
+    get:
+      tags:
+      - a2a
+      summary: Get Agent Card for a specific AgentSystem (legacy path)
+      description: Legacy alias for /v1/agent-systems/{name}/.well-known/agent-card.json.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      security: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/a2a.yaml#/components/schemas/AgentCard"
+        '404':
+          description: AgentSystem not found or not A2A-enabled
           content:
             text/plain:
               schema:
@@ -5842,10 +5873,11 @@ paths:
       - a2a
       summary: A2A JSON-RPC endpoint
       description: 'JSON-RPC 2.0 endpoint implementing the A2A protocol. Supports
-        methods: tasks/send, tasks/get, tasks/cancel, tasks/sendSubscribe.'
+        methods: tasks/send, tasks/get, tasks/cancel, tasks/sendSubscribe. Auth
+        depends on the target AgentSystem spec.a2a.auth policy (public or bearer).'
       security:
+      - {}
       - bearerAuth: []
-      - sessionCookie: []
       requestBody:
         required: true
         content:
@@ -5871,16 +5903,58 @@ paths:
             text/plain:
               schema:
                 "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+  "/v1/agent-systems/{name}/a2a":
+    post:
+      tags:
+      - a2a
+      summary: A2A JSON-RPC endpoint for a specific AgentSystem
+      description: JSON-RPC 2.0 endpoint for the named AgentSystem. The system name
+        in the path determines routing; no target field is needed in request params.
+        Auth depends on the target AgentSystem spec.a2a.auth policy (public or bearer).
+      security:
+      - {}
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "./schemas/a2a.yaml#/components/schemas/A2AJsonRpcRequest"
+      responses:
+        '200':
+          description: JSON-RPC response
+          content:
+            application/json:
+              schema:
+                "$ref": "./schemas/a2a.yaml#/components/schemas/A2AJsonRpcResponse"
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+        default:
+          description: Error
+          content:
+            text/plain:
+              schema:
+                "$ref": "./schemas/common.yaml#/components/schemas/PlainTextError"
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
   "/v1/agents/{name}/a2a":
     post:
       tags:
       - a2a
-      summary: A2A JSON-RPC endpoint for a specific agent
-      description: JSON-RPC 2.0 endpoint for the named agent. The agent name in the
-        path determines routing; no target field is needed in request params.
+      summary: A2A JSON-RPC endpoint for a specific AgentSystem (legacy path)
+      description: Legacy alias for /v1/agent-systems/{name}/a2a. Auth depends on
+        the target AgentSystem spec.a2a.auth policy (public or bearer).
       security:
+      - {}
       - bearerAuth: []
-      - sessionCookie: []
       requestBody:
         required: true
         content:
@@ -5917,11 +5991,12 @@ paths:
       tags:
       - a2a
       summary: List A2A agent registry
-      description: Returns locally exposed Agent Cards and configured remote agent
-        entries with cache metadata.
+      description: Returns locally exposed A2A-enabled AgentSystem cards visible to
+        the caller. Unauthenticated requests see only public systems; authenticated
+        requests see public systems plus systems the token is scoped to.
       security:
+      - {}
       - bearerAuth: []
-      - sessionCookie: []
       responses:
         '200':
           description: OK

--- a/openapi/schemas/agent-system.yaml
+++ b/openapi/schemas/agent-system.yaml
@@ -57,6 +57,20 @@ components:
         ttl: { type: string }
         allow_request_changes: { type: boolean, default: true }
         max_review_cycles: { type: integer, minimum: 1, default: 3 }
+    AgentSystemA2ASpec:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Expose this AgentSystem through inbound A2A discovery and JSON-RPC invocation.
+        auth:
+          type: string
+          enum: [public, bearer]
+          default: bearer
+          description: >-
+            Controls whether A2A invoke requires authentication for this system.
+            "public" allows unauthenticated invoke; "bearer" (default) requires
+            a valid API token when instance-wide auth is enabled.
     GraphEdge:
       type: object
       properties:
@@ -92,6 +106,8 @@ components:
         completion_review:
           description: Optional final human review checkpoint before the task transitions to Succeeded.
           $ref: "#/components/schemas/ReviewCheckpointSpec"
+        a2a:
+          $ref: "#/components/schemas/AgentSystemA2ASpec"
     AgentSystemStatus:
       type: object
       properties:

--- a/openapi/schemas/common.yaml
+++ b/openapi/schemas/common.yaml
@@ -86,20 +86,36 @@ components:
       required: [name, role]
       properties:
         name: { type: string }
-        role: { type: string }
+        role:
+          type: string
+          enum: [admin, writer, reader, controller, a2a]
+        a2a_agent_systems:
+          type: array
+          description: Required when role is `a2a`; AgentSystem refs this token may invoke. Bare names resolve in the default namespace.
+          items: { type: string }
     TokenMetadata:
       type: object
       properties:
         name: { type: string }
-        role: { type: string }
+        role:
+          type: string
+          enum: [admin, writer, reader, controller, a2a]
         created_at: { type: string }
+        a2a_agent_systems:
+          type: array
+          items: { type: string }
     TokenCreateResponse:
       type: object
       properties:
         name: { type: string }
-        role: { type: string }
+        role:
+          type: string
+          enum: [admin, writer, reader, controller, a2a]
         created_at: { type: string }
         token: { type: string }
+        a2a_agent_systems:
+          type: array
+          items: { type: string }
     TokenListResponse:
       type: object
       properties:

--- a/resources/graph_test.go
+++ b/resources/graph_test.go
@@ -88,6 +88,28 @@ spec:
 	}
 }
 
+func TestParseAgentSystemManifestA2AYAML(t *testing.T) {
+	raw := []byte(`
+apiVersion: orloj.dev/v1
+kind: AgentSystem
+metadata:
+  name: a2a-system
+spec:
+  a2a:
+    enabled: true
+  agents:
+    - planner
+`)
+
+	system, err := ParseAgentSystemManifest(raw)
+	if err != nil {
+		t.Fatalf("parse agent system failed: %v", err)
+	}
+	if !system.Spec.A2A.Enabled {
+		t.Fatal("expected spec.a2a.enabled=true")
+	}
+}
+
 func TestFilterRoutesForOutputNoConditionsPassThrough(t *testing.T) {
 	routes := []GraphRoute{
 		{To: "a"},

--- a/resources/manifest_parser_ext.go
+++ b/resources/manifest_parser_ext.go
@@ -142,6 +142,14 @@ func ParseAgentSystemManifest(data []byte) (AgentSystem, error) {
 				currentGraphEdgeIndex = -1
 				delegateNestedSection = ""
 				currentDelegateIndex = -1
+			case section == "spec" && key == "a2a":
+				subsection = "a2a"
+				currentGraphNode = ""
+				graphNodeSection = ""
+				edgeNestedSection = ""
+				currentGraphEdgeIndex = -1
+				delegateNestedSection = ""
+				currentDelegateIndex = -1
 			case section == "metadata" && key == "labels":
 				subsection = "labels"
 				currentGraphNode = ""
@@ -269,6 +277,13 @@ func ParseAgentSystemManifest(data []byte) (AgentSystem, error) {
 			}
 		case section == "spec" && subsection == "" && (key == "context_adapter" || key == "contextAdapter"):
 			out.Spec.ContextAdapter = value
+		case section == "spec" && subsection == "a2a":
+			switch key {
+			case "enabled":
+				out.Spec.A2A.Enabled = strings.EqualFold(value, "true") || value == "1"
+			case "auth":
+				out.Spec.A2A.Auth = value
+			}
 		case section == "spec" && subsection == "graph" && currentGraphNode != "":
 			node := out.Spec.Graph[currentGraphNode]
 			switch {
@@ -563,16 +578,16 @@ func ParseToolManifest(data []byte) (Tool, error) {
 					subsection = "wasm"
 					runtimeSubsection = ""
 				}
-		case "cli":
-			if section == "spec" {
-				subsection = "cli"
-				runtimeSubsection = ""
-			}
-		case "a2a":
-			if section == "spec" {
-				subsection = "a2a"
-				runtimeSubsection = ""
-			}
+			case "cli":
+				if section == "spec" {
+					subsection = "cli"
+					runtimeSubsection = ""
+				}
+			case "a2a":
+				if section == "spec" {
+					subsection = "a2a"
+					runtimeSubsection = ""
+				}
 			case "args":
 				if section == "spec" && subsection == "cli" {
 					runtimeSubsection = "args"
@@ -2320,15 +2335,15 @@ func ParseMcpServerManifest(data []byte) (McpServer, error) {
 				if section == "spec" {
 					subsection = "env"
 				}
-		case "auth":
-			if section == "spec" {
-				subsection = "auth"
-			}
-		case "scopes":
-			if section == "spec" && subsection == "auth" {
-				subsection = "auth_scopes"
-			}
-		case "tool_filter", "toolFilter":
+			case "auth":
+				if section == "spec" {
+					subsection = "auth"
+				}
+			case "scopes":
+				if section == "spec" && subsection == "auth" {
+					subsection = "auth_scopes"
+				}
+			case "tool_filter", "toolFilter":
 				if section == "spec" {
 					subsection = "tool_filter"
 				}
@@ -2348,18 +2363,18 @@ func ParseMcpServerManifest(data []byte) (McpServer, error) {
 				if section == "spec" {
 					subsection = "resources"
 				}
-		case "default_tool_runtime", "defaultToolRuntime":
-			if section == "spec" {
-				subsection = "default_tool_runtime"
-				if out.Spec.DefaultToolRuntime == nil {
-					out.Spec.DefaultToolRuntime = &ToolRuntimePolicy{}
+			case "default_tool_runtime", "defaultToolRuntime":
+				if section == "spec" {
+					subsection = "default_tool_runtime"
+					if out.Spec.DefaultToolRuntime == nil {
+						out.Spec.DefaultToolRuntime = &ToolRuntimePolicy{}
+					}
+				}
+			case "retry":
+				if section == "spec" && subsection == "default_tool_runtime" {
+					subsection = "default_tool_runtime_retry"
 				}
 			}
-		case "retry":
-			if section == "spec" && subsection == "default_tool_runtime" {
-				subsection = "default_tool_runtime_retry"
-			}
-		}
 			continue
 		}
 
@@ -2462,32 +2477,32 @@ func ParseMcpServerManifest(data []byte) (McpServer, error) {
 					last.MountPath = value
 				}
 			}
-	case section == "spec" && subsection == "default_tool_runtime":
-		if out.Spec.DefaultToolRuntime == nil {
-			out.Spec.DefaultToolRuntime = &ToolRuntimePolicy{}
+		case section == "spec" && subsection == "default_tool_runtime":
+			if out.Spec.DefaultToolRuntime == nil {
+				out.Spec.DefaultToolRuntime = &ToolRuntimePolicy{}
+			}
+			switch key {
+			case "timeout":
+				out.Spec.DefaultToolRuntime.Timeout = value
+			case "isolation_mode", "isolationMode":
+				out.Spec.DefaultToolRuntime.IsolationMode = value
+			}
+		case section == "spec" && subsection == "default_tool_runtime_retry":
+			if out.Spec.DefaultToolRuntime == nil {
+				out.Spec.DefaultToolRuntime = &ToolRuntimePolicy{}
+			}
+			switch key {
+			case "max_attempts", "maxAttempts":
+				v, _ := strconv.Atoi(value)
+				out.Spec.DefaultToolRuntime.Retry.MaxAttempts = v
+			case "backoff":
+				out.Spec.DefaultToolRuntime.Retry.Backoff = value
+			case "max_backoff", "maxBackoff":
+				out.Spec.DefaultToolRuntime.Retry.MaxBackoff = value
+			case "jitter":
+				out.Spec.DefaultToolRuntime.Retry.Jitter = value
+			}
 		}
-		switch key {
-		case "timeout":
-			out.Spec.DefaultToolRuntime.Timeout = value
-		case "isolation_mode", "isolationMode":
-			out.Spec.DefaultToolRuntime.IsolationMode = value
-		}
-	case section == "spec" && subsection == "default_tool_runtime_retry":
-		if out.Spec.DefaultToolRuntime == nil {
-			out.Spec.DefaultToolRuntime = &ToolRuntimePolicy{}
-		}
-		switch key {
-		case "max_attempts", "maxAttempts":
-			v, _ := strconv.Atoi(value)
-			out.Spec.DefaultToolRuntime.Retry.MaxAttempts = v
-		case "backoff":
-			out.Spec.DefaultToolRuntime.Retry.Backoff = value
-		case "max_backoff", "maxBackoff":
-			out.Spec.DefaultToolRuntime.Retry.MaxBackoff = value
-		case "jitter":
-			out.Spec.DefaultToolRuntime.Retry.Jitter = value
-		}
-	}
 	}
 
 	if err := out.Normalize(); err != nil {

--- a/resources/resource_types.go
+++ b/resources/resource_types.go
@@ -41,7 +41,19 @@ type AgentSystemSpec struct {
 	Graph            map[string]GraphEdge  `json:"graph,omitempty" yaml:"graph,omitempty"`
 	CompletionReview *ReviewCheckpointSpec `json:"completion_review,omitempty" yaml:"completion_review,omitempty"`
 	ContextAdapter   string                `json:"context_adapter,omitempty" yaml:"context_adapter,omitempty"`
+	A2A              AgentSystemA2ASpec    `json:"a2a,omitempty" yaml:"a2a,omitempty"`
 }
+
+type AgentSystemA2ASpec struct {
+	Enabled bool   `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Auth    string `json:"auth,omitempty" yaml:"auth,omitempty"`
+}
+
+// A2AAuthPublic means unauthenticated callers may invoke this system.
+const A2AAuthPublic = "public"
+
+// A2AAuthBearer means a valid bearer token is required (default).
+const A2AAuthBearer = "bearer"
 
 type GraphEdge struct {
 	// Legacy single-hop edge. Preserved for backward compatibility.
@@ -272,6 +284,15 @@ func (a *AgentSystem) Normalize() error {
 		}
 	}
 
+	switch strings.ToLower(strings.TrimSpace(a.Spec.A2A.Auth)) {
+	case "", A2AAuthBearer:
+		a.Spec.A2A.Auth = ""
+	case A2AAuthPublic:
+		a.Spec.A2A.Auth = A2AAuthPublic
+	default:
+		return fmt.Errorf("unsupported spec.a2a.auth value %q (expected %q or %q)", a.Spec.A2A.Auth, A2AAuthPublic, A2AAuthBearer)
+	}
+
 	if a.Spec.ContextAdapter != "" {
 		a.Spec.ContextAdapter = strings.TrimSpace(a.Spec.ContextAdapter)
 	}
@@ -373,9 +394,9 @@ type Tool struct {
 }
 
 type ToolSpec struct {
-	Type             string            `json:"type,omitempty" yaml:"type,omitempty"`
-	Endpoint         string            `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
-	Description      string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Type        string `json:"type,omitempty" yaml:"type,omitempty"`
+	Endpoint    string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	InputSchema      map[string]any    `json:"input_schema,omitempty" yaml:"input_schema,omitempty"`
@@ -406,7 +427,7 @@ type ToolWasmSpec struct {
 type ToolA2ASpec struct {
 	AgentURL        string `json:"agent_url,omitempty" yaml:"agent_url,omitempty"`
 	ProtocolVersion string `json:"protocol_version,omitempty" yaml:"protocol_version,omitempty"`
-	PreferStreaming  bool   `json:"prefer_streaming,omitempty" yaml:"prefer_streaming,omitempty"`
+	PreferStreaming bool   `json:"prefer_streaming,omitempty" yaml:"prefer_streaming,omitempty"`
 }
 
 // ContainerResources defines per-tool or per-McpServer container resource

--- a/runtime/a2a/card.go
+++ b/runtime/a2a/card.go
@@ -1,6 +1,7 @@
 package a2a
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/OrlojHQ/orloj/resources"
@@ -8,11 +9,12 @@ import (
 
 // CardGeneratorConfig controls Agent Card generation.
 type CardGeneratorConfig struct {
-	PublicBaseURL     string
+	PublicBaseURL    string
 	ProtocolVersion  string
 	StreamingEnabled bool
 	WebhooksEnabled  bool
 	AuthSchemes      []string
+	Namespace        string
 }
 
 // GenerateAgentCard builds an A2A Agent Card from an Orloj Agent and its tools.
@@ -26,7 +28,7 @@ func GenerateAgentCard(agent resources.Agent, tools []resources.Tool, config Car
 		desc = truncatePrompt(agent.Spec.Prompt, 200)
 	}
 
-	agentURL := strings.TrimSuffix(config.PublicBaseURL, "/") + "/v1/agents/" + name + "/a2a"
+	agentURL := appendNamespaceQuery(strings.TrimSuffix(config.PublicBaseURL, "/")+"/v1/agents/"+url.PathEscape(name)+"/a2a", config.Namespace)
 
 	card := AgentCard{
 		Name:            name,
@@ -71,7 +73,7 @@ func GenerateSystemCard(system resources.AgentSystem, agents []resources.Agent, 
 		desc = "Multi-agent system: " + name
 	}
 
-	agentURL := strings.TrimSuffix(config.PublicBaseURL, "/") + "/v1/agents/" + name + "/a2a"
+	agentURL := appendNamespaceQuery(strings.TrimSuffix(config.PublicBaseURL, "/")+"/v1/agent-systems/"+url.PathEscape(name)+"/a2a", config.Namespace)
 
 	card := AgentCard{
 		Name:            name,
@@ -118,6 +120,18 @@ func GenerateSystemCard(system resources.AgentSystem, agents []resources.Agent, 
 	}
 
 	return card
+}
+
+func appendNamespaceQuery(rawURL, namespace string) string {
+	namespace = resources.NormalizeNamespace(namespace)
+	if namespace == "" || namespace == resources.DefaultNamespace {
+		return rawURL
+	}
+	sep := "?"
+	if strings.Contains(rawURL, "?") {
+		sep = "&"
+	}
+	return rawURL + sep + "namespace=" + url.QueryEscape(namespace)
 }
 
 func truncatePrompt(prompt string, maxLen int) string {

--- a/store/auth_store.go
+++ b/store/auth_store.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -14,7 +15,6 @@ import (
 	"sync"
 	"time"
 )
-
 
 var (
 	ErrAuthUserExists     = errors.New("auth user already exists")
@@ -28,6 +28,13 @@ var (
 		"writer":     {},
 		"reader":     {},
 		"controller": {},
+	}
+	allowedAPITokenRoleValues = map[string]struct{}{
+		"admin":      {},
+		"writer":     {},
+		"reader":     {},
+		"controller": {},
+		"a2a":        {},
 	}
 )
 
@@ -44,6 +51,56 @@ func normalizeAuthRoleWithDefault(role, defaultRole string) (string, error) {
 
 func normalizeAuthRole(role string) (string, error) {
 	return normalizeAuthRoleWithDefault(role, "")
+}
+
+func normalizeAPITokenRoleWithDefault(role, defaultRole string) (string, error) {
+	r := strings.ToLower(strings.TrimSpace(role))
+	if r == "" {
+		r = strings.ToLower(strings.TrimSpace(defaultRole))
+	}
+	if _, ok := allowedAPITokenRoleValues[r]; !ok {
+		return "", fmt.Errorf("%w: %q", ErrInvalidAuthRole, strings.TrimSpace(role))
+	}
+	return r, nil
+}
+
+func normalizeA2AAgentSystems(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		v := strings.TrimSpace(value)
+		if v == "" {
+			continue
+		}
+		key := strings.ToLower(v)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func encodeA2AAgentSystems(values []string) string {
+	raw, err := json.Marshal(normalizeA2AAgentSystems(values))
+	if err != nil {
+		return "[]"
+	}
+	return string(raw)
+}
+
+func decodeA2AAgentSystems(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var values []string
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil
+	}
+	return normalizeA2AAgentSystems(values)
 }
 
 func normalizeLocalUsername(username string) string {
@@ -723,11 +780,12 @@ func (s *AuthSessionStore) DeleteExpired(now time.Time) error {
 }
 
 type APITokenRecord struct {
-	Name      string
-	Role      string
-	TokenHash string
-	CreatedAt string
-	UpdatedAt string
+	Name            string
+	Role            string
+	TokenHash       string
+	CreatedAt       string
+	UpdatedAt       string
+	A2AAgentSystems []string
 }
 
 type APITokenStore struct {
@@ -749,6 +807,10 @@ func normalizeTokenName(name string) string {
 }
 
 func (s *APITokenStore) Create(name, tokenHash, role string, now time.Time) (APITokenRecord, error) {
+	return s.CreateWithA2AAgentSystems(name, tokenHash, role, nil, now)
+}
+
+func (s *APITokenStore) CreateWithA2AAgentSystems(name, tokenHash, role string, a2aAgentSystems []string, now time.Time) (APITokenRecord, error) {
 	name = normalizeTokenName(name)
 	tokenHash = strings.TrimSpace(tokenHash)
 	if name == "" {
@@ -757,20 +819,28 @@ func (s *APITokenStore) Create(name, tokenHash, role string, now time.Time) (API
 	if tokenHash == "" {
 		return APITokenRecord{}, fmt.Errorf("token hash is required")
 	}
-	r, err := normalizeAuthRoleWithDefault(role, "reader")
+	r, err := normalizeAPITokenRoleWithDefault(role, "reader")
 	if err != nil {
 		return APITokenRecord{}, err
+	}
+	scopes := normalizeA2AAgentSystems(a2aAgentSystems)
+	if r == "a2a" && len(scopes) == 0 {
+		return APITokenRecord{}, fmt.Errorf("a2a_agent_systems is required for role %q", r)
+	}
+	if r != "a2a" {
+		scopes = nil
 	}
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
 	if s.db != nil {
 		_, err := s.db.Exec(
-			`INSERT INTO auth_api_tokens(name, token_hash, role, created_at, updated_at)
-			 VALUES($1, $2, $3, NOW(), NOW())`,
+			`INSERT INTO auth_api_tokens(name, token_hash, role, a2a_agent_systems, created_at, updated_at)
+			 VALUES($1, $2, $3, $4, NOW(), NOW())`,
 			name,
 			tokenHash,
 			r,
+			encodeA2AAgentSystems(scopes),
 		)
 		if err != nil {
 			msg := strings.ToLower(err.Error())
@@ -800,11 +870,12 @@ func (s *APITokenStore) Create(name, tokenHash, role string, now time.Time) (API
 		}
 	}
 	record := APITokenRecord{
-		Name:      name,
-		Role:      r,
-		TokenHash: tokenHash,
-		CreatedAt: now.UTC().Format(time.RFC3339Nano),
-		UpdatedAt: now.UTC().Format(time.RFC3339Nano),
+		Name:            name,
+		Role:            r,
+		TokenHash:       tokenHash,
+		CreatedAt:       now.UTC().Format(time.RFC3339Nano),
+		UpdatedAt:       now.UTC().Format(time.RFC3339Nano),
+		A2AAgentSystems: scopes,
 	}
 	s.tokens[name] = record
 	return record, nil
@@ -819,13 +890,14 @@ func (s *APITokenStore) Get(name string) (APITokenRecord, bool, error) {
 		var (
 			record             APITokenRecord
 			createdAt, updated time.Time
+			scopesJSON         string
 		)
 		err := s.db.QueryRow(
-			`SELECT name, token_hash, role, created_at, updated_at
+			`SELECT name, token_hash, role, a2a_agent_systems, created_at, updated_at
 			 FROM auth_api_tokens
 			 WHERE name = $1`,
 			name,
-		).Scan(&record.Name, &record.TokenHash, &record.Role, &createdAt, &updated)
+		).Scan(&record.Name, &record.TokenHash, &record.Role, &scopesJSON, &createdAt, &updated)
 		if err == sql.ErrNoRows {
 			return APITokenRecord{}, false, nil
 		}
@@ -834,6 +906,7 @@ func (s *APITokenStore) Get(name string) (APITokenRecord, bool, error) {
 		}
 		record.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
 		record.UpdatedAt = updated.UTC().Format(time.RFC3339Nano)
+		record.A2AAgentSystems = decodeA2AAgentSystems(scopesJSON)
 		return record, true, nil
 	}
 
@@ -855,13 +928,14 @@ func (s *APITokenStore) GetByHash(tokenHash string) (APITokenRecord, bool, error
 		var (
 			record             APITokenRecord
 			createdAt, updated time.Time
+			scopesJSON         string
 		)
 		err := s.db.QueryRow(
-			`SELECT name, token_hash, role, created_at, updated_at
+			`SELECT name, token_hash, role, a2a_agent_systems, created_at, updated_at
 			 FROM auth_api_tokens
 			 WHERE token_hash = $1`,
 			tokenHash,
-		).Scan(&record.Name, &record.TokenHash, &record.Role, &createdAt, &updated)
+		).Scan(&record.Name, &record.TokenHash, &record.Role, &scopesJSON, &createdAt, &updated)
 		if err == sql.ErrNoRows {
 			return APITokenRecord{}, false, nil
 		}
@@ -870,6 +944,7 @@ func (s *APITokenStore) GetByHash(tokenHash string) (APITokenRecord, bool, error
 		}
 		record.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
 		record.UpdatedAt = updated.UTC().Format(time.RFC3339Nano)
+		record.A2AAgentSystems = decodeA2AAgentSystems(scopesJSON)
 		return record, true, nil
 	}
 
@@ -886,7 +961,7 @@ func (s *APITokenStore) GetByHash(tokenHash string) (APITokenRecord, bool, error
 func (s *APITokenStore) List() ([]APITokenRecord, error) {
 	if s.db != nil {
 		rows, err := s.db.Query(`
-			SELECT name, token_hash, role, created_at, updated_at
+			SELECT name, token_hash, role, a2a_agent_systems, created_at, updated_at
 			FROM auth_api_tokens
 			ORDER BY name ASC`)
 		if err != nil {
@@ -898,12 +973,14 @@ func (s *APITokenStore) List() ([]APITokenRecord, error) {
 			var (
 				record             APITokenRecord
 				createdAt, updated time.Time
+				scopesJSON         string
 			)
-			if err := rows.Scan(&record.Name, &record.TokenHash, &record.Role, &createdAt, &updated); err != nil {
+			if err := rows.Scan(&record.Name, &record.TokenHash, &record.Role, &scopesJSON, &createdAt, &updated); err != nil {
 				return nil, err
 			}
 			record.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
 			record.UpdatedAt = updated.UTC().Format(time.RFC3339Nano)
+			record.A2AAgentSystems = decodeA2AAgentSystems(scopesJSON)
 			out = append(out, record)
 		}
 		if err := rows.Err(); err != nil {

--- a/store/auth_upsert_test.go
+++ b/store/auth_upsert_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"errors"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -127,6 +129,55 @@ func TestTokenStoreDuplicateHashRejected(t *testing.T) {
 	_, err = s.Create("tok-b", "samehash", "writer", now)
 	if err != ErrAPITokenExists {
 		t.Fatalf("expected ErrAPITokenExists for duplicate hash, got %v", err)
+	}
+}
+
+func TestTokenStoreCreateA2ATokenRequiresScopes(t *testing.T) {
+	s := NewAPITokenStore()
+	_, err := s.CreateWithA2AAgentSystems("a2a-token", "hash-a2a", "a2a", nil, time.Now().UTC())
+	if err == nil {
+		t.Fatal("expected error for a2a token without scopes")
+	}
+}
+
+func TestTokenStoreCreateA2ATokenStoresNormalizedScopes(t *testing.T) {
+	s := NewAPITokenStore()
+	now := time.Now().UTC()
+	record, err := s.CreateWithA2AAgentSystems(
+		"a2a-token",
+		"hash-a2a",
+		"a2a",
+		[]string{" team-b/report ", "default/research", "team-b/report", ""},
+		now,
+	)
+	if err != nil {
+		t.Fatalf("create a2a token failed: %v", err)
+	}
+	want := []string{"default/research", "team-b/report"}
+	if !reflect.DeepEqual(record.A2AAgentSystems, want) {
+		t.Fatalf("unexpected scopes: got=%v want=%v", record.A2AAgentSystems, want)
+	}
+
+	got, ok, err := s.GetByHash("hash-a2a")
+	if err != nil {
+		t.Fatalf("get token by hash failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected token by hash")
+	}
+	if got.Role != "a2a" {
+		t.Fatalf("expected role a2a, got %q", got.Role)
+	}
+	if !reflect.DeepEqual(got.A2AAgentSystems, want) {
+		t.Fatalf("unexpected stored scopes: got=%v want=%v", got.A2AAgentSystems, want)
+	}
+}
+
+func TestCreateUserRejectsA2ARole(t *testing.T) {
+	s := NewLocalAdminStore()
+	_, err := s.CreateUser("a2a-user", "$2a$10$fakehash1234567890abcdefghijklmnopqrstuvwxyz012345678", "a2a")
+	if !errors.Is(err, ErrInvalidAuthRole) {
+		t.Fatalf("expected ErrInvalidAuthRole for local a2a user, got %v", err)
 	}
 }
 

--- a/store/migrations/014_a2a_token_scopes.up.sql
+++ b/store/migrations/014_a2a_token_scopes.up.sql
@@ -1,0 +1,11 @@
+-- 014: scoped API tokens for inbound A2A invocation.
+
+ALTER TABLE auth_api_tokens
+    ADD COLUMN IF NOT EXISTS a2a_agent_systems TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE auth_api_tokens
+    DROP CONSTRAINT IF EXISTS auth_api_tokens_role;
+
+ALTER TABLE auth_api_tokens
+    ADD CONSTRAINT auth_api_tokens_role
+    CHECK (role IN ('admin', 'writer', 'reader', 'controller', 'a2a'));


### PR DESCRIPTION

Expose AgentSystems as A2A agents, accept inbound JSON-RPC task requests, call external A2A agents as tools, and maintain a remote agent registry. Includes per-system auth (spec.a2a.auth: bearer|public), scoped API tokens, Agent Card generation, CLI commands, Helm chart values, and docs.

Fixes auth bypass on tasks/get and tasks/cancel, --api-key flag wiring, subscribe namespace mismatch, cross-system task ID collisions, empty task ID validation, SSE error handling, and Helm CRD drift.

