### PR TITLE
fix: Wire Kubernetes tool runtime into message-driven consumers

### DIFF
--- a/cmd/orlojd/main.go
+++ b/cmd/orlojd/main.go
@@ -315,6 +315,7 @@ func main() {
 	taskController.SetIsolatedToolRuntime(isolatedToolRuntime)
 	taskController.SetWasmToolRuntime(wasmToolRuntime)
 	taskController.SetMcpRuntime(mcpSessionManager, stores.McpServers)
+	var k8sToolRT agentruntime.ToolRuntime
 	if *toolK8sEnabled {
 		k8sRT, k8sErr := startup.NewKubernetesToolRuntime(startup.KubernetesToolRuntimeConfig{
 			Namespace:       *toolK8sNamespace,
@@ -327,10 +328,13 @@ func main() {
 		if k8sErr != nil {
 			fatalLogger.Fatalf("failed to configure kubernetes tool runtime: %v", k8sErr)
 		}
+		k8sToolRT = k8sRT
 		taskController.SetKubernetesToolRuntime(k8sRT)
 	}
+	var agentK8sRT *agentruntime.KubernetesAgentRuntime
 	if *agentK8sEnabled {
-		agentK8sRT, agentK8sErr := startup.NewKubernetesAgentRuntime(startup.KubernetesAgentRuntimeConfig{
+		var agentK8sErr error
+		agentK8sRT, agentK8sErr = startup.NewKubernetesAgentRuntime(startup.KubernetesAgentRuntimeConfig{
 			Namespace:      *agentK8sNamespace,
 			ServiceAccount: *agentK8sServiceAccount,
 			Image:          *agentK8sImage,
@@ -568,6 +572,7 @@ func main() {
 						Policies:            stores.Policies,
 						ContextAdapters:     stores.ContextAdapters,
 						A2AToolRuntime:      a2aToolRT,
+						KubernetesToolRT:    k8sToolRT,
 						DebugLogger:         debugLogger,
 						OnStepEvent: func(taskName, namespace string, evt agentruntime.AgentStepEvent) {
 							if bus != nil {

--- a/cmd/orlojworker/main.go
+++ b/cmd/orlojworker/main.go
@@ -344,6 +344,7 @@ func main() {
 	taskController.SetIsolatedToolRuntime(isolatedToolRuntime)
 	taskController.SetWasmToolRuntime(wasmToolRuntime)
 	taskController.SetMcpRuntime(mcpSessionManager, stores.McpServers)
+	var k8sToolRT agentruntime.ToolRuntime
 	if *toolK8sEnabled {
 		k8sRT, k8sErr := startup.NewKubernetesToolRuntime(startup.KubernetesToolRuntimeConfig{
 			Namespace:       *toolK8sNamespace,
@@ -356,6 +357,7 @@ func main() {
 		if k8sErr != nil {
 			fatalLogger.Fatalf("failed to configure kubernetes tool runtime: %v", k8sErr)
 		}
+		k8sToolRT = k8sRT
 		taskController.SetKubernetesToolRuntime(k8sRT)
 	}
 	var agentK8sRT *agentruntime.KubernetesAgentRuntime
@@ -475,6 +477,7 @@ func main() {
 					Policies:            stores.Policies,
 				ContextAdapters:     stores.ContextAdapters,
 				A2AToolRuntime:      a2aToolRT,
+				KubernetesToolRT:    k8sToolRT,
 				AgentK8sRuntime:     agentK8sRT,
 				DebugLogger:         debugLogger,
 				},


### PR DESCRIPTION
## Summary
- Pass `KubernetesToolRT` into `AgentMessageConsumerOptions` in orlojd and orlojworker
- Fixes `isolation_unavailable` for `isolation_mode: kubernetes` tools under message-driven execution

## Test plan
- [x] Cherry-picked from validated fork build
- [ ] Manual: Tool with `isolation_mode: kubernetes` creates a Job instead of returning `isolation_unavailable`


Made with [Cursor](https://cursor.com)