### PR TITLE
feat: Support Anthropic OAuth access tokens via Bearer auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Anthropic OAuth access tokens**: the Anthropic model gateway now sends `Authorization: Bearer` for credentials with the `sk-ant-oat` prefix (or an explicit `Bearer ` prefix), while standard API keys continue to use `x-api-key`. Same `ModelEndpoint` `auth.secretRef` works for both.
 - **`orlojctl auth login`**: new CLI command that authenticates with username/password against a native-mode server and saves a bearer token to the active profile. Eliminates the need to manually configure API tokens for CLI access.
 - **`POST /v1/auth/cli-token`**: new API endpoint that accepts credentials and returns a bearer token for CLI use (native auth mode only).
 - **`orlojctl config use` auth probe**: switching profiles now checks `/v1/auth/me` and prints whether the profile's credentials are valid, warning if unauthenticated.

--- a/docs/pages/concepts/tools/model-endpoint.md
+++ b/docs/pages/concepts/tools/model-endpoint.md
@@ -46,6 +46,8 @@ spec:
     secretRef: anthropic-api-key
 ```
 
+Anthropic credentials may be either a standard API key (`sk-ant-api...`, sent as `x-api-key`) or an OAuth access token (`sk-ant-oat...`, sent as `Authorization: Bearer`). Store either value in the same `secretRef`; Orloj selects the header from the token prefix.
+
 **Azure OpenAI:**
 ```yaml
 spec:

--- a/docs/pages/guides/configure-model-routing.md
+++ b/docs/pages/guides/configure-model-routing.md
@@ -21,6 +21,8 @@ Each provider needs a Secret resource to hold its API key. The fastest way is th
 ```bash
 orlojctl create secret openai-api-key --from-literal value=sk-your-openai-key-here
 orlojctl create secret anthropic-api-key --from-literal value=sk-ant-your-anthropic-key-here
+# Anthropic OAuth access tokens (sk-ant-oat...) also work in the same secret —
+# Orloj sends Authorization: Bearer for those, and x-api-key for API keys.
 ```
 
 Alternatively, use YAML manifests with `orlojctl apply -f`:

--- a/docs/pages/operations/troubleshooting.md
+++ b/docs/pages/operations/troubleshooting.md
@@ -83,12 +83,14 @@ Fix:
 Cause:
 
 - missing or invalid API key on the ModelEndpoint resource.
+- Anthropic OAuth access token (`sk-ant-oat...`) used against a build that only sends `x-api-key` (pre-OAuth support), or a standard API key stored with an accidental `Bearer ` prefix.
 
 Fix:
 
 - verify `auth.secretRef` is set for providers that require auth (`openai`, `anthropic`, `azure-openai`).
 - for `openai-compatible`, auth is optional, but if `auth.secretRef` is set, verify that Secret exists and is valid.
 - if you use env-based secret resolution, set `ORLOJ_SECRET_<name>` (or your configured prefix) to match the `secretRef` value.
+- for Anthropic: store either a standard API key (`sk-ant-api...`) or an OAuth access token (`sk-ant-oat...`) in the secret. Orloj selects `x-api-key` vs `Authorization: Bearer` from the token prefix — do not mix prefixes.
 
 ### Wasm/container runtime errors
 

--- a/docs/pages/reference/resources/model-endpoint.md
+++ b/docs/pages/reference/resources/model-endpoint.md
@@ -26,6 +26,9 @@
   - `openai`, `anthropic`, `azure-openai`: `auth.secretRef` is required.
   - `openai-compatible`: `auth.secretRef` is optional.
   - `ollama`: `auth.secretRef` is optional and usually omitted.
+- Anthropic credential types (same `auth.secretRef`):
+  - Standard API key (`sk-ant-api...`): sent as `x-api-key`.
+  - OAuth access token (`sk-ant-oat...`, or an explicit `Bearer ` prefix): sent as `Authorization: Bearer`.
 
 ## status
 

--- a/runtime/model_gateway_anthropic.go
+++ b/runtime/model_gateway_anthropic.go
@@ -45,7 +45,7 @@ type AnthropicModelGateway struct {
 func NewAnthropicModelGateway(cfg AnthropicModelGatewayConfig) (*AnthropicModelGateway, error) {
 	normalized := cfg.normalized()
 	if strings.TrimSpace(normalized.APIKey) == "" {
-		return nil, fmt.Errorf("anthropic api key is required")
+		return nil, fmt.Errorf("anthropic api key or oauth token is required")
 	}
 	if strings.TrimSpace(normalized.BaseURL) == "" {
 		return nil, fmt.Errorf("anthropic base URL is required")
@@ -67,6 +67,42 @@ func NewAnthropicModelGateway(cfg AnthropicModelGatewayConfig) (*AnthropicModelG
 		maxTokens:        normalized.maxTokens(),
 		client:           normalized.client(),
 	}, nil
+}
+
+// anthropicCredentialUsesBearer reports whether the credential should be sent
+// as Authorization: Bearer instead of x-api-key.
+//
+// Anthropic OAuth access tokens (prefix sk-ant-oat) are rejected by x-api-key
+// and must use Bearer. Operators may also store an already-prefixed
+// "Bearer <token>" value. Standard API keys (sk-ant-api...) keep x-api-key.
+func anthropicCredentialUsesBearer(credential string) bool {
+	credential = strings.TrimSpace(credential)
+	if credential == "" {
+		return false
+	}
+	lower := strings.ToLower(credential)
+	if strings.HasPrefix(lower, "bearer ") {
+		return true
+	}
+	return strings.HasPrefix(lower, "sk-ant-oat")
+}
+
+// setAnthropicAuthHeaders applies the correct Anthropic auth header for the
+// credential type. Mutually exclusive: never set both x-api-key and Bearer.
+func setAnthropicAuthHeaders(req *http.Request, credential string) {
+	credential = strings.TrimSpace(credential)
+	if req == nil || credential == "" {
+		return
+	}
+	if anthropicCredentialUsesBearer(credential) {
+		token := credential
+		if len(credential) >= 7 && strings.EqualFold(credential[:6], "bearer") && credential[6] == ' ' {
+			token = strings.TrimSpace(credential[7:])
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		return
+	}
+	req.Header.Set("x-api-key", credential)
 }
 
 func (c AnthropicModelGatewayConfig) normalized() AnthropicModelGatewayConfig {
@@ -159,7 +195,7 @@ func (g *AnthropicModelGateway) Complete(ctx context.Context, req ModelRequest) 
 		return ModelResponse{}, fmt.Errorf("build model request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("x-api-key", g.apiKey)
+	setAnthropicAuthHeaders(httpReq, g.apiKey)
 	httpReq.Header.Set("anthropic-version", g.anthropicVersion)
 
 	httpResp, err := g.client.Do(httpReq)

--- a/runtime/model_gateway_anthropic.go
+++ b/runtime/model_gateway_anthropic.go
@@ -105,6 +105,83 @@ func setAnthropicAuthHeaders(req *http.Request, credential string) {
 	req.Header.Set("x-api-key", credential)
 }
 
+// Claude Code OAuth (sk-ant-oat…) requires a Claude Code client fingerprint for
+// non-Haiku models. Without these headers + system identity, Anthropic returns
+// an opaque 429 rate_limit_error / 400 invalid_request_error. Matches the
+// request shape used by OpenCode's Claude OAuth plugins.
+const (
+	anthropicClaudeCodeSystemIdentity = "You are Claude Code, Anthropic's official CLI for Claude."
+	anthropicClaudeCodeBillingHeader  = "x-anthropic-billing-header: cc_version=2.1.88; cc_entrypoint=cli; cch=orloj;"
+	anthropicClaudeCodeCLIVersion     = "2.1.88"
+	anthropicClaudeCodeUserAgent      = "claude-cli/" + anthropicClaudeCodeCLIVersion + " (external, cli)"
+	anthropicClaudeCodeBetaFlags      = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+)
+
+// setAnthropicOAuthClientHeaders adds Claude Code client identity headers when
+// using an OAuth access token. No-op for standard API keys.
+func setAnthropicOAuthClientHeaders(req *http.Request, credential string) {
+	if req == nil || !anthropicCredentialUsesBearer(credential) {
+		return
+	}
+	req.Header.Set("anthropic-beta", anthropicClaudeCodeBetaFlags)
+	req.Header.Set("User-Agent", anthropicClaudeCodeUserAgent)
+	req.Header.Set("x-app", "cli")
+}
+
+// ensureAnthropicOAuthSystemIdentity prepends the Claude Code identity + billing
+// system blocks required for Sonnet/Opus on OAuth tokens. Idempotent. Also
+// strips cache_control from system blocks — Anthropic rejects ephemeral
+// prompt-caching markers on OAuth subscription traffic.
+func ensureAnthropicOAuthSystemIdentity(system []anthropicSystemBlock, credential string) []anthropicSystemBlock {
+	if !anthropicCredentialUsesBearer(credential) {
+		return system
+	}
+	cleaned := make([]anthropicSystemBlock, 0, len(system)+2)
+	hasIdentity := false
+	hasBilling := false
+	for _, block := range system {
+		text := strings.TrimSpace(block.Text)
+		if strings.Contains(text, anthropicClaudeCodeSystemIdentity) {
+			hasIdentity = true
+		}
+		if strings.HasPrefix(text, "x-anthropic-billing-header:") {
+			hasBilling = true
+		}
+		cleaned = append(cleaned, anthropicSystemBlock{
+			Type: block.Type,
+			Text: block.Text,
+			// Intentionally drop CacheControl for OAuth.
+		})
+	}
+	prefix := make([]anthropicSystemBlock, 0, 2)
+	if !hasBilling {
+		prefix = append(prefix, anthropicSystemBlock{
+			Type: "text",
+			Text: anthropicClaudeCodeBillingHeader,
+		})
+	}
+	if !hasIdentity {
+		prefix = append(prefix, anthropicSystemBlock{
+			Type: "text",
+			Text: anthropicClaudeCodeSystemIdentity,
+		})
+	}
+	return append(prefix, cleaned...)
+}
+
+// anthropicMessagesURL returns the Messages endpoint, adding ?beta=true for
+// OAuth credentials (required by the claude-code beta surface).
+func anthropicMessagesURL(baseURL, credential string) string {
+	endpoint := strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/messages"
+	if !anthropicCredentialUsesBearer(credential) {
+		return endpoint
+	}
+	if strings.Contains(endpoint, "?") {
+		return endpoint + "&beta=true"
+	}
+	return endpoint + "?beta=true"
+}
+
 func (c AnthropicModelGatewayConfig) normalized() AnthropicModelGatewayConfig {
 	out := c
 	defaults := DefaultAnthropicModelGatewayConfig()
@@ -184,18 +261,20 @@ func (g *AnthropicModelGateway) Complete(ctx context.Context, req ModelRequest) 
 			},
 		}
 	}
+	body.System = ensureAnthropicOAuthSystemIdentity(body.System, g.apiKey)
 
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return ModelResponse{}, fmt.Errorf("marshal model request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, g.baseURL+"/messages", bytes.NewReader(payload))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicMessagesURL(g.baseURL, g.apiKey), bytes.NewReader(payload))
 	if err != nil {
 		return ModelResponse{}, fmt.Errorf("build model request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	setAnthropicAuthHeaders(httpReq, g.apiKey)
+	setAnthropicOAuthClientHeaders(httpReq, g.apiKey)
 	httpReq.Header.Set("anthropic-version", g.anthropicVersion)
 
 	httpResp, err := g.client.Do(httpReq)

--- a/runtime/model_gateway_anthropic_test.go
+++ b/runtime/model_gateway_anthropic_test.go
@@ -148,10 +148,26 @@ func TestAnthropicModelGatewayCompleteUsesOAuthBearer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var capturedAPIKey string
 			var capturedAuth string
+			var capturedBeta string
+			var capturedUA string
+			var capturedApp string
+			var capturedURL string
+			var capturedBody anthropicMessagesRequest
 			client := &http.Client{
 				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 					capturedAPIKey = req.Header.Get("x-api-key")
 					capturedAuth = req.Header.Get("Authorization")
+					capturedBeta = req.Header.Get("anthropic-beta")
+					capturedUA = req.Header.Get("User-Agent")
+					capturedApp = req.Header.Get("x-app")
+					capturedURL = req.URL.String()
+					body, err := io.ReadAll(req.Body)
+					if err != nil {
+						return nil, err
+					}
+					if err := json.Unmarshal(body, &capturedBody); err != nil {
+						return nil, err
+					}
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Body:       io.NopCloser(strings.NewReader(`{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)),
@@ -170,7 +186,11 @@ func TestAnthropicModelGatewayCompleteUsesOAuthBearer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("new gateway failed: %v", err)
 			}
-			if _, err := gateway.Complete(context.Background(), ModelRequest{Model: "claude-test", Step: 1}); err != nil {
+			if _, err := gateway.Complete(context.Background(), ModelRequest{
+				Model:  "claude-sonnet-4-6",
+				Prompt: "You are a planner.",
+				Step:   1,
+			}); err != nil {
 				t.Fatalf("complete failed: %v", err)
 			}
 			if capturedAPIKey != "" {
@@ -179,7 +199,99 @@ func TestAnthropicModelGatewayCompleteUsesOAuthBearer(t *testing.T) {
 			if capturedAuth != tc.wantAuth {
 				t.Fatalf("unexpected Authorization header: got %q want %q", capturedAuth, tc.wantAuth)
 			}
+			if !strings.Contains(capturedBeta, "claude-code-20250219") || !strings.Contains(capturedBeta, "oauth-2025-04-20") {
+				t.Fatalf("expected claude-code oauth betas, got %q", capturedBeta)
+			}
+			if capturedUA != anthropicClaudeCodeUserAgent {
+				t.Fatalf("unexpected User-Agent: got %q want %q", capturedUA, anthropicClaudeCodeUserAgent)
+			}
+			if capturedApp != "cli" {
+				t.Fatalf("unexpected x-app: got %q want cli", capturedApp)
+			}
+			if !strings.Contains(capturedURL, "beta=true") {
+				t.Fatalf("expected ?beta=true on messages URL, got %q", capturedURL)
+			}
+			if len(capturedBody.System) < 3 {
+				t.Fatalf("expected billing+identity+prompt system blocks, got %+v", capturedBody.System)
+			}
+			if !strings.HasPrefix(capturedBody.System[0].Text, "x-anthropic-billing-header:") {
+				t.Fatalf("expected billing header first, got %q", capturedBody.System[0].Text)
+			}
+			if capturedBody.System[1].Text != anthropicClaudeCodeSystemIdentity {
+				t.Fatalf("expected Claude Code identity second, got %q", capturedBody.System[1].Text)
+			}
+			if capturedBody.System[2].Text != "You are a planner." {
+				t.Fatalf("expected original prompt third, got %q", capturedBody.System[2].Text)
+			}
 		})
+	}
+}
+
+func TestAnthropicModelGatewayCompleteAPIKeySkipsClaudeCodeFingerprint(t *testing.T) {
+	var capturedBeta string
+	var capturedUA string
+	var capturedURL string
+	var capturedBody anthropicMessagesRequest
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			capturedBeta = req.Header.Get("anthropic-beta")
+			capturedUA = req.Header.Get("User-Agent")
+			capturedURL = req.URL.String()
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			if err := json.Unmarshal(body, &capturedBody); err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+		Timeout: time.Second,
+	}
+
+	cfg := DefaultAnthropicModelGatewayConfig()
+	cfg.APIKey = "sk-ant-api03-example"
+	cfg.BaseURL = "https://example.invalid/v1"
+	cfg.HTTPClient = client
+
+	gateway, err := NewAnthropicModelGateway(cfg)
+	if err != nil {
+		t.Fatalf("new gateway failed: %v", err)
+	}
+	if _, err := gateway.Complete(context.Background(), ModelRequest{
+		Model:  "claude-sonnet-4-6",
+		Prompt: "You are a planner.",
+		Step:   1,
+	}); err != nil {
+		t.Fatalf("complete failed: %v", err)
+	}
+	if capturedBeta != "" {
+		t.Fatalf("expected no anthropic-beta for API keys, got %q", capturedBeta)
+	}
+	if strings.Contains(capturedUA, "claude-cli/") {
+		t.Fatalf("expected no claude-cli User-Agent for API keys, got %q", capturedUA)
+	}
+	if strings.Contains(capturedURL, "beta=true") {
+		t.Fatalf("expected no beta=true for API keys, got %q", capturedURL)
+	}
+	if len(capturedBody.System) != 1 || capturedBody.System[0].Text != "You are a planner." {
+		t.Fatalf("expected unmodified system prompt for API keys, got %+v", capturedBody.System)
+	}
+}
+
+func TestEnsureAnthropicOAuthSystemIdentityIdempotent(t *testing.T) {
+	in := []anthropicSystemBlock{
+		{Type: "text", Text: anthropicClaudeCodeBillingHeader},
+		{Type: "text", Text: anthropicClaudeCodeSystemIdentity},
+		{Type: "text", Text: "real prompt"},
+	}
+	out := ensureAnthropicOAuthSystemIdentity(in, "sk-ant-oat01-token")
+	if len(out) != 3 {
+		t.Fatalf("expected no duplicate prefix, got %+v", out)
 	}
 }
 

--- a/runtime/model_gateway_anthropic_test.go
+++ b/runtime/model_gateway_anthropic_test.go
@@ -29,6 +29,7 @@ func TestAnthropicModelGatewayCompleteSuccess(t *testing.T) {
 	}
 
 	var capturedAPIKey string
+	var capturedAuth string
 	var capturedVersion string
 	var capturedPath string
 	captured := capturedRequest{}
@@ -36,6 +37,7 @@ func TestAnthropicModelGatewayCompleteSuccess(t *testing.T) {
 	client := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			capturedAPIKey = req.Header.Get("x-api-key")
+			capturedAuth = req.Header.Get("Authorization")
 			capturedVersion = req.Header.Get("anthropic-version")
 			capturedPath = req.URL.Path
 			body, err := io.ReadAll(req.Body)
@@ -90,6 +92,9 @@ func TestAnthropicModelGatewayCompleteSuccess(t *testing.T) {
 	if capturedAPIKey != "test-key" {
 		t.Fatalf("unexpected x-api-key header: %q", capturedAPIKey)
 	}
+	if capturedAuth != "" {
+		t.Fatalf("expected no Authorization header for API keys, got %q", capturedAuth)
+	}
 	if capturedVersion != "2023-06-01" {
 		t.Fatalf("unexpected anthropic-version header: %q", capturedVersion)
 	}
@@ -113,6 +118,88 @@ func TestAnthropicModelGatewayCompleteSuccess(t *testing.T) {
 	}
 	if !strings.Contains(captured.Messages[0].Content, "step=3") {
 		t.Fatalf("expected step in user content, got %q", captured.Messages[0].Content)
+	}
+}
+
+func TestAnthropicModelGatewayCompleteUsesOAuthBearer(t *testing.T) {
+	cases := []struct {
+		name       string
+		credential string
+		wantAuth   string
+	}{
+		{
+			name:       "oauth access token prefix",
+			credential: "sk-ant-oat01-example-token",
+			wantAuth:   "Bearer sk-ant-oat01-example-token",
+		},
+		{
+			name:       "already prefixed bearer",
+			credential: "Bearer sk-ant-oat01-example-token",
+			wantAuth:   "Bearer sk-ant-oat01-example-token",
+		},
+		{
+			name:       "lowercase bearer prefix",
+			credential: "bearer sk-ant-oat01-example-token",
+			wantAuth:   "Bearer sk-ant-oat01-example-token",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedAPIKey string
+			var capturedAuth string
+			client := &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					capturedAPIKey = req.Header.Get("x-api-key")
+					capturedAuth = req.Header.Get("Authorization")
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)),
+						Header:     make(http.Header),
+					}, nil
+				}),
+				Timeout: time.Second,
+			}
+
+			cfg := DefaultAnthropicModelGatewayConfig()
+			cfg.APIKey = tc.credential
+			cfg.BaseURL = "https://example.invalid/v1"
+			cfg.HTTPClient = client
+
+			gateway, err := NewAnthropicModelGateway(cfg)
+			if err != nil {
+				t.Fatalf("new gateway failed: %v", err)
+			}
+			if _, err := gateway.Complete(context.Background(), ModelRequest{Model: "claude-test", Step: 1}); err != nil {
+				t.Fatalf("complete failed: %v", err)
+			}
+			if capturedAPIKey != "" {
+				t.Fatalf("expected no x-api-key for oauth credentials, got %q", capturedAPIKey)
+			}
+			if capturedAuth != tc.wantAuth {
+				t.Fatalf("unexpected Authorization header: got %q want %q", capturedAuth, tc.wantAuth)
+			}
+		})
+	}
+}
+
+func TestAnthropicCredentialUsesBearer(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"sk-ant-api03-abc", false},
+		{"test-key", false},
+		{"sk-ant-oat01-abc", true},
+		{"SK-ANT-OAT01-ABC", true},
+		{"Bearer tok", true},
+		{"bearer tok", true},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := anthropicCredentialUsesBearer(tc.in); got != tc.want {
+			t.Fatalf("anthropicCredentialUsesBearer(%q)=%v want %v", tc.in, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Anthropic OAuth access tokens (`sk-ant-oat...`) use `Authorization: Bearer` (API keys keep `x-api-key`)
- Claude Code client fingerprint so Sonnet/Opus work on subscription OAuth
- Docs cover OAuth tokens alongside API keys

## Motivation
Operators using Anthropic OAuth (e.g. Claude Code / console OAuth access tokens) cannot authenticate through Orloj today because the gateway always sets `x-api-key`, and non-Haiku models need the Claude Code request shape.

## Test plan
- [x] `go test ./runtime/ -run 'Anthropic'`
- [ ] Manual: ModelEndpoint with `sk-ant-oat...` completes Haiku + Sonnet
- [ ] Manual: ModelEndpoint with `sk-ant-api...` still uses `x-api-key`