### PR TITLE
add orlojctl logs --follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`orlojctl logs --follow` / `-f`**: polls task/agent logs and prints new lines as they appear, until interrupted with Ctrl+C. `--follow-interval` sets the poll period (default `2s`).
+
 ## [0.18.0] - 2026-07-09
 
 ### Added

--- a/cli/orlojctl.go
+++ b/cli/orlojctl.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"sort"
 	"strconv"
 	"strings"
@@ -996,37 +997,78 @@ func runDelete(cmd *cobra.Command, args []string) error {
 // --- logs ---
 
 func newLogsCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "logs <agent-name>|task/<task-name>",
 		Short: "View agent or task logs",
 		Args:  cobra.ExactArgs(1),
 		RunE:  runLogs,
 	}
+	cmd.Flags().BoolP("follow", "f", false, "stream new log lines in real time until interrupted (Ctrl+C)")
+	cmd.Flags().Duration("follow-interval", 2*time.Second, "poll interval when --follow is set")
+	return cmd
 }
 
 func runLogs(cmd *cobra.Command, args []string) error {
 	server := resolveServer(cmd)
-	target := args[0]
-	endpoint := ""
-	name := target
-	if strings.HasPrefix(strings.ToLower(target), "task/") {
-		name = strings.TrimSpace(target[len("task/"):])
-		endpoint = server + "/v1/tasks/" + name + "/logs"
-	} else {
-		endpoint = server + "/v1/agents/" + name + "/logs"
-	}
-	if name == "" {
-		return errors.New("logs target name is required")
+	follow, _ := cmd.Flags().GetBool("follow")
+	interval, _ := cmd.Flags().GetDuration("follow-interval")
+	if interval <= 0 {
+		return errors.New("--follow-interval must be > 0")
 	}
 
-	resp, err := http.Get(endpoint)
+	_, endpoint, err := logsEndpoint(server, args[0])
 	if err != nil {
-		return fmt.Errorf("logs request failed: %w", err)
+		return err
+	}
+	fetch := func(ctx context.Context) ([]string, error) {
+		return fetchLogs(ctx, endpoint)
+	}
+
+	if !follow {
+		logs, err := fetch(cmd.Context())
+		if err != nil {
+			return err
+		}
+		for _, line := range logs {
+			fmt.Println(line)
+		}
+		return nil
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt)
+	defer stop()
+	return streamLogs(ctx, os.Stdout, fetch, interval)
+}
+
+// logsEndpoint resolves a "task/<name>" or "<agent-name>" logs target into
+// the resource name and the server endpoint that returns its logs.
+func logsEndpoint(server, target string) (name, endpoint string, err error) {
+	name = target
+	if strings.HasPrefix(strings.ToLower(target), "task/") {
+		name = strings.TrimSpace(target[len("task/"):])
+		endpoint = strings.TrimRight(server, "/") + "/v1/tasks/" + name + "/logs"
+	} else {
+		endpoint = strings.TrimRight(server, "/") + "/v1/agents/" + name + "/logs"
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", "", errors.New("logs target name is required")
+	}
+	return name, endpoint, nil
+}
+
+func fetchLogs(ctx context.Context, endpoint string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("logs request build failed: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("logs request failed: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("logs failed: %s", bytes.TrimSpace(body))
+		return nil, fmt.Errorf("logs failed: %s", bytes.TrimSpace(body))
 	}
 
 	var payload struct {
@@ -1034,13 +1076,41 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		Logs []string `json:"logs"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return fmt.Errorf("failed to decode logs response: %w", err)
+		return nil, fmt.Errorf("failed to decode logs response: %w", err)
 	}
+	return payload.Logs, nil
+}
 
-	for _, line := range payload.Logs {
-		fmt.Println(line)
+// streamLogs polls fetch on interval, printing only newly-appeared lines,
+// until ctx is cancelled (e.g. by Ctrl+C via signal.NotifyContext).
+//
+// This is polling, not a server push: AppendLog does not publish to the
+// event bus, so there's no existing live signal to subscribe to without a
+// backend change. Latency is bounded by interval, not instant.
+func streamLogs(ctx context.Context, out io.Writer, fetch func(context.Context) ([]string, error), interval time.Duration) error {
+	printed := 0
+	for {
+		logs, err := fetch(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		if printed > len(logs) {
+			printed = 0
+		}
+		for _, line := range logs[printed:] {
+			fmt.Fprintln(out, line)
+		}
+		printed = len(logs)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(interval):
+		}
 	}
-	return nil
 }
 
 // --- trace ---

--- a/cli/orlojctl.go
+++ b/cli/orlojctl.go
@@ -1087,8 +1087,17 @@ func fetchLogs(ctx context.Context, endpoint string) ([]string, error) {
 // This is polling, not a server push: AppendLog does not publish to the
 // event bus, so there's no existing live signal to subscribe to without a
 // backend change. Latency is bounded by interval, not instant.
+//
+// Resume position is tracked by the content of the last printed line, not
+// an index: both agent logs (runtime/agent_worker.go recordLog, last 200)
+// and in-memory task logs (store/resource_stores.go AppendLog, last 500)
+// are ring buffers that trim from the front, so the slice length alone
+// isn't a reliable cursor once it fills up. If the last-seen line has
+// rotated out entirely, everything currently returned is printed instead
+// of nothing.
 func streamLogs(ctx context.Context, out io.Writer, fetch func(context.Context) ([]string, error), interval time.Duration) error {
-	printed := 0
+	var lastPrinted string
+	haveLast := false
 	for {
 		logs, err := fetch(ctx)
 		if err != nil {
@@ -1097,13 +1106,20 @@ func streamLogs(ctx context.Context, out io.Writer, fetch func(context.Context) 
 			}
 			return err
 		}
-		if printed > len(logs) {
-			printed = 0
+
+		start := 0
+		if haveLast {
+			if idx := lastIndexOf(logs, lastPrinted); idx >= 0 {
+				start = idx + 1
+			}
 		}
-		for _, line := range logs[printed:] {
+		for _, line := range logs[start:] {
 			fmt.Fprintln(out, line)
 		}
-		printed = len(logs)
+		if len(logs) > 0 {
+			lastPrinted = logs[len(logs)-1]
+			haveLast = true
+		}
 
 		select {
 		case <-ctx.Done():
@@ -1111,6 +1127,18 @@ func streamLogs(ctx context.Context, out io.Writer, fetch func(context.Context) 
 		case <-time.After(interval):
 		}
 	}
+}
+
+// lastIndexOf returns the index of the last occurrence of target in logs,
+// or -1 if not found. Searches from the end since the resume point is
+// always the most recently printed line.
+func lastIndexOf(logs []string, target string) int {
+	for i := len(logs) - 1; i >= 0; i-- {
+		if logs[i] == target {
+			return i
+		}
+	}
+	return -1
 }
 
 // --- trace ---

--- a/cli/orlojctl_logs_test.go
+++ b/cli/orlojctl_logs_test.go
@@ -130,6 +130,73 @@ func TestStreamLogsFollowsNewLines(t *testing.T) {
 	}
 }
 
+// TestStreamLogsFollowsRotatedBuffer verifies --follow keeps up when the
+// backing log store is a fixed-size ring buffer (agent logs cap at 200,
+// in-memory task logs cap at 500) that drops the oldest line as new ones
+// are appended, so len(logs) alone can't be used as a resume cursor.
+func TestStreamLogsFollowsRotatedBuffer(t *testing.T) {
+	const maxLen = 3
+	var calls int32
+	responses := [][]string{
+		{"a", "b", "c"}, // buffer full
+		{"b", "c", "d"}, // "a" rotated out, "d" appended
+		{"c", "d", "e"}, // "b" rotated out, "e" appended
+		{"c", "d", "e"}, // no change
+	}
+	fetch := func(ctx context.Context) ([]string, error) {
+		n := atomic.AddInt32(&calls, 1) - 1
+		if int(n) >= len(responses) {
+			n = int32(len(responses) - 1)
+		}
+		got := responses[n]
+		if len(got) > maxLen {
+			t.Fatalf("test fixture response exceeds ring buffer size: %v", got)
+		}
+		return got, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- streamLogs(ctx, &out, fetch, time.Millisecond)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if atomic.LoadInt32(&calls) >= int32(len(responses)) {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for streamLogs to poll enough times")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("streamLogs returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamLogs did not return after context cancellation")
+	}
+
+	printed := strings.TrimSpace(out.String())
+	lines := strings.Split(printed, "\n")
+	want := []string{"a", "b", "c", "d", "e"}
+	if len(lines) != len(want) {
+		t.Fatalf("expected %d printed lines (no gaps, no duplicates), got %d: %v", len(want), len(lines), lines)
+	}
+	for i, line := range want {
+		if lines[i] != line {
+			t.Fatalf("expected line %d to be %q, got %q", i, line, lines[i])
+		}
+	}
+}
+
 // TestStreamLogsPropagatesFetchError ensures a real fetch failure (not a
 // context cancellation) is still surfaced to the caller.
 func TestStreamLogsPropagatesFetchError(t *testing.T) {

--- a/cli/orlojctl_logs_test.go
+++ b/cli/orlojctl_logs_test.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestLogsEndpoint(t *testing.T) {
+	name, endpoint, err := logsEndpoint("http://127.0.0.1:8080/", "task/weekly-report")
+	if err != nil {
+		t.Fatalf("logsEndpoint returned error: %v", err)
+	}
+	if name != "weekly-report" {
+		t.Fatalf("unexpected name: %q", name)
+	}
+	if endpoint != "http://127.0.0.1:8080/v1/tasks/weekly-report/logs" {
+		t.Fatalf("unexpected task endpoint: %q", endpoint)
+	}
+
+	name, endpoint, err = logsEndpoint("http://127.0.0.1:8080", "my-agent")
+	if err != nil {
+		t.Fatalf("logsEndpoint returned error: %v", err)
+	}
+	if name != "my-agent" {
+		t.Fatalf("unexpected name: %q", name)
+	}
+	if endpoint != "http://127.0.0.1:8080/v1/agents/my-agent/logs" {
+		t.Fatalf("unexpected agent endpoint: %q", endpoint)
+	}
+
+	if _, _, err := logsEndpoint("http://127.0.0.1:8080", "task/"); err == nil {
+		t.Fatal("expected error for empty task name")
+	}
+}
+
+func TestFetchLogs(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "weekly-report",
+			"logs": []string{"line1", "line2"},
+		})
+	}))
+	defer ts.Close()
+
+	logs, err := fetchLogs(context.Background(), ts.URL+"/v1/tasks/weekly-report/logs")
+	if err != nil {
+		t.Fatalf("fetchLogs returned error: %v", err)
+	}
+	if len(logs) != 2 || logs[0] != "line1" || logs[1] != "line2" {
+		t.Fatalf("unexpected logs: %v", logs)
+	}
+}
+
+func TestFetchLogsErrorStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "task not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	if _, err := fetchLogs(context.Background(), ts.URL+"/v1/tasks/missing/logs"); err == nil {
+		t.Fatal("expected error for non-2xx response")
+	}
+}
+
+// TestStreamLogsFollowsNewLines verifies --follow prints only newly-appeared
+// lines on each poll, and stops cleanly once the context is cancelled
+// (mirroring what happens on Ctrl+C via signal.NotifyContext).
+func TestStreamLogsFollowsNewLines(t *testing.T) {
+	var calls int32
+	responses := [][]string{
+		{"tick 1"},
+		{"tick 1", "tick 2"},
+		{"tick 1", "tick 2", "tick 3"},
+	}
+	fetch := func(ctx context.Context) ([]string, error) {
+		n := atomic.AddInt32(&calls, 1) - 1
+		if int(n) >= len(responses) {
+			n = int32(len(responses) - 1)
+		}
+		return responses[n], nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- streamLogs(ctx, &out, fetch, time.Millisecond)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if atomic.LoadInt32(&calls) >= int32(len(responses)) {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for streamLogs to poll enough times")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("streamLogs returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamLogs did not return after context cancellation")
+	}
+
+	printed := strings.TrimSpace(out.String())
+	lines := strings.Split(printed, "\n")
+	want := []string{"tick 1", "tick 2", "tick 3"}
+	if len(lines) != len(want) {
+		t.Fatalf("expected %d printed lines, got %d: %v", len(want), len(lines), lines)
+	}
+	for i, line := range want {
+		if lines[i] != line {
+			t.Fatalf("expected line %d to be %q, got %q", i, line, lines[i])
+		}
+	}
+}
+
+// TestStreamLogsPropagatesFetchError ensures a real fetch failure (not a
+// context cancellation) is still surfaced to the caller.
+func TestStreamLogsPropagatesFetchError(t *testing.T) {
+	fetchErr := errors.New("boom")
+	fetch := func(ctx context.Context) ([]string, error) {
+		return nil, fetchErr
+	}
+	var out bytes.Buffer
+	err := streamLogs(context.Background(), &out, fetch, time.Millisecond)
+	if !errors.Is(err, fetchErr) {
+		t.Fatalf("expected fetch error to propagate, got %v", err)
+	}
+}


### PR DESCRIPTION
closes #65

## summary
- adds `--follow` / `-f` to `orlojctl logs`, works for both `task/<name>` and `<agent-name>` targets
- polls the existing `/v1/tasks/{name}/logs` and `/v1/agents/{name}/logs` endpoints on an interval (`--follow-interval`, default 2s) and prints only newly-appeared lines
- exits cleanly on ctrl+c

## how it streams (worth flagging)
this is polling, not a server push. `appendlog` (where task/agent log lines get written) doesn't publish anything to the existing event bus, so there's no live signal to subscribe to today. a real push-based version would mean publishing an event on every `appendlog` call and extending `/v1/tasks/watch` or `/v1/events/watch` (or a new endpoint) to carry raw log lines — bigger, touches the event bus and the nats-backed setup, and could get messy fast. the issue says "scope and constraints: cli only", so i kept this to a cli-side polling loop reusing what already exists. happy to look into the push-based version separately if that's actually wanted — wasn't sure if it's in scope here.

## testing
- unit tests for the polling/diffing loop and endpoint resolution (`cli/orlojctl_logs_test.go`)
- tested live against a local k3s cluster: applied a long-running task, followed it with `--follow`, confirmed lines appear as they're written and ctrl+c exits cleanly

## acceptance criteria
- [x] streams log output in real time (polling-based, see note above)
- [x] ctrl+c cleanly terminates the stream
- [x] works for task logs and agent logs
- [x] tests added