### PR TITLE
fix: Heartbeat message lease and NATS InProgress during agent runs

### DIFF
--- a/runtime/agent_message_bus_nats.go
+++ b/runtime/agent_message_bus_nats.go
@@ -27,7 +27,8 @@ const (
 	defaultConsumerMaxDeliver = 10
 
 	// defaultConsumerAckWait is the time the server waits for an ack before
-	// redelivering.  Matches the long-running agent execution window.
+	// redelivering. Handlers must call ExtendLease/InProgress periodically
+	// during long agent/tool runs; this is the idle window between heartbeats.
 	defaultConsumerAckWait = 120 * time.Second
 )
 
@@ -79,6 +80,13 @@ func (d *natsAgentMessageDelivery) NackWithDelay(_ context.Context, delay time.D
 }
 
 func (d *natsAgentMessageDelivery) ExtendLease(_ context.Context, _ time.Duration) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.acked {
+		return nil
+	}
+	// InProgress resets AckWait so long-running handlers are not redelivered
+	// while still actively processing.
 	return d.msg.InProgress()
 }
 

--- a/runtime/agent_message_consumer.go
+++ b/runtime/agent_message_consumer.go
@@ -374,10 +374,10 @@ func (m *AgentMessageConsumerManager) handleDelivery(ctx context.Context, _ stri
 		return nil
 	}
 
-	return m.processMessage(ctx, taskKey, task, msg)
+	return m.processMessage(ctx, taskKey, task, msg, delivery)
 }
 
-func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKey string, cachedTask resources.Task, msg AgentMessage) error {
+func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKey string, cachedTask resources.Task, msg AgentMessage, delivery AgentMessageDelivery) error {
 	// Restore the W3C trace context from task annotations so the message span
 	// is linked as a continuation of the HTTP request that created the task.
 	// Uses the task already fetched by handleDelivery to avoid a redundant lookup.
@@ -400,16 +400,23 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 		return RetryAfter(retryAfter, nil)
 	}
 
+	// Ownership is held; keep the task lease + NATS AckWait alive for the full
+	// agent/tool window so another worker cannot takeover mid-run.
+	parentCtx := ctx
+	hbCtx, stopHeartbeat := m.startMessageLeaseHeartbeat(ctx, delivery, taskKey)
+	defer stopHeartbeat()
+	ctx = hbCtx
+
 	ns, _ := splitTaskKey(taskKey)
 	systemKey := scopedTaskName(ns, task.Spec.System)
 	system, ok, sysErr := m.systems.Get(ctx, systemKey)
 	if sysErr != nil {
-		return sysErr
+		return remapLeaseLost(sysErr, hbCtx, parentCtx)
 	}
 	if !ok {
 		retryScheduled, delay, markErr := m.recordRetryOrDeadLetter(ctx, taskKey, msg, record, fmt.Errorf("agentsystem %q not found", task.Spec.System))
 		if markErr != nil {
-			return markErr
+			return remapLeaseLost(markErr, hbCtx, parentCtx)
 		}
 		if retryScheduled {
 			return RetryAfter(delay, nil)
@@ -420,7 +427,7 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 
 	joinDecision, err := m.applyJoinGate(ctx, taskKey, msg, system)
 	if err != nil {
-		return err
+		return remapLeaseLost(err, hbCtx, parentCtx)
 	}
 	if joinDecision.SkipExecution {
 		m.debugf("agent message skipped task=%s message_id=%s reason=join_gate_waiting mode=%s required=%d received=%d", taskKey, msg.MessageID, joinDecision.JoinMode, joinDecision.Required, len(joinDecision.Sources))
@@ -429,7 +436,7 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 
 	delegationDecision, err := m.applyDelegationGate(ctx, taskKey, msg, system)
 	if err != nil {
-		return err
+		return remapLeaseLost(err, hbCtx, parentCtx)
 	}
 	if delegationDecision.SkipExecution {
 		m.debugf("agent message skipped task=%s message_id=%s reason=delegation_gate_waiting mode=%s required=%d received=%d", taskKey, msg.MessageID, delegationDecision.DelegationMode, delegationDecision.Required, len(delegationDecision.Sources))
@@ -439,12 +446,12 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 	agentKey := scopedTaskName(ns, msg.ToAgent)
 	agent, ok, agentErr := m.agents.Get(ctx, agentKey)
 	if agentErr != nil {
-		return agentErr
+		return remapLeaseLost(agentErr, hbCtx, parentCtx)
 	}
 	if !ok {
 		retryScheduled, delay, markErr := m.recordRetryOrDeadLetter(ctx, taskKey, msg, record, fmt.Errorf("agent %q not found for message processing", msg.ToAgent))
 		if markErr != nil {
-			return markErr
+			return remapLeaseLost(markErr, hbCtx, parentCtx)
 		}
 		if retryScheduled {
 			return RetryAfter(delay, nil)
@@ -455,7 +462,7 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 	if err != nil {
 		retryScheduled, delay, markErr := m.recordRetryOrDeadLetter(ctx, taskKey, msg, record, fmt.Errorf("agent %s model resolution failed: %w", agent.Metadata.Name, err))
 		if markErr != nil {
-			return markErr
+			return remapLeaseLost(markErr, hbCtx, parentCtx)
 		}
 		if retryScheduled {
 			return RetryAfter(delay, nil)
@@ -664,6 +671,9 @@ func (m *AgentMessageConsumerManager) processMessage(ctx context.Context, taskKe
 	}
 	if err != nil {
 		telemetry.EndSpanError(agentSpan, err)
+		if remapped := remapLeaseLost(err, hbCtx, parentCtx); errors.Is(remapped, errMessageLeaseLost) {
+			return remapped
+		}
 		if IsApprovalRequiredError(err) && m.toolApprovals != nil {
 			if pauseErr := m.pauseTaskForToolApproval(ctx, taskKey, msg, record, agent, err); pauseErr == nil {
 				return RetryAfter(2*time.Second, nil)
@@ -2085,6 +2095,106 @@ func extendWorkerLease(task *resources.Task, workerID string, duration time.Dura
 	now := time.Now().UTC()
 	task.Status.LastHeartbeat = now.Format(time.RFC3339Nano)
 	task.Status.LeaseUntil = now.Add(duration).Format(time.RFC3339Nano)
+}
+
+// errMessageLeaseLost is returned when a worker loses message ownership mid-run
+// (task deleted, terminal, or claimed by another worker). Callers should stop
+// processing rather than continue as a zombie.
+var errMessageLeaseLost = errors.New("message lease lost")
+
+func remapLeaseLost(err error, hbCtx, parentCtx context.Context) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) && hbCtx != nil && errors.Is(hbCtx.Err(), context.Canceled) && (parentCtx == nil || parentCtx.Err() == nil) {
+		return errMessageLeaseLost
+	}
+	return err
+}
+
+// startMessageLeaseHeartbeat periodically renews the task lease and signals
+// NATS InProgress so AckWait does not expire during long agent/tool runs.
+// The returned context is cancelled if ownership is lost so in-flight model
+// HTTP calls abort instead of racing a takeover worker.
+func (m *AgentMessageConsumerManager) startMessageLeaseHeartbeat(
+	parent context.Context,
+	delivery AgentMessageDelivery,
+	taskKey string,
+) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	interval := m.leaseExtend / 3
+	switch {
+	case interval <= 0:
+		interval = 5 * time.Second
+	case interval > 15*time.Second:
+		interval = 15 * time.Second
+	case interval < 5*time.Second && m.leaseExtend >= 15*time.Second:
+		// Production leases are >=30s; keep a 5s floor so we renew well
+		// before AckWait/lease expiry. Short leases are allowed for tests.
+		interval = 5 * time.Second
+	}
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if delivery != nil {
+					if err := delivery.ExtendLease(ctx, m.leaseExtend); err != nil {
+						m.debugf("message bus lease extend failed task=%s: %v", taskKey, err)
+					}
+				}
+				if err := m.renewTaskMessageLease(ctx, taskKey); err != nil {
+					m.debugf("task message lease renew failed task=%s: %v", taskKey, err)
+					if errors.Is(err, errMessageLeaseLost) {
+						cancel()
+						return
+					}
+				}
+			}
+		}
+	}()
+	return ctx, cancel
+}
+
+func (m *AgentMessageConsumerManager) renewTaskMessageLease(ctx context.Context, taskKey string) error {
+	if m == nil || m.tasks == nil {
+		return nil
+	}
+	worker := strings.TrimSpace(m.workerID)
+	if worker == "" {
+		return nil
+	}
+	for attempt := 0; attempt < 5; attempt++ {
+		task, ok, err := m.tasks.Get(ctx, taskKey)
+		if err != nil {
+			return err
+		}
+		if !ok || isTerminalTaskPhase(task.Status.Phase) {
+			return errMessageLeaseLost
+		}
+		claimedBy := strings.TrimSpace(task.Status.ClaimedBy)
+		if claimedBy != "" && !strings.EqualFold(claimedBy, worker) {
+			return errMessageLeaseLost
+		}
+		if claimedBy == "" {
+			task.Status.ClaimedBy = worker
+			task.Status.AssignedWorker = worker
+		}
+		extendWorkerLease(&task, worker, m.leaseExtend)
+		task.Status.ObservedGeneration = task.Metadata.Generation
+		if _, err := m.tasks.Upsert(ctx, task); err != nil {
+			if !casRetryDelay(ctx, attempt) {
+				return ctx.Err()
+			}
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("task lease renew exhausted retries for %s", taskKey)
 }
 
 func hasTraceMarker(trace []resources.TaskTraceEvent, eventType, messageID string) bool {

--- a/runtime/agent_message_lease_heartbeat_test.go
+++ b/runtime/agent_message_lease_heartbeat_test.go
@@ -1,0 +1,182 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/OrlojHQ/orloj/resources"
+	"github.com/OrlojHQ/orloj/store"
+)
+
+type countingLeaseDelivery struct {
+	message     AgentMessage
+	extendCalls atomic.Int64
+}
+
+func (d *countingLeaseDelivery) Message() AgentMessage                       { return d.message }
+func (d *countingLeaseDelivery) Ack(context.Context) error                   { return nil }
+func (d *countingLeaseDelivery) Nack(context.Context, bool) error            { return nil }
+func (d *countingLeaseDelivery) NackWithDelay(context.Context, time.Duration) error {
+	return nil
+}
+func (d *countingLeaseDelivery) ExtendLease(context.Context, time.Duration) error {
+	d.extendCalls.Add(1)
+	return nil
+}
+
+func TestRenewTaskMessageLeaseExtendsOwnedLease(t *testing.T) {
+	taskStore := store.NewTaskStore()
+	if _, err := taskStore.Upsert(context.Background(), resources.Task{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "Task",
+		Metadata:   resources.ObjectMeta{Name: "lease-task", Namespace: "default"},
+		Spec:       resources.TaskSpec{System: "sys", Mode: "run"},
+		Status: resources.TaskStatus{
+			Phase:     "Running",
+			ClaimedBy: "worker-a",
+		},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	manager := &AgentMessageConsumerManager{
+		tasks:       taskStore,
+		workerID:    "worker-a",
+		leaseExtend: 30 * time.Second,
+	}
+	if err := manager.renewTaskMessageLease(context.Background(), "default/lease-task"); err != nil {
+		t.Fatalf("renew: %v", err)
+	}
+	got, ok, err := taskStore.Get(context.Background(), "default/lease-task")
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if got.Status.LastHeartbeat == "" || got.Status.LeaseUntil == "" {
+		t.Fatalf("expected heartbeat/leaseUntil to be set, got %+v", got.Status)
+	}
+	leaseUntil, ok := parseTaskLeaseUntil(got.Status.LeaseUntil)
+	if !ok || time.Until(leaseUntil) < 20*time.Second {
+		t.Fatalf("expected lease ~30s ahead, got %q", got.Status.LeaseUntil)
+	}
+}
+
+func TestRenewTaskMessageLeaseLostWhenClaimedByOther(t *testing.T) {
+	taskStore := store.NewTaskStore()
+	if _, err := taskStore.Upsert(context.Background(), resources.Task{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "Task",
+		Metadata:   resources.ObjectMeta{Name: "lease-task", Namespace: "default"},
+		Spec:       resources.TaskSpec{System: "sys", Mode: "run"},
+		Status: resources.TaskStatus{
+			Phase:     "Running",
+			ClaimedBy: "worker-b",
+		},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	manager := &AgentMessageConsumerManager{
+		tasks:       taskStore,
+		workerID:    "worker-a",
+		leaseExtend: 30 * time.Second,
+	}
+	err := manager.renewTaskMessageLease(context.Background(), "default/lease-task")
+	if !errors.Is(err, errMessageLeaseLost) {
+		t.Fatalf("expected errMessageLeaseLost, got %v", err)
+	}
+}
+
+func TestRenewTaskMessageLeaseLostWhenTaskMissing(t *testing.T) {
+	manager := &AgentMessageConsumerManager{
+		tasks:       store.NewTaskStore(),
+		workerID:    "worker-a",
+		leaseExtend: 30 * time.Second,
+	}
+	err := manager.renewTaskMessageLease(context.Background(), "default/missing")
+	if !errors.Is(err, errMessageLeaseLost) {
+		t.Fatalf("expected errMessageLeaseLost, got %v", err)
+	}
+}
+
+func TestStartMessageLeaseHeartbeatCallsExtendLease(t *testing.T) {
+	taskStore := store.NewTaskStore()
+	if _, err := taskStore.Upsert(context.Background(), resources.Task{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "Task",
+		Metadata:   resources.ObjectMeta{Name: "hb-task", Namespace: "default"},
+		Spec:       resources.TaskSpec{System: "sys", Mode: "run"},
+		Status: resources.TaskStatus{
+			Phase:     "Running",
+			ClaimedBy: "worker-a",
+		},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	delivery := &countingLeaseDelivery{message: AgentMessage{MessageID: "m1"}}
+	manager := &AgentMessageConsumerManager{
+		tasks:       taskStore,
+		workerID:    "worker-a",
+		leaseExtend: 30 * time.Millisecond,
+	}
+	ctx, stop := manager.startMessageLeaseHeartbeat(context.Background(), delivery, "default/hb-task")
+	defer stop()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for delivery.extendCalls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if delivery.extendCalls.Load() < 2 {
+		t.Fatalf("expected >=2 ExtendLease calls, got %d", delivery.extendCalls.Load())
+	}
+	got, ok, err := taskStore.Get(ctx, "default/hb-task")
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if got.Status.LeaseUntil == "" {
+		t.Fatal("expected leaseUntil refreshed by heartbeat")
+	}
+}
+
+func TestStartMessageLeaseHeartbeatCancelsOnOwnershipLoss(t *testing.T) {
+	taskStore := store.NewTaskStore()
+	if _, err := taskStore.Upsert(context.Background(), resources.Task{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "Task",
+		Metadata:   resources.ObjectMeta{Name: "lost-task", Namespace: "default"},
+		Spec:       resources.TaskSpec{System: "sys", Mode: "run"},
+		Status: resources.TaskStatus{
+			Phase:     "Running",
+			ClaimedBy: "worker-a",
+		},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	delivery := &countingLeaseDelivery{}
+	manager := &AgentMessageConsumerManager{
+		tasks:       taskStore,
+		workerID:    "worker-a",
+		leaseExtend: 30 * time.Millisecond,
+	}
+	ctx, stop := manager.startMessageLeaseHeartbeat(context.Background(), delivery, "default/lost-task")
+	defer stop()
+
+	// Steal ownership so the next renew returns errMessageLeaseLost and cancels ctx.
+	task, ok, err := taskStore.Get(context.Background(), "default/lost-task")
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	task.Status.ClaimedBy = "worker-b"
+	if _, err := taskStore.Upsert(context.Background(), task); err != nil {
+		t.Fatalf("steal ownership: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected heartbeat to cancel context after ownership loss")
+	}
+}


### PR DESCRIPTION
## Summary
- Renew the task message lease on an interval while a worker owns a delivery, so long agent/tool runs cannot expire and get taken over by another worker
- Call JetStream `InProgress` via `ExtendLease` on the same heartbeat so AckWait does not redeliver mid-run
- Cancel the in-flight handler context if ownership is lost (task deleted/terminal/stolen) so zombie Anthropic calls abort

## Context
Observed on a compliance dry-run with two workers: lease expired ~30s after claim with no heartbeat, NATS durables left with outstanding acks (AckWait=2m, never InProgress), and both workers held ESTABLISHED connections to Anthropic while the task hung in `Running`.

## Test plan
- [x] `go test ./runtime/ -count=1`
- [ ] Deploy custom image with this commit and re-run a long multi-tool agent task
- [ ] Confirm only one worker processes the message and NATS outstanding ack clears on completion
- [ ] Confirm takeover still works after a hard worker kill (lease expires without heartbeat)


Made with [Cursor](https://cursor.com)