### PR TITLE
ci: Add amd64-only custom image workflow

### DIFF
--- a/.github/workflows/build-custom-images.yml
+++ b/.github/workflows/build-custom-images.yml
@@ -1,0 +1,62 @@
+# One-off / custom image builds for LinkPool forks (amd64 only, no QEMU).
+# Prefer ma-builder locally when write:packages is available on the client token.
+name: build-custom-images
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to push (e.g. v0.17.0-anthropic-oauth.1)"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to build (branch, tag, or SHA). Empty = workflow ref."
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  images:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: orlojd
+            image: orloj-orlojd
+          - target: orlojworker
+            image: orloj-orlojworker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.target }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          target: ${{ matrix.target }}
+          platforms: linux/amd64
+          tags: ghcr.io/linkpoolio/${{ matrix.image }}:${{ inputs.tag }}
+          build-args: |
+            VERSION=${{ inputs.tag }}
+            COMMIT=${{ github.sha }}
+            DATE=${{ github.event.repository.updated_at }}
+          provenance: false
+          sbom: false


### PR DESCRIPTION
## Summary
- Adds a workflow to build/push amd64-only custom Orloj images (useful for private forks / GHCR pins without multi-arch)

## Test plan
- [ ] Workflow runs successfully on the fork
- [ ] Produced tags pull on linux/amd64


Made with [Cursor](https://cursor.com)