### PR TITLE
fix: Convert Docker-style tool memory and harden CLI arg templating

### DIFF
--- a/charts/orloj/values.yaml
+++ b/charts/orloj/values.yaml
@@ -343,9 +343,12 @@ toolIsolation:
   containerImage: "curlimages/curl:8.8.0"
   # -- Container network mode
   containerNetwork: none
-  # -- Default container memory limit
+  # -- Default container memory limit (Docker-style or Kubernetes units).
+  # Also used as the fallback memory limit for kubernetes tool Jobs when a Tool
+  # omits cli.resources.memory. Docker-style values (128m) are converted to
+  # BinarySI quantities before the Job is created.
   containerMemory: 128m
-  # -- Default container CPU limit
+  # -- Default container CPU limit (also kubernetes tool Job fallback)
   containerCpus: "0.50"
   # -- Default container PID limit
   containerPidsLimit: 64

--- a/cmd/orlojd/main.go
+++ b/cmd/orlojd/main.go
@@ -321,6 +321,8 @@ func main() {
 			ServiceAccount:  *toolK8sServiceAccount,
 			JobTTLSeconds:   int32(*toolK8sJobTTL),
 			DefaultImage:    *toolK8sDefaultImage,
+			DefaultMemory:   *toolContainerMemory,
+			DefaultCPUs:     *toolContainerCPUs,
 			SecretEnvPrefix: *toolSecretEnvPrefix,
 			Secrets:         stores.Secrets,
 		}, logger)

--- a/cmd/orlojworker/main.go
+++ b/cmd/orlojworker/main.go
@@ -239,6 +239,8 @@ func main() {
 				ServiceAccount:  *toolK8sServiceAccount,
 				JobTTLSeconds:   int32(*toolK8sJobTTL),
 				DefaultImage:    *toolK8sDefaultImage,
+				DefaultMemory:   *toolContainerMemory,
+				DefaultCPUs:     *toolContainerCPUs,
 				SecretEnvPrefix: *toolSecretEnvPrefix,
 				Secrets:         stores.Secrets,
 			}, logger)
@@ -350,6 +352,8 @@ func main() {
 			ServiceAccount:  *toolK8sServiceAccount,
 			JobTTLSeconds:   int32(*toolK8sJobTTL),
 			DefaultImage:    *toolK8sDefaultImage,
+			DefaultMemory:   *toolContainerMemory,
+			DefaultCPUs:     *toolContainerCPUs,
 			SecretEnvPrefix: *toolSecretEnvPrefix,
 			Secrets:         stores.Secrets,
 		}, logger)

--- a/runtime/tool_cli_args.go
+++ b/runtime/tool_cli_args.go
@@ -11,7 +11,30 @@ import (
 // evaluateCLIArgs evaluates Go text/template strings against parsed JSON input,
 // producing a flat argv slice. Each template produces exactly one argv entry;
 // entries that evaluate to empty strings are dropped.
+//
+// When no arg contains "{{", input is ignored for templating (so tools that only
+// consume stdin_from_input / have static argv keep working when the model passes
+// free-form text). Missing map keys evaluate to the zero value so optional
+// fields like `{{ if .name }}{{ .name }}{{ end }}` work without requiring every
+// schema property to be present.
 func evaluateCLIArgs(templates []string, input string) ([]string, error) {
+	needsTemplate := false
+	for _, tmplStr := range templates {
+		if strings.Contains(tmplStr, "{{") {
+			needsTemplate = true
+			break
+		}
+	}
+	if !needsTemplate {
+		out := make([]string, 0, len(templates))
+		for _, tmplStr := range templates {
+			if tmplStr != "" {
+				out = append(out, tmplStr)
+			}
+		}
+		return out, nil
+	}
+
 	var data map[string]any
 	input = strings.TrimSpace(input)
 	if input != "" {
@@ -37,7 +60,8 @@ func evaluateCLIArgs(templates []string, input string) ([]string, error) {
 			out = append(out, tmplStr)
 			continue
 		}
-		tmpl, err := template.New(fmt.Sprintf("arg[%d]", i)).Option("missingkey=error").Parse(tmplStr)
+		// missingkey=zero: optional fields ({{ if .name }}) must not fail when absent.
+		tmpl, err := template.New(fmt.Sprintf("arg[%d]", i)).Option("missingkey=zero").Parse(tmplStr)
 		if err != nil {
 			return nil, NewToolError(
 				ToolStatusError,
@@ -61,7 +85,12 @@ func evaluateCLIArgs(templates []string, input string) ([]string, error) {
 				map[string]string{"index": fmt.Sprintf("%d", i), "template": tmplStr},
 			)
 		}
-		value := buf.String()
+		value := strings.TrimSpace(buf.String())
+		// text/template prints "<no value>" for nil interface{} map entries even
+		// with missingkey=zero; treat that as empty so optional fields drop cleanly.
+		if value == "<no value>" {
+			value = ""
+		}
 		if value != "" {
 			out = append(out, value)
 		}

--- a/runtime/tool_cli_args_test.go
+++ b/runtime/tool_cli_args_test.go
@@ -47,13 +47,42 @@ func TestEvaluateCLIArgsDropsEmpty(t *testing.T) {
 	}
 }
 
-func TestEvaluateCLIArgsMissingKeyError(t *testing.T) {
-	_, err := evaluateCLIArgs(
+func TestEvaluateCLIArgsMissingKeyIsEmpty(t *testing.T) {
+	args, err := evaluateCLIArgs(
 		[]string{"cmd", "{{ .missing }}"},
 		`{"other": "value"}`,
 	)
-	if err == nil {
-		t.Fatal("expected error for missing template key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 1 || args[0] != "cmd" {
+		t.Fatalf("expected missing key to drop empty arg, got %v", args)
+	}
+}
+
+func TestEvaluateCLIArgsOptionalIfMissing(t *testing.T) {
+	args, err := evaluateCLIArgs(
+		[]string{"get", "{{ .resource }}", "{{ if .name }}{{ .name }}{{ end }}", "-n", "{{ .namespace }}"},
+		`{"resource": "pods", "namespace": "compliance-agent"}`,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 4 || args[0] != "get" || args[1] != "pods" || args[2] != "-n" || args[3] != "compliance-agent" {
+		t.Fatalf("expected optional name dropped, got %v", args)
+	}
+}
+
+func TestEvaluateCLIArgsStaticIgnoresNonJSONInput(t *testing.T) {
+	args, err := evaluateCLIArgs(
+		[]string{"sh", "-c", "echo ok"},
+		`not-json free-form model text`,
+	)
+	if err != nil {
+		t.Fatalf("static argv should ignore non-JSON input: %v", err)
+	}
+	if len(args) != 3 || args[0] != "sh" {
+		t.Fatalf("unexpected args: %v", args)
 	}
 }
 
@@ -73,7 +102,7 @@ func TestEvaluateCLIArgsInvalidJSON(t *testing.T) {
 		`not-json`,
 	)
 	if err == nil {
-		t.Fatal("expected error for invalid JSON input")
+		t.Fatal("expected error for invalid JSON input when templates are present")
 	}
 }
 

--- a/runtime/tool_runtime_kubernetes.go
+++ b/runtime/tool_runtime_kubernetes.go
@@ -589,12 +589,21 @@ func firstNonEmptyTrimmed(values ...string) string {
 	return ""
 }
 
-// wrapWithStdin builds a command that echoes stdin data into the real command via a shell heredoc.
+// wrapWithStdin builds a command that pipes stdinData into the real command.
+// Each argv entry is single-quoted so multi-arg commands (e.g. sh -c "<script>")
+// stay intact; a naive strings.Join would make `sh -c` only see the first word.
 func wrapWithStdin(command []string, stdinData string) []string {
-	escaped := strings.ReplaceAll(stdinData, "'", "'\"'\"'")
-	inner := strings.Join(command, " ")
-	script := fmt.Sprintf("printf '%%s' '%s' | %s", escaped, inner)
+	escaped := shellSingleQuote(stdinData)
+	quoted := make([]string, len(command))
+	for i, arg := range command {
+		quoted[i] = shellSingleQuote(arg)
+	}
+	script := fmt.Sprintf("printf '%%s' %s | %s", escaped, strings.Join(quoted, " "))
 	return []string{"/bin/sh", "-c", script}
+}
+
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
 func sanitizeK8sName(name string) string {

--- a/runtime/tool_runtime_kubernetes.go
+++ b/runtime/tool_runtime_kubernetes.go
@@ -22,6 +22,12 @@ type KubernetesToolConfig struct {
 	ServiceAccount string
 	DefaultImage   string
 	JobTTLSeconds  int32
+	// DefaultMemory / DefaultCPUs apply when a Tool CR omits cli.resources.*.
+	// Memory accepts Docker-style units (128m, 1g) or Kubernetes IEC units
+	// (128Mi, 1Gi); Docker-style values are converted before the Job is created
+	// so Kubernetes does not treat "m" as millibytes.
+	DefaultMemory string
+	DefaultCPUs   string
 }
 
 func (c KubernetesToolConfig) normalized() KubernetesToolConfig {
@@ -329,29 +335,12 @@ func (r *KubernetesToolRuntime) buildJob(
 	var backoffLimit int32
 	ttl := cfg.JobTTLSeconds
 
-	resourceReqs := corev1.ResourceRequirements{}
-	if mem := strings.TrimSpace(spec.Cli.Resources.Memory); mem != "" {
-		if resourceReqs.Limits == nil {
-			resourceReqs.Limits = corev1.ResourceList{}
-		}
-		if resourceReqs.Requests == nil {
-			resourceReqs.Requests = corev1.ResourceList{}
-		}
-		q := resource.MustParse(mem)
-		resourceReqs.Limits[corev1.ResourceMemory] = q
-		resourceReqs.Requests[corev1.ResourceMemory] = q
-	}
-	if cpus := strings.TrimSpace(spec.Cli.Resources.CPUs); cpus != "" {
-		if resourceReqs.Limits == nil {
-			resourceReqs.Limits = corev1.ResourceList{}
-		}
-		if resourceReqs.Requests == nil {
-			resourceReqs.Requests = corev1.ResourceList{}
-		}
-		q := resource.MustParse(cpus)
-		resourceReqs.Limits[corev1.ResourceCPU] = q
-		resourceReqs.Requests[corev1.ResourceCPU] = q
-	}
+	resourceReqs := toolJobResourceRequirements(
+		spec.Cli.Resources.Memory,
+		spec.Cli.Resources.CPUs,
+		cfg.DefaultMemory,
+		cfg.DefaultCPUs,
+	)
 
 	var activeDeadline *int64
 	if timeout := strings.TrimSpace(spec.Runtime.Timeout); timeout != "" {
@@ -547,6 +536,57 @@ func ctx_is_deadline(err error) bool {
 
 func ctx_is_canceled(err error) bool {
 	return err == context.Canceled
+}
+
+// toolJobResourceRequirements builds Pod resource requests/limits for a tool Job.
+// Memory accepts Docker-style units (256m, 1g) or Kubernetes IEC units (256Mi, 1Gi).
+// Docker-style values are converted to BinarySI quantities so Kubernetes does not
+// treat the "m" suffix as millibytes (which collapses SizeMemoryBackedVolumes
+// projected SA mounts to ~0 bytes and yields FailedMount ENOSPC).
+func toolJobResourceRequirements(mem, cpus, defaultMem, defaultCPUs string) corev1.ResourceRequirements {
+	reqs := corev1.ResourceRequirements{}
+	if resolved := firstNonEmptyTrimmed(mem, defaultMem); resolved != "" {
+		if q, err := parseToolMemoryQuantity(resolved); err == nil {
+			if reqs.Limits == nil {
+				reqs.Limits = corev1.ResourceList{}
+			}
+			if reqs.Requests == nil {
+				reqs.Requests = corev1.ResourceList{}
+			}
+			reqs.Limits[corev1.ResourceMemory] = q
+			reqs.Requests[corev1.ResourceMemory] = q
+		}
+	}
+	if resolved := firstNonEmptyTrimmed(cpus, defaultCPUs); resolved != "" {
+		if q, err := resource.ParseQuantity(resolved); err == nil {
+			if reqs.Limits == nil {
+				reqs.Limits = corev1.ResourceList{}
+			}
+			if reqs.Requests == nil {
+				reqs.Requests = corev1.ResourceList{}
+			}
+			reqs.Limits[corev1.ResourceCPU] = q
+			reqs.Requests[corev1.ResourceCPU] = q
+		}
+	}
+	return reqs
+}
+
+func parseToolMemoryQuantity(mem string) (resource.Quantity, error) {
+	bytes, err := resources.ParseMemoryBytes(mem)
+	if err != nil {
+		return resource.Quantity{}, err
+	}
+	return *resource.NewQuantity(bytes, resource.BinarySI), nil
+}
+
+func firstNonEmptyTrimmed(values ...string) string {
+	for _, v := range values {
+		if t := strings.TrimSpace(v); t != "" {
+			return t
+		}
+	}
+	return ""
 }
 
 // wrapWithStdin builds a command that echoes stdin data into the real command via a shell heredoc.

--- a/runtime/tool_runtime_kubernetes_test.go
+++ b/runtime/tool_runtime_kubernetes_test.go
@@ -410,6 +410,86 @@ func TestKubernetesToolRuntimeCreateJobError(t *testing.T) {
 	}
 }
 
+func TestParseToolMemoryQuantity(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{"256m", 256 * 1024 * 1024, false},
+		{"512Mi", 512 * 1024 * 1024, false},
+		{"1g", 1024 * 1024 * 1024, false},
+		{"1Gi", 1024 * 1024 * 1024, false},
+		{"", 0, true},
+		{"not-a-size", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseToolMemoryQuantity(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %s", tt.input, got.String())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+			if got.Value() != tt.want {
+				t.Fatalf("parseToolMemoryQuantity(%q) = %d (%s), want %d", tt.input, got.Value(), got.String(), tt.want)
+			}
+			// Regression: Docker-style "256m" must not become Kubernetes millibytes.
+			if tt.input == "256m" && got.Value() < 1024 {
+				t.Fatalf("256m collapsed to millibytes (%s); projected SA mounts would ENOSPC", got.String())
+			}
+		})
+	}
+}
+
+func TestToolJobResourceRequirementsDockerMemory(t *testing.T) {
+	reqs := toolJobResourceRequirements("256m", "0.5", "", "")
+	mem := reqs.Limits[corev1.ResourceMemory]
+	if mem.Value() != 256*1024*1024 {
+		t.Fatalf("expected 256Mi worth of bytes, got %s (%d)", mem.String(), mem.Value())
+	}
+	cpu := reqs.Limits[corev1.ResourceCPU]
+	if cpu.AsApproximateFloat64() != 0.5 {
+		t.Fatalf("expected 0.5 CPU, got %s", cpu.String())
+	}
+}
+
+func TestToolJobResourceRequirementsFallsBackToDefaults(t *testing.T) {
+	reqs := toolJobResourceRequirements("", "", "128m", "0.25")
+	mem := reqs.Limits[corev1.ResourceMemory]
+	if mem.Value() != 128*1024*1024 {
+		t.Fatalf("expected default 128m as bytes, got %s (%d)", mem.String(), mem.Value())
+	}
+}
+
+func TestKubernetesToolRuntimeBuildJobConvertsDockerMemory(t *testing.T) {
+	rt := NewKubernetesToolRuntimeWithClient(&fakeKubernetesJobClient{}, KubernetesToolConfig{
+		Namespace:     "test-ns",
+		DefaultMemory: "64m",
+		DefaultCPUs:   "0.25",
+	}, nil)
+
+	job := rt.buildJob("slack-notify", "node:20-alpine", []string{"true"}, nil, "", resources.ToolSpec{
+		Type: "cli",
+		Cli: resources.ToolCliSpec{
+			Resources: resources.ContainerResources{Memory: "256m", CPUs: "0.5"},
+		},
+	})
+	container := job.Spec.Template.Spec.Containers[0]
+	mem := container.Resources.Limits[corev1.ResourceMemory]
+	if mem.Value() != 256*1024*1024 {
+		t.Fatalf("job memory = %s (%d), want 256Mi bytes", mem.String(), mem.Value())
+	}
+	// Ensure we did not pass the raw Docker string through resource.MustParse.
+	if mem.String() == "256m" {
+		t.Fatal("job still carries Docker-style 256m quantity (millibytes)")
+	}
+}
+
 func TestSanitizeK8sName(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/runtime/tool_runtime_kubernetes_test.go
+++ b/runtime/tool_runtime_kubernetes_test.go
@@ -490,6 +490,23 @@ func TestKubernetesToolRuntimeBuildJobConvertsDockerMemory(t *testing.T) {
 	}
 }
 
+func TestWrapWithStdinQuotesMultiArgCommand(t *testing.T) {
+	got := wrapWithStdin([]string{"sh", "-c", "INPUT=$(cat); echo \"$INPUT\""}, `{"message":"hi"}`)
+	if len(got) != 3 || got[0] != "/bin/sh" || got[1] != "-c" {
+		t.Fatalf("unexpected wrapper argv: %v", got)
+	}
+	script := got[2]
+	if !strings.Contains(script, "| 'sh' '-c'") && !strings.Contains(script, "| 'sh' '-c' '") {
+		// Expect each original argv entry to be single-quoted.
+		if !strings.Contains(script, "'sh'") || !strings.Contains(script, "'-c'") {
+			t.Fatalf("expected quoted multi-arg command in script, got %q", script)
+		}
+	}
+	if strings.Contains(script, "| sh -c INPUT=") {
+		t.Fatalf("unquoted join would break sh -c: %q", script)
+	}
+}
+
 func TestSanitizeK8sName(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/startup/runtime.go
+++ b/startup/runtime.go
@@ -150,12 +150,14 @@ func NewWASMToolRuntime(cfg IsolatedToolRuntimeConfig, logger *log.Logger) (agen
 
 // KubernetesToolRuntimeConfig holds flag-level configuration for the K8s backend.
 type KubernetesToolRuntimeConfig struct {
-	Namespace      string
-	ServiceAccount string
-	JobTTLSeconds  int32
-	DefaultImage   string
+	Namespace       string
+	ServiceAccount  string
+	JobTTLSeconds   int32
+	DefaultImage    string
+	DefaultMemory   string
+	DefaultCPUs     string
 	SecretEnvPrefix string
-	Secrets        agentruntime.SecretResourceLookup
+	Secrets         agentruntime.SecretResourceLookup
 }
 
 // NewKubernetesToolRuntime creates a K8s Job-based tool runtime.
@@ -170,6 +172,8 @@ func NewKubernetesToolRuntime(cfg KubernetesToolRuntimeConfig, logger *log.Logge
 		ServiceAccount: strings.TrimSpace(cfg.ServiceAccount),
 		DefaultImage:   strings.TrimSpace(cfg.DefaultImage),
 		JobTTLSeconds:  cfg.JobTTLSeconds,
+		DefaultMemory:  strings.TrimSpace(cfg.DefaultMemory),
+		DefaultCPUs:    strings.TrimSpace(cfg.DefaultCPUs),
 	}
 
 	clientset, err := buildKubernetesClientset()
@@ -186,8 +190,9 @@ func NewKubernetesToolRuntime(cfg KubernetesToolRuntimeConfig, logger *log.Logge
 		if ns == "" {
 			ns = "(pod-namespace or default)"
 		}
-		logger.Printf("kubernetes tool isolation enabled namespace=%s service_account=%s job_ttl=%d default_image=%s",
-			ns, strings.TrimSpace(cfg.ServiceAccount), cfg.JobTTLSeconds, strings.TrimSpace(cfg.DefaultImage))
+		logger.Printf("kubernetes tool isolation enabled namespace=%s service_account=%s job_ttl=%d default_image=%s default_memory=%s default_cpus=%s",
+			ns, strings.TrimSpace(cfg.ServiceAccount), cfg.JobTTLSeconds, strings.TrimSpace(cfg.DefaultImage),
+			strings.TrimSpace(cfg.DefaultMemory), strings.TrimSpace(cfg.DefaultCPUs))
 	}
 	return rt, nil
 }


### PR DESCRIPTION
## Summary
- Convert Docker-style tool memory (`256m`) to K8s BinarySI before creating Jobs (fixes projected SA mount ENOSPC under `SizeMemoryBackedVolumes`)
- Fall back to `ORLOJ_TOOL_CONTAINER_MEMORY` / `CPUS` when a Tool omits `cli.resources`
- Skip JSON parse when argv has no templates; optional missing keys evaluate empty; shell-quote `wrapWithStdin` so `sh -c` scripts keep their full body

## Test plan
- [x] `go test ./runtime/ ./startup/`
- [ ] Manual: tool Job memory limit is ~256Mi (not millibytes); SA mount succeeds
- [ ] Manual: static-argv tools ignore non-JSON model input; optional `{{ if .name }}` works when absent; `stdin_from_input` reaches `sh -c` scripts


Made with [Cursor](https://cursor.com)