### PR TITLE
fix: Poll Kubernetes tool Jobs so silent watches cannot hang agents

### DIFF
--- a/runtime/tool_runtime_kubernetes.go
+++ b/runtime/tool_runtime_kubernetes.go
@@ -72,8 +72,12 @@ func (c *defaultKubernetesJobClient) GetJob(ctx context.Context, namespace, name
 }
 
 func (c *defaultKubernetesJobClient) GetPodLogs(ctx context.Context, namespace, podName string) (string, error) {
+	// Bound log reads so a stalled apiserver stream cannot hang the agent loop
+	// for the full agent timeout (often 20m).
+	logCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
 	req := c.clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
-	stream, err := req.Stream(ctx)
+	stream, err := req.Stream(logCtx)
 	if err != nil {
 		return "", err
 	}
@@ -465,21 +469,49 @@ func (r *KubernetesToolRuntime) waitForJobCompletion(ctx context.Context, tool, 
 	}
 	defer watcher.Stop()
 
+	// Poll as a backstop: watches can miss the terminal event when a Job
+	// completes between Create and Watch connect, and a silent watch never
+	// closes ResultChan — leaving the agent blocked until its outer timeout.
+	poll := time.NewTicker(2 * time.Second)
+	defer poll.Stop()
+
+	checkOnce := func() (done bool, checkErr error) {
+		job, getErr := r.client.GetJob(ctx, namespace, jobName)
+		if getErr != nil {
+			if ctx.Err() != nil {
+				return true, mapKubernetesContextError(tool, ctx.Err())
+			}
+			// Transient get failures are ignored; the next poll/watch event retries.
+			return false, nil
+		}
+		if result := checkJobStatus(tool, jobName, job); result != errJobStillRunning {
+			return true, result
+		}
+		return false, nil
+	}
+
+	if done, checkErr := checkOnce(); done {
+		return checkErr
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return mapKubernetesContextError(tool, ctx.Err())
+		case <-poll.C:
+			if done, checkErr := checkOnce(); done {
+				return checkErr
+			}
 		case event, ok := <-watcher.ResultChan():
 			if !ok {
-				job, getErr := r.client.GetJob(ctx, namespace, jobName)
-				if getErr != nil {
-					return NewToolError(
-						ToolStatusError, ToolCodeExecutionFailed, ToolReasonBackendFailure, true,
-						fmt.Sprintf("kubernetes job watch closed and get failed for tool=%s job=%s", tool, jobName),
-						getErr, map[string]string{"tool": tool, "job": jobName, "isolation_mode": "kubernetes"},
-					)
+				if done, checkErr := checkOnce(); done {
+					return checkErr
 				}
-				return checkJobStatus(tool, jobName, job)
+				return NewToolError(
+					ToolStatusError, ToolCodeExecutionFailed, ToolReasonBackendFailure, true,
+					fmt.Sprintf("kubernetes job watch closed while job still running for tool=%s job=%s", tool, jobName),
+					nil, map[string]string{"tool": tool, "job": jobName, "isolation_mode": "kubernetes"},
+				)
 			}
 			if event.Type == watch.Deleted {
 				return NewToolError(
@@ -502,6 +534,9 @@ func (r *KubernetesToolRuntime) waitForJobCompletion(ctx context.Context, tool, 
 var errJobStillRunning = fmt.Errorf("job still running")
 
 func checkJobStatus(tool, jobName string, job *batchv1.Job) error {
+	if job == nil {
+		return errJobStillRunning
+	}
 	for _, cond := range job.Status.Conditions {
 		switch cond.Type {
 		case batchv1.JobComplete:

--- a/runtime/tool_runtime_kubernetes_test.go
+++ b/runtime/tool_runtime_kubernetes_test.go
@@ -211,6 +211,10 @@ func TestKubernetesToolRuntimeContextTimeout(t *testing.T) {
 
 	client := &fakeKubernetesJobClient{
 		watchCh: watchCh,
+		getJob: &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+			Status:     batchv1.JobStatus{}, // still running
+		},
 	}
 
 	registry := NewStaticToolCapabilityRegistry(map[string]resources.ToolSpec{
@@ -240,6 +244,50 @@ func TestKubernetesToolRuntimeContextTimeout(t *testing.T) {
 	}
 	if toolErr.Code != ToolCodeTimeout {
 		t.Errorf("expected code=%s, got %s", ToolCodeTimeout, toolErr.Code)
+	}
+}
+
+func TestKubernetesToolRuntimePollDetectsCompletionWithoutWatchEvent(t *testing.T) {
+	// Watch stays silent; Job is already Complete when polled via Get.
+	watchCh := make(chan watch.Event)
+	client := &fakeKubernetesJobClient{
+		watchCh: watchCh,
+		getJob: &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+			Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{{
+					Type:   batchv1.JobComplete,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		},
+		pods: []corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}}},
+		logs: "polled-ok",
+	}
+
+	registry := NewStaticToolCapabilityRegistry(map[string]resources.ToolSpec{
+		"my-tool": {
+			Type: "cli",
+			Cli: resources.ToolCliSpec{
+				Image:   "alpine:latest",
+				Command: "echo",
+				Args:    []string{"hi"},
+			},
+		},
+	})
+
+	rt := NewKubernetesToolRuntimeWithClient(client, KubernetesToolConfig{}, nil)
+	rt = rt.WithRegistry(registry).(*KubernetesToolRuntime)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := rt.Call(ctx, "my-tool", `{}`)
+	if err != nil {
+		t.Fatalf("expected poll to observe completion, got %v", err)
+	}
+	if strings.TrimSpace(out) != "polled-ok" {
+		t.Fatalf("unexpected output %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `waitForJobCompletion` now polls `Get` every 2s alongside the watch
- Prevents hangs when a Job completes between Create and Watch connect (watch stays open with no events)
- Bound `GetPodLogs` to 60s so a stalled log stream cannot pin the agent for the full agent timeout

## Context
Compliance dry-run on MA: many `evidence-auto-draft` Jobs completed, then the worker sat idle (~5m CPU) with the task `Running` until the 1200s agent timeout. Lease heartbeat was healthy; NATS had 1 outstanding ack with 0 redeliveries. Root cause is a silent Job watch, not Anthropic.

## Test plan
- [x] `go test ./runtime/ -run KubernetesToolRuntime`
- [ ] Deploy custom image and re-run a multi-tool agent that creates short-lived Jobs


Made with [Cursor](https://cursor.com)