### PR TITLE
fix: Stop agent workers spinning on consecutive model errors

### DIFF
--- a/runtime/agent_worker.go
+++ b/runtime/agent_worker.go
@@ -114,6 +114,11 @@ func (w *AgentWorker) Run(ctx context.Context) {
 
 	toolResultCache := make(map[string]string)
 	toolCalled := make(map[string]bool)
+	// Consecutive model failures used to spin through max_steps with no
+	// progress (timeout → continue → timeout). Cap retries so the task
+	// fails closed instead of hanging until the outer agent timeout.
+	const maxConsecutiveModelErrors = 3
+	consecutiveModelErrors := 0
 
 	normalizeContractMessage := func(message string) string {
 		message = strings.TrimSpace(message)
@@ -205,12 +210,28 @@ func (w *AgentWorker) Run(ctx context.Context) {
 			})
 		modelLatencyMS := time.Since(modelStart).Milliseconds()
 		if modelErr != nil {
+			consecutiveModelErrors++
 			if w.onEvent != nil {
-				w.onEvent(fmt.Sprintf("step=%d model_error=%v latency_ms=%d", step, modelErr, modelLatencyMS))
+				w.onEvent(fmt.Sprintf("step=%d model_error=%v latency_ms=%d consecutive_errors=%d", step, modelErr, modelLatencyMS, consecutiveModelErrors))
 			}
 			w.history = w.history[:len(w.history)-1]
+			if mge, retryable := IsModelGatewayError(modelErr); mge != nil && !retryable {
+				if w.onEvent != nil {
+					w.onEvent(fmt.Sprintf("step=%d model_error non-retryable status=%d; stopping", step, mge.StatusCode))
+					w.onEvent("worker stopped model error")
+				}
+				return
+			}
+			if consecutiveModelErrors >= maxConsecutiveModelErrors {
+				if w.onEvent != nil {
+					w.onEvent(fmt.Sprintf("step=%d model_error circuit open after %d consecutive failures; stopping", step, consecutiveModelErrors))
+					w.onEvent("worker stopped model error")
+				}
+				return
+			}
 			continue
 		}
+		consecutiveModelErrors = 0
 		if modelResp.Done && modelResp.Content == "" && len(modelResp.ToolCalls) == 0 {
 			if w.onEvent != nil {
 				w.onEvent(fmt.Sprintf("step=%d model signaled done with no output", step))

--- a/runtime/agent_worker_model_error_test.go
+++ b/runtime/agent_worker_model_error_test.go
@@ -1,0 +1,110 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/OrlojHQ/orloj/resources"
+)
+
+type countingErrorGateway struct {
+	calls atomic.Int32
+	err   error
+}
+
+func (g *countingErrorGateway) Complete(_ context.Context, _ ModelRequest) (ModelResponse, error) {
+	g.calls.Add(1)
+	return ModelResponse{}, g.err
+}
+
+func TestAgentWorkerStopsAfterConsecutiveModelErrors(t *testing.T) {
+	gateway := &countingErrorGateway{err: errors.New("context deadline exceeded")}
+	var events []string
+	worker := NewAgentWorkerWithIntervalAndGateway(
+		resources.Agent{
+			Metadata: resources.ObjectMeta{Name: "planner", Namespace: "ns"},
+			Spec: resources.AgentSpec{
+				Model:  "claude-sonnet-4-5",
+				Prompt: "test",
+				Limits: resources.AgentLimits{MaxSteps: 20},
+			},
+		},
+		&staticToolRuntime{},
+		nil,
+		gateway,
+		func(event string) { events = append(events, event) },
+		time.Millisecond,
+	)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker.Run(context.Background())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not stop after consecutive model errors")
+	}
+
+	if got := gateway.calls.Load(); got != 3 {
+		t.Fatalf("expected 3 model attempts before circuit open, got %d", got)
+	}
+	joined := strings.Join(events, "\n")
+	if !strings.Contains(joined, "model_error circuit open after 3 consecutive failures") {
+		t.Fatalf("expected circuit-open event, got events:\n%s", joined)
+	}
+	if !strings.Contains(joined, "worker stopped model error") {
+		t.Fatalf("expected worker stopped model error, got events:\n%s", joined)
+	}
+}
+
+func TestAgentWorkerStopsOnNonRetryableModelGatewayError(t *testing.T) {
+	gateway := &countingErrorGateway{err: &ModelGatewayError{
+		StatusCode: http.StatusUnauthorized,
+		Provider:   "anthropic",
+		Message:    "invalid api key",
+	}}
+	var events []string
+	worker := NewAgentWorkerWithIntervalAndGateway(
+		resources.Agent{
+			Metadata: resources.ObjectMeta{Name: "planner", Namespace: "ns"},
+			Spec: resources.AgentSpec{
+				Model:  "claude-sonnet-4-5",
+				Prompt: "test",
+				Limits: resources.AgentLimits{MaxSteps: 20},
+			},
+		},
+		&staticToolRuntime{},
+		nil,
+		gateway,
+		func(event string) { events = append(events, event) },
+		time.Millisecond,
+	)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker.Run(context.Background())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not stop on non-retryable model error")
+	}
+
+	if got := gateway.calls.Load(); got != 1 {
+		t.Fatalf("expected single non-retryable attempt, got %d", got)
+	}
+	joined := strings.Join(events, "\n")
+	if !strings.Contains(joined, "model_error non-retryable status=401") {
+		t.Fatalf("expected non-retryable stop event, got events:\n%s", joined)
+	}
+}

--- a/runtime/model_gateway_factory.go
+++ b/runtime/model_gateway_factory.go
@@ -149,10 +149,17 @@ func (p *anthropicModelProviderPlugin) BuildGateway(cfg ModelGatewayConfig) (Mod
 	if strings.TrimSpace(cfg.DefaultModel) != "" {
 		anthropicCfg.DefaultModel = strings.TrimSpace(cfg.DefaultModel)
 	}
-	if cfg.Timeout > 0 {
+	// ModelRouter builds gateways with DefaultModelGatewayConfig.Timeout (30s).
+	// Anthropic tool-heavy turns routinely need longer; keep the Anthropic
+	// default (120s) unless the caller set an explicit longer timeout.
+	if cfg.Timeout > anthropicCfg.Timeout {
 		anthropicCfg.Timeout = cfg.Timeout
 	}
-	anthropicCfg.HTTPClient = resolveGatewayHTTPClient(cfg)
+	httpCfg := cfg
+	if httpCfg.HTTPClient == nil {
+		httpCfg.Timeout = anthropicCfg.Timeout
+	}
+	anthropicCfg.HTTPClient = resolveGatewayHTTPClient(httpCfg)
 
 	options := normalizeModelProviderOptions(cfg.Options)
 	if value, ok := options["anthropic_version"]; ok && strings.TrimSpace(value) != "" {

--- a/runtime/model_gateway_factory_test.go
+++ b/runtime/model_gateway_factory_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestNewModelGatewayFromConfigDefaultsToMock(t *testing.T) {
@@ -106,5 +107,45 @@ func TestNewModelGatewayFromConfigUnsupportedProvider(t *testing.T) {
 	}
 	if !errors.Is(err, ErrModelGatewayConfiguration) {
 		t.Fatalf("expected ErrModelGatewayConfiguration, got %v", err)
+	}
+}
+
+func TestAnthropicProviderKeepsDefaultTimeoutOverRouterDefault(t *testing.T) {
+	cfg := DefaultModelGatewayConfig()
+	cfg.Provider = "anthropic"
+	cfg.APIKey = "test-key"
+	// Router default is 30s; Anthropic should keep its 120s default for tool-heavy turns.
+	if cfg.Timeout != 30*time.Second {
+		t.Fatalf("expected router default timeout 30s, got %s", cfg.Timeout)
+	}
+
+	gateway, err := NewModelGatewayFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("expected anthropic gateway, got %v", err)
+	}
+	ag, ok := gateway.(*AnthropicModelGateway)
+	if !ok {
+		t.Fatalf("expected *AnthropicModelGateway, got %T", gateway)
+	}
+	if ag.client == nil {
+		t.Fatal("expected HTTP client")
+	}
+	if ag.client.Timeout != 120*time.Second {
+		t.Fatalf("expected anthropic HTTP timeout 120s, got %s", ag.client.Timeout)
+	}
+}
+
+func TestAnthropicProviderHonorsLongerExplicitTimeout(t *testing.T) {
+	gateway, err := NewModelGatewayFromConfig(ModelGatewayConfig{
+		Provider: "anthropic",
+		APIKey:   "test-key",
+		Timeout:  5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("expected anthropic gateway, got %v", err)
+	}
+	ag := gateway.(*AnthropicModelGateway)
+	if ag.client.Timeout != 5*time.Minute {
+		t.Fatalf("expected explicit timeout 5m, got %s", ag.client.Timeout)
 	}
 }


### PR DESCRIPTION
## Summary
- Cap consecutive model failures at 3 and stop immediately on non-retryable `ModelGatewayError` (4xx except 429), instead of logging and continuing through `max_steps`.
- Keep Anthropic's 120s HTTP timeout when ModelRouter supplies the 30s default; still honor an explicit longer timeout.
- Adds unit coverage for the circuit breaker and Anthropic timeout selection.

## Test plan
- [x] `go test ./runtime/ -run 'TestAgentWorkerStopsAfterConsecutiveModelErrors|TestAgentWorkerStopsOnNonRetryableModelGatewayError|TestAnthropicProviderKeepsDefaultTimeoutOverRouterDefault|TestAnthropicProviderHonorsLongerExplicitTimeout'`
- [ ] Manual: tool-heavy Anthropic agent that previously hung after tools should either complete or fail closed with `model_error circuit open` / non-retryable stop within ~3 attempts


Made with [Cursor](https://cursor.com)