### PR TITLE
Preserve Orloj runtime and OpenAI gateway fixes

### DIFF
--- a/controllers/mcp_server_controller.go
+++ b/controllers/mcp_server_controller.go
@@ -118,22 +118,24 @@ func (c *McpServerController) reconcileByName(ctx context.Context, name string) 
 		server.Status.Phase = "Ready"
 		server.Status.LastError = ""
 		server.Status.ObservedGeneration = server.Metadata.Generation
-		_, err = c.store.Upsert(ctx, server)
+		_, err = c.store.UpdateStatus(ctx, name, server.Status)
 		return err
 	}
 
 	server.Status.Phase = "Connecting"
 	server.Status.LastError = ""
-	if updated, err := c.store.Upsert(ctx, server); err == nil {
+	if updated, err := c.store.UpdateStatus(ctx, name, server.Status); err == nil {
 		server = updated
+	} else {
+		return err
 	}
 
 	session, err := c.sessionManager.GetOrCreate(ctx, server)
 	if err != nil {
 		server.Status.Phase = "Error"
 		server.Status.LastError = err.Error()
-		if updated, uErr := c.store.Upsert(ctx, server); uErr == nil {
-			server = updated
+		if _, uErr := c.store.UpdateStatus(ctx, name, server.Status); uErr != nil {
+			return fmt.Errorf("connect to mcp server %s: %w; additionally failed to update status: %v", name, err, uErr)
 		}
 		return fmt.Errorf("connect to mcp server %s: %w", name, err)
 	}
@@ -142,8 +144,8 @@ func (c *McpServerController) reconcileByName(ctx context.Context, name string) 
 	if err != nil {
 		server.Status.Phase = "Error"
 		server.Status.LastError = fmt.Sprintf("tools/list: %s", err.Error())
-		if updated, uErr := c.store.Upsert(ctx, server); uErr == nil {
-			server = updated
+		if _, uErr := c.store.UpdateStatus(ctx, name, server.Status); uErr != nil {
+			return fmt.Errorf("list tools from mcp server %s: %w; additionally failed to update status: %v", name, err, uErr)
 		}
 		return fmt.Errorf("list tools from mcp server %s: %w", name, err)
 	}
@@ -158,8 +160,8 @@ func (c *McpServerController) reconcileByName(ctx context.Context, name string) 
 	if err != nil {
 		server.Status.Phase = "Error"
 		server.Status.LastError = fmt.Sprintf("sync tools: %s", err.Error())
-		if updated, uErr := c.store.Upsert(ctx, server); uErr == nil {
-			server = updated
+		if _, uErr := c.store.UpdateStatus(ctx, name, server.Status); uErr != nil {
+			return fmt.Errorf("%w; additionally failed to update status: %v", err, uErr)
 		}
 		return err
 	}
@@ -172,7 +174,7 @@ func (c *McpServerController) reconcileByName(ctx context.Context, name string) 
 	server.Status.GeneratedTools = generatedNames
 	server.Status.LastSyncedAt = time.Now().UTC().Format(time.RFC3339)
 	server.Status.ObservedGeneration = server.Metadata.Generation
-	_, err = c.store.Upsert(ctx, server)
+	_, err = c.store.UpdateStatus(ctx, name, server.Status)
 	return err
 }
 

--- a/controllers/mcp_server_controller_test.go
+++ b/controllers/mcp_server_controller_test.go
@@ -1,0 +1,67 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/OrlojHQ/orloj/resources"
+	"github.com/OrlojHQ/orloj/store"
+)
+
+func TestMcpServerControllerStatusReconcileDoesNotBumpGeneration(t *testing.T) {
+	ctx := context.Background()
+	mcpStore := store.NewMcpServerStore()
+	toolStore := store.NewToolStore()
+
+	created, err := mcpStore.Upsert(ctx, resources.McpServer{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "McpServer",
+		Metadata:   resources.ObjectMeta{Name: "context7"},
+		Spec: resources.McpServerSpec{
+			Transport: "stdio",
+			Command:   "npx",
+			Args:      []string{"@upstash/context7-mcp"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create mcp server failed: %v", err)
+	}
+
+	controller := NewMcpServerController(mcpStore, toolStore, nil, time.Second)
+	if err := controller.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	updated, ok, err := mcpStore.Get(ctx, "context7")
+	if err != nil {
+		t.Fatalf("get mcp server failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected mcp server to exist")
+	}
+	if updated.Metadata.Generation != created.Metadata.Generation {
+		t.Fatalf("reconcile bumped generation: before=%d after=%d", created.Metadata.Generation, updated.Metadata.Generation)
+	}
+	if updated.Status.Phase != "Ready" {
+		t.Fatalf("expected Ready phase, got %q", updated.Status.Phase)
+	}
+	if updated.Status.ObservedGeneration != created.Metadata.Generation {
+		t.Fatalf("expected observed generation=%d, got %d", created.Metadata.Generation, updated.Status.ObservedGeneration)
+	}
+
+	rvAfterFirstReconcile := updated.Metadata.ResourceVersion
+	if err := controller.ReconcileOnce(ctx); err != nil {
+		t.Fatalf("second reconcile failed: %v", err)
+	}
+	unchanged, ok, err := mcpStore.Get(ctx, "context7")
+	if err != nil {
+		t.Fatalf("get mcp server after second reconcile failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected mcp server to exist after second reconcile")
+	}
+	if unchanged.Metadata.ResourceVersion != rvAfterFirstReconcile {
+		t.Fatalf("ready/observed reconcile should be a no-op: before rv=%q after rv=%q", rvAfterFirstReconcile, unchanged.Metadata.ResourceVersion)
+	}
+}

--- a/runtime/mcp_integration_test.go
+++ b/runtime/mcp_integration_test.go
@@ -742,6 +742,15 @@ func TestMcpServerNormalizeMountPath(t *testing.T) {
 	})
 }
 
+func argValueAfter(args []string, flag string) string {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
 func TestBuildContainerStdioTransport(t *testing.T) {
 	mgr := NewMcpSessionManager(nil)
 	mgr.SetContainerConfig(ContainerToolRuntimeConfig{
@@ -836,15 +845,28 @@ func TestBuildContainerStdioTransport(t *testing.T) {
 			t.Fatalf("build failed: %v", err)
 		}
 		stdio := transport.(*StdioMcpTransport)
-		envCount := 0
+		envFile := argValueAfter(stdio.args, "--env-file")
+		if envFile == "" {
+			t.Fatalf("expected --env-file in args: %v", stdio.args)
+		}
 		for _, arg := range stdio.args {
 			if arg == "FOO=bar" || arg == "BAZ=qux" {
-				envCount++
+				t.Fatalf("env var leaked into docker args: %v", stdio.args)
 			}
 		}
-		if envCount != 2 {
-			t.Errorf("expected 2 env vars in args, found %d: %v", envCount, stdio.args)
+		envBytes, err := os.ReadFile(envFile)
+		if err != nil {
+			t.Fatalf("read env file: %v", err)
 		}
+		for _, expected := range []string{"FOO=bar", "BAZ=qux"} {
+			if !strings.Contains(string(envBytes), expected+"\n") {
+				t.Fatalf("expected %q in env file, got %q", expected, string(envBytes))
+			}
+		}
+		if cidFile := argValueAfter(stdio.args, "--cidfile"); cidFile == "" {
+			t.Fatalf("expected --cidfile in args: %v", stdio.args)
+		}
+		stdio.onClose()
 	})
 
 	t.Run("container_config_applied", func(t *testing.T) {
@@ -911,14 +933,21 @@ func TestBuildContainerStdioTransport(t *testing.T) {
 			t.Errorf("expected --mount with bind,target=/secrets/creds.json,readonly in args: %v", stdio.args)
 		}
 
-		hasEnv := false
+		envFile := argValueAfter(stdio.args, "--env-file")
+		if envFile == "" {
+			t.Fatalf("expected --env-file in args: %v", stdio.args)
+		}
 		for _, arg := range stdio.args {
 			if arg == "CREDS_PATH=/secrets/creds.json" {
-				hasEnv = true
+				t.Fatalf("env var leaked into docker args: %v", stdio.args)
 			}
 		}
-		if !hasEnv {
-			t.Errorf("expected env var CREDS_PATH=/secrets/creds.json in args: %v", stdio.args)
+		envBytes, err := os.ReadFile(envFile)
+		if err != nil {
+			t.Fatalf("read env file: %v", err)
+		}
+		if !strings.Contains(string(envBytes), "CREDS_PATH=/secrets/creds.json\n") {
+			t.Fatalf("expected CREDS_PATH in env file, got %q", string(envBytes))
 		}
 
 		if stdio.onClose == nil {
@@ -974,10 +1003,22 @@ func TestBuildContainerStdioTransport(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read temp dir: %v", err)
 		}
-		if len(files) != 1 {
-			t.Fatalf("expected 1 file in temp dir, got %d", len(files))
+		var secretFile string
+		for _, file := range files {
+			if strings.HasPrefix(file.Name(), "mount_") {
+				secretFile = file.Name()
+			}
 		}
-		content, err := os.ReadFile(filepath.Join(tmpDir, files[0].Name()))
+		if secretFile == "" {
+			t.Fatalf("expected secret mount file in temp dir, got %v", files)
+		}
+		if argValueAfter(stdio.args, "--env-file") == "" {
+			t.Fatalf("expected --env-file in args: %v", stdio.args)
+		}
+		if argValueAfter(stdio.args, "--cidfile") == "" {
+			t.Fatalf("expected --cidfile in args: %v", stdio.args)
+		}
+		content, err := os.ReadFile(filepath.Join(tmpDir, secretFile))
 		if err != nil {
 			t.Fatalf("read secret file: %v", err)
 		}

--- a/runtime/mcp_session.go
+++ b/runtime/mcp_session.go
@@ -302,17 +302,47 @@ func (m *McpSessionManager) buildContainerStdioTransport(server resources.McpSer
 	}
 
 	var cleanupDir string
-	if len(resolved.Mounts) > 0 {
+	ensureCleanupDir := func() (string, error) {
+		if cleanupDir != "" {
+			return cleanupDir, nil
+		}
 		tmpDir, err := os.MkdirTemp("", "orloj-mcp-*")
 		if err != nil {
-			return nil, fmt.Errorf("create temp dir for secret mounts: %w", err)
+			return "", fmt.Errorf("create temp dir for mcp container metadata: %w", err)
 		}
 		cleanupDir = tmpDir
+		return cleanupDir, nil
+	}
+	cleanupBuildArtifacts := func() {
+		if cleanupDir != "" {
+			_ = os.RemoveAll(cleanupDir)
+		}
+		if creds != nil {
+			creds.Cleanup()
+		}
+	}
+
+	metadataDir, err := ensureCleanupDir()
+	if err != nil {
+		if creds != nil {
+			creds.Cleanup()
+		}
+		return nil, err
+	}
+	cidFile := filepath.Join(metadataDir, "container.cid")
+	dockerArgs = append(dockerArgs, "--cidfile", cidFile)
+
+	if len(resolved.Mounts) > 0 {
+		tmpDir, err := ensureCleanupDir()
+		if err != nil {
+			cleanupBuildArtifacts()
+			return nil, fmt.Errorf("create temp dir for secret mounts: %w", err)
+		}
 
 		for i, mount := range resolved.Mounts {
 			hostFile := filepath.Join(tmpDir, fmt.Sprintf("mount_%d", i))
 			if err := os.WriteFile(hostFile, []byte(mount.Content), 0600); err != nil {
-				_ = os.RemoveAll(tmpDir)
+				cleanupBuildArtifacts()
 				return nil, fmt.Errorf("write secret mount %q: %w", mount.ContainerPath, err)
 			}
 			dockerArgs = append(dockerArgs,
@@ -321,8 +351,18 @@ func (m *McpSessionManager) buildContainerStdioTransport(server resources.McpSer
 		}
 	}
 
-	for _, e := range resolved.EnvVars {
-		dockerArgs = append(dockerArgs, "-e", e)
+	if len(resolved.EnvVars) > 0 {
+		envDir, err := ensureCleanupDir()
+		if err != nil {
+			cleanupBuildArtifacts()
+			return nil, fmt.Errorf("create temp dir for env file: %w", err)
+		}
+		envFile := filepath.Join(envDir, "container.env")
+		if err := os.WriteFile(envFile, []byte(strings.Join(resolved.EnvVars, "\n")+"\n"), 0600); err != nil {
+			cleanupBuildArtifacts()
+			return nil, fmt.Errorf("write mcp env file: %w", err)
+		}
+		dockerArgs = append(dockerArgs, "--env-file", envFile)
 	}
 
 	if command != "" {
@@ -333,6 +373,11 @@ func (m *McpSessionManager) buildContainerStdioTransport(server resources.McpSer
 	dockerArgs = append(dockerArgs, server.Spec.Args...)
 
 	onClose := func() {
+		if cidBytes, err := os.ReadFile(cidFile); err == nil {
+			if cid := strings.TrimSpace(string(cidBytes)); cid != "" {
+				_ = exec.Command(runtimeBinary, "rm", "-f", cid).Run()
+			}
+		}
 		if cleanupDir != "" {
 			_ = os.RemoveAll(cleanupDir)
 		}

--- a/runtime/mcp_session.go
+++ b/runtime/mcp_session.go
@@ -525,9 +525,17 @@ func (m *McpSessionManager) buildHTTPTransport(ctx context.Context, server resou
 	if server.Spec.AllowPrivate != nil {
 		allowPrivate = *server.Spec.AllowPrivate
 	}
+	httpTimeout := 60 * time.Second
+	if server.Spec.DefaultToolRuntime != nil {
+		timeoutRaw := strings.TrimSpace(server.Spec.DefaultToolRuntime.Timeout)
+		if parsed, err := time.ParseDuration(timeoutRaw); err == nil && parsed > httpTimeout {
+			httpTimeout = parsed
+		}
+	}
 	return NewStreamableHTTPMcpTransport(StreamableHTTPMcpTransportConfig{
 		Endpoint:     server.Spec.Endpoint,
 		Headers:      headers,
+		Timeout:      httpTimeout,
 		AllowPrivate: allowPrivate,
 	}), nil
 }

--- a/runtime/mcp_session_container_test.go
+++ b/runtime/mcp_session_container_test.go
@@ -1,0 +1,106 @@
+package agentruntime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/OrlojHQ/orloj/resources"
+)
+
+func TestBuildContainerStdioTransportUsesEnvFileAndCidFile(t *testing.T) {
+	manager := NewMcpSessionManager(nil)
+	transport, err := manager.buildContainerStdioTransport(
+		resources.McpServer{
+			Metadata: resources.ObjectMeta{Name: "codex-github-official"},
+			Spec: resources.McpServerSpec{
+				Image:   "agentflow-github-mcp-server:test",
+				Command: "server",
+				Args:    []string{"stdio"},
+			},
+		},
+		"server",
+		&resolvedMcpEnv{EnvVars: []string{"GITHUB_PERSONAL_ACCESS_TOKEN=secret-token", "GITHUB_READ_ONLY=1"}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("build container transport: %v", err)
+	}
+	stdio, ok := transport.(*StdioMcpTransport)
+	if !ok {
+		t.Fatalf("expected *StdioMcpTransport, got %T", transport)
+	}
+
+	args := strings.Join(stdio.args, " ")
+	if strings.Contains(args, "secret-token") {
+		t.Fatalf("docker args leaked secret: %s", args)
+	}
+	if mcpSessionContainsArg(stdio.args, "-e") {
+		t.Fatalf("docker args should use --env-file, got %v", stdio.args)
+	}
+
+	envFile := argAfter(stdio.args, "--env-file")
+	if envFile == "" {
+		t.Fatalf("expected --env-file in docker args: %v", stdio.args)
+	}
+	cidFile := argAfter(stdio.args, "--cidfile")
+	if cidFile == "" {
+		t.Fatalf("expected --cidfile in docker args: %v", stdio.args)
+	}
+	if filepath.Dir(envFile) != filepath.Dir(cidFile) {
+		t.Fatalf("expected env and cid files in same cleanup dir, got %q and %q", envFile, cidFile)
+	}
+
+	content, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	if got := string(content); !strings.Contains(got, "GITHUB_PERSONAL_ACCESS_TOKEN=secret-token\n") || !strings.Contains(got, "GITHUB_READ_ONLY=1\n") {
+		t.Fatalf("env file missing expected values: %q", got)
+	}
+
+	cleanupDir := filepath.Dir(envFile)
+	if err := stdio.Close(); err != nil {
+		t.Fatalf("close transport: %v", err)
+	}
+	if _, err := os.Stat(cleanupDir); !os.IsNotExist(err) {
+		t.Fatalf("expected cleanup dir removed, stat err=%v", err)
+	}
+}
+
+func TestStdioTransportCleanupRunsOnceAfterStartFailureAndClose(t *testing.T) {
+	called := 0
+	transport := NewStdioMcpTransport(StdioMcpTransportConfig{
+		Command: "definitely-not-a-real-mcp-command",
+		OnClose: func() { called++ },
+	})
+	if _, err := transport.Initialize(context.Background()); err == nil {
+		t.Fatal("expected initialize failure")
+	}
+	if err := transport.Close(); err != nil {
+		t.Fatalf("close transport: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("expected cleanup once, got %d", called)
+	}
+}
+
+func argAfter(args []string, key string) string {
+	for i, arg := range args {
+		if arg == key && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func mcpSessionContainsArg(args []string, key string) bool {
+	for _, arg := range args {
+		if arg == key {
+			return true
+		}
+	}
+	return false
+}

--- a/runtime/mcp_transport_http.go
+++ b/runtime/mcp_transport_http.go
@@ -29,13 +29,18 @@ type StreamableHTTPMcpTransportConfig struct {
 	Endpoint     string
 	Headers      map[string]string
 	Client       HTTPDoer
+	Timeout      time.Duration
 	AllowPrivate bool // permit connections to private/internal IPs
 }
 
 func NewStreamableHTTPMcpTransport(cfg StreamableHTTPMcpTransportConfig) *StreamableHTTPMcpTransport {
 	client := cfg.Client
 	if client == nil {
-		client = SafeHTTPClient(cfg.AllowPrivate, 60*time.Second)
+		timeout := cfg.Timeout
+		if timeout <= 0 {
+			timeout = 60 * time.Second
+		}
+		client = SafeHTTPClient(cfg.AllowPrivate, timeout)
 	}
 	return &StreamableHTTPMcpTransport{
 		endpoint:     strings.TrimRight(cfg.Endpoint, "/"),

--- a/runtime/mcp_transport_stdio.go
+++ b/runtime/mcp_transport_stdio.go
@@ -19,11 +19,12 @@ type StdioMcpTransport struct {
 	env     []string
 	onClose func()
 
-	mu      sync.Mutex
-	cmd     *exec.Cmd
-	stdin   io.WriteCloser
-	scanner *bufio.Scanner
-	ctx     context.Context
+	mu        sync.Mutex
+	cmd       *exec.Cmd
+	stdin     io.WriteCloser
+	scanner   *bufio.Scanner
+	ctx       context.Context
+	closeOnce sync.Once
 
 	pending   map[int64]chan jsonrpcResponse
 	pendingMu sync.Mutex
@@ -51,6 +52,7 @@ func NewStdioMcpTransport(cfg StdioMcpTransportConfig) *StdioMcpTransport {
 
 func (t *StdioMcpTransport) Initialize(ctx context.Context) (*McpInitResult, error) {
 	if err := t.startProcess(ctx); err != nil {
+		t.runOnClose()
 		return nil, fmt.Errorf("mcp stdio: failed to start process: %w", err)
 	}
 
@@ -130,10 +132,14 @@ func (t *StdioMcpTransport) Close() error {
 	default:
 		close(t.done)
 	}
-	if t.onClose != nil {
-		t.onClose()
-	}
+	t.runOnClose()
 	return nil
+}
+
+func (t *StdioMcpTransport) runOnClose() {
+	if t.onClose != nil {
+		t.closeOnce.Do(t.onClose)
+	}
 }
 
 func (t *StdioMcpTransport) startProcess(ctx context.Context) error {

--- a/runtime/model_gateway_factory.go
+++ b/runtime/model_gateway_factory.go
@@ -51,6 +51,12 @@ func newModelGatewayFromConfigWithRegistry(cfg ModelGatewayConfig, registry *Mod
 	if registry == nil {
 		return nil, fmt.Errorf("%w: model provider registry is not configured", ErrModelGatewayConfiguration)
 	}
+	if timeout, ok, err := modelGatewayTimeoutFromOptions(cfg.Options); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrModelGatewayConfiguration, err)
+	} else if ok {
+		cfg.Timeout = timeout
+	}
+
 	plugin, ok := registry.Lookup(provider)
 	if !ok {
 		return nil, fmt.Errorf("%w: unsupported provider %q", ErrModelGatewayConfiguration, cfg.Provider)
@@ -318,4 +324,17 @@ func normalizeModelProviderOptions(options map[string]string) map[string]string 
 		out[k] = strings.TrimSpace(value)
 	}
 	return out
+}
+
+func modelGatewayTimeoutFromOptions(options map[string]string) (time.Duration, bool, error) {
+	normalized := normalizeModelProviderOptions(options)
+	value := strings.TrimSpace(normalized["timeout"])
+	if value == "" {
+		return 0, false, nil
+	}
+	timeout, err := time.ParseDuration(value)
+	if err != nil || timeout <= 0 {
+		return 0, false, fmt.Errorf("invalid model endpoint timeout %q", value)
+	}
+	return timeout, true, nil
 }

--- a/runtime/model_gateway_factory.go
+++ b/runtime/model_gateway_factory.go
@@ -100,6 +100,10 @@ func (p *openAIModelProviderPlugin) BuildGateway(cfg ModelGatewayConfig) (ModelG
 	if strings.TrimSpace(cfg.DefaultModel) != "" {
 		openaiCfg.DefaultModel = strings.TrimSpace(cfg.DefaultModel)
 	}
+	options := normalizeModelProviderOptions(cfg.Options)
+	if value, ok := modelProviderOption(options, "reasoning_effort", "reasoning.effort"); ok {
+		openaiCfg.ReasoningEffort = strings.ToLower(strings.TrimSpace(value))
+	}
 	if cfg.Timeout > 0 {
 		openaiCfg.Timeout = cfg.Timeout
 	}
@@ -128,6 +132,10 @@ func (p *openAICompatibleModelProviderPlugin) BuildGateway(cfg ModelGatewayConfi
 	}
 	if strings.TrimSpace(cfg.DefaultModel) != "" {
 		openaiCfg.DefaultModel = strings.TrimSpace(cfg.DefaultModel)
+	}
+	options := normalizeModelProviderOptions(cfg.Options)
+	if value, ok := modelProviderOption(options, "reasoning_effort", "reasoning.effort"); ok {
+		openaiCfg.ReasoningEffort = strings.ToLower(strings.TrimSpace(value))
 	}
 	if cfg.Timeout > 0 {
 		openaiCfg.Timeout = cfg.Timeout
@@ -309,6 +317,15 @@ func resolveGatewayHTTPClient(cfg ModelGatewayConfig) *http.Client {
 		return cfg.HTTPClient
 	}
 	return SafeModelGatewayHTTPClient(cfg.AllowPrivate, cfg.Timeout)
+}
+
+func modelProviderOption(options map[string]string, keys ...string) (string, bool) {
+	for _, key := range keys {
+		if value, ok := options[key]; ok && strings.TrimSpace(value) != "" {
+			return value, true
+		}
+	}
+	return "", false
 }
 
 func normalizeModelProviderOptions(options map[string]string) map[string]string {

--- a/runtime/model_gateway_factory_test.go
+++ b/runtime/model_gateway_factory_test.go
@@ -46,6 +46,26 @@ func TestNewModelGatewayFromConfigOpenAICompatibleUnderscoreAlias(t *testing.T) 
 	}
 }
 
+func TestNewModelGatewayFromConfigOpenAICompatibleReasoningEffortOption(t *testing.T) {
+	gateway, err := NewModelGatewayFromConfig(ModelGatewayConfig{
+		Provider: "openai-compatible",
+		BaseURL:  "https://example.invalid/v1",
+		Options: map[string]string{
+			"reasoning_effort": "XHIGH",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected openai-compatible gateway config to succeed, got %v", err)
+	}
+	openaiGateway, ok := gateway.(*OpenAIModelGateway)
+	if !ok {
+		t.Fatalf("expected *OpenAIModelGateway, got %T", gateway)
+	}
+	if openaiGateway.reasoningEffort != "xhigh" {
+		t.Fatalf("expected reasoning effort xhigh, got %q", openaiGateway.reasoningEffort)
+	}
+}
+
 func TestNewModelGatewayFromConfigAnthropicMissingKey(t *testing.T) {
 	_, err := NewModelGatewayFromConfig(ModelGatewayConfig{Provider: "anthropic"})
 	if err == nil {

--- a/runtime/model_gateway_openai.go
+++ b/runtime/model_gateway_openai.go
@@ -14,12 +14,13 @@ import (
 
 // OpenAIModelGatewayConfig defines OpenAI-compatible model gateway settings.
 type OpenAIModelGatewayConfig struct {
-	APIKey        string
-	RequireAPIKey bool
-	BaseURL       string
-	DefaultModel  string
-	Timeout       time.Duration
-	HTTPClient    *http.Client
+	APIKey          string
+	RequireAPIKey   bool
+	BaseURL         string
+	DefaultModel    string
+	ReasoningEffort string
+	Timeout         time.Duration
+	HTTPClient      *http.Client
 }
 
 // DefaultOpenAIModelGatewayConfig returns OpenAI gateway defaults.
@@ -33,10 +34,11 @@ func DefaultOpenAIModelGatewayConfig() OpenAIModelGatewayConfig {
 
 // OpenAIModelGateway calls an OpenAI-compatible Chat Completions endpoint.
 type OpenAIModelGateway struct {
-	apiKey       string
-	baseURL      string
-	defaultModel string
-	client       *http.Client
+	apiKey          string
+	baseURL         string
+	defaultModel    string
+	reasoningEffort string
+	client          *http.Client
 }
 
 func NewOpenAIModelGateway(cfg OpenAIModelGatewayConfig) (*OpenAIModelGateway, error) {
@@ -51,10 +53,11 @@ func NewOpenAIModelGateway(cfg OpenAIModelGatewayConfig) (*OpenAIModelGateway, e
 		return nil, fmt.Errorf("openai HTTP client is required")
 	}
 	return &OpenAIModelGateway{
-		apiKey:       strings.TrimSpace(normalized.APIKey),
-		baseURL:      strings.TrimRight(strings.TrimSpace(normalized.BaseURL), "/"),
-		defaultModel: strings.TrimSpace(normalized.DefaultModel),
-		client:       normalized.client(),
+		apiKey:          strings.TrimSpace(normalized.APIKey),
+		baseURL:         strings.TrimRight(strings.TrimSpace(normalized.BaseURL), "/"),
+		defaultModel:    strings.TrimSpace(normalized.DefaultModel),
+		reasoningEffort: strings.TrimSpace(normalized.ReasoningEffort),
+		client:          normalized.client(),
 	}, nil
 }
 
@@ -321,6 +324,9 @@ func (g *OpenAIModelGateway) buildRequest(req ModelRequest, stream bool) (openAI
 		Model:  model,
 		Stream: stream,
 	}
+	if strings.TrimSpace(g.reasoningEffort) != "" {
+		body.ReasoningEffort = strings.TrimSpace(g.reasoningEffort)
+	}
 	if stream {
 		body.StreamOptions = &openAIStreamOptions{IncludeUsage: true}
 	}
@@ -412,13 +418,14 @@ func parseOpenAIMessageContent(raw json.RawMessage) string {
 }
 
 type openAIChatCompletionRequest struct {
-	Model          string                        `json:"model"`
-	Messages       []openAIChatCompletionMessage `json:"messages"`
-	Tools          []openAIChatTool              `json:"tools,omitempty"`
-	ToolChoice     string                        `json:"tool_choice,omitempty"`
-	ResponseFormat *openAIResponseFormat         `json:"response_format,omitempty"`
-	Stream         bool                          `json:"stream,omitempty"`
-	StreamOptions  *openAIStreamOptions          `json:"stream_options,omitempty"`
+	Model           string                        `json:"model"`
+	Messages        []openAIChatCompletionMessage `json:"messages"`
+	ReasoningEffort string                        `json:"reasoning_effort,omitempty"`
+	Tools           []openAIChatTool              `json:"tools,omitempty"`
+	ToolChoice      string                        `json:"tool_choice,omitempty"`
+	ResponseFormat  *openAIResponseFormat         `json:"response_format,omitempty"`
+	Stream          bool                          `json:"stream,omitempty"`
+	StreamOptions   *openAIStreamOptions          `json:"stream_options,omitempty"`
 }
 
 type openAIStreamOptions struct {

--- a/runtime/model_gateway_openai_test.go
+++ b/runtime/model_gateway_openai_test.go
@@ -105,6 +105,45 @@ func TestOpenAIModelGatewayCompleteSuccess(t *testing.T) {
 	}
 }
 
+func TestOpenAIModelGatewaySendsReasoningEffort(t *testing.T) {
+	var captured map[string]interface{}
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			if err := json.Unmarshal(body, &captured); err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"choices":[{"message":{"content":"ok"}}]}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+		Timeout: time.Second,
+	}
+
+	cfg := DefaultOpenAIModelGatewayConfig()
+	cfg.APIKey = "test-key"
+	cfg.BaseURL = "https://example.invalid/v1"
+	cfg.ReasoningEffort = "xhigh"
+	cfg.HTTPClient = client
+
+	gateway, err := NewOpenAIModelGateway(cfg)
+	if err != nil {
+		t.Fatalf("new gateway failed: %v", err)
+	}
+	_, err = gateway.Complete(context.Background(), ModelRequest{Model: "gpt-5.5", Prompt: "test", Step: 1})
+	if err != nil {
+		t.Fatalf("complete failed: %v", err)
+	}
+	if got, _ := captured["reasoning_effort"].(string); got != "xhigh" {
+		t.Fatalf("expected reasoning_effort xhigh, got %q in %#v", got, captured)
+	}
+}
+
 func TestOpenAIModelGatewayCompleteWithoutAuthHeaderWhenKeyNotProvided(t *testing.T) {
 	var capturedAuth string
 	client := &http.Client{

--- a/runtime/policy_enforcement.go
+++ b/runtime/policy_enforcement.go
@@ -61,6 +61,11 @@ func MinimumTokenBudget(policies []resources.AgentPolicy) int {
 }
 
 func policyAppliesTo(policy resources.AgentPolicy, task resources.Task, system resources.AgentSystem) bool {
+	policyNamespace := resources.NormalizeNamespace(policy.Metadata.Namespace)
+	taskNamespace := resources.NormalizeNamespace(task.Metadata.Namespace)
+	if policyNamespace != taskNamespace {
+		return false
+	}
 	mode := strings.ToLower(strings.TrimSpace(policy.Spec.ApplyMode))
 	if mode == "" {
 		mode = "scoped"

--- a/runtime/policy_enforcement_test.go
+++ b/runtime/policy_enforcement_test.go
@@ -77,6 +77,24 @@ func TestMatchedPolicies_Global(t *testing.T) {
 	}
 }
 
+func TestMatchedPolicies_IgnoresPoliciesFromOtherNamespaces(t *testing.T) {
+	task := resources.Task{Metadata: resources.ObjectMeta{Name: "task-1"}}
+	system := resources.AgentSystem{Metadata: resources.ObjectMeta{Name: "system-1"}}
+	globalDefault := resources.AgentPolicy{
+		Metadata: resources.ObjectMeta{Name: "default-global"},
+		Spec:     resources.AgentPolicySpec{ApplyMode: "global"},
+	}
+	globalOtherNamespace := resources.AgentPolicy{
+		Metadata: resources.ObjectMeta{Name: "other-global", Namespace: "other-namespace"},
+		Spec:     resources.AgentPolicySpec{ApplyMode: "global"},
+	}
+
+	matched := MatchedPolicies(task, system, []resources.AgentPolicy{globalDefault, globalOtherNamespace})
+	if len(matched) != 1 || matched[0].Metadata.Name != "default-global" {
+		t.Fatalf("expected only default namespace global policy, got %d policies", len(matched))
+	}
+}
+
 func TestMatchedPolicies_ScopedBySystem(t *testing.T) {
 	task := resources.Task{Metadata: resources.ObjectMeta{Name: "task-1"}}
 	system := resources.AgentSystem{Metadata: resources.ObjectMeta{Name: "research-system"}}

--- a/store/resource_stores.go
+++ b/store/resource_stores.go
@@ -2974,6 +2974,70 @@ func (s *McpServerStore) Upsert(ctx context.Context, item resources.McpServer) (
 	return item, nil
 }
 
+// UpdateStatus updates only the observed status for an MCP server.
+// It preserves spec and metadata.generation so controller reconciliation does
+// not turn an observed-state write into a desired-state generation change.
+func (s *McpServerStore) UpdateStatus(ctx context.Context, name string, status resources.McpServerStatus) (resources.McpServer, error) {
+	key := normalizeLookupName(name)
+	if s.db != nil {
+		tx, err := s.db.Begin()
+		if err != nil {
+			return resources.McpServer{}, err
+		}
+		defer tx.Rollback()
+
+		item, found, err := getFromTableForUpdate[resources.McpServer](ctx, tx, tableMcpServers, key)
+		if err != nil {
+			return resources.McpServer{}, err
+		}
+		if !found {
+			return resources.McpServer{}, fmt.Errorf("mcp-server %q not found", name)
+		}
+
+		nextVersion, err := nextResourceVersion(item.Metadata.ResourceVersion)
+		if err != nil {
+			return resources.McpServer{}, fmt.Errorf("invalid McpServer current resourceVersion %q: %w", item.Metadata.ResourceVersion, err)
+		}
+		item.Metadata.ResourceVersion = nextVersion
+		if item.Metadata.Generation <= 0 {
+			item.Metadata.Generation = 1
+		}
+		if strings.TrimSpace(item.Metadata.CreatedAt) == "" {
+			item.Metadata.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+		}
+		item.Status = status
+
+		if err := upsertMcpServerSQL(ctx, tx, key, item); err != nil {
+			return resources.McpServer{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return resources.McpServer{}, err
+		}
+		return item, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, ok := s.items[key]
+	if !ok {
+		return resources.McpServer{}, fmt.Errorf("mcp-server %q not found", name)
+	}
+	nextVersion, err := nextResourceVersion(item.Metadata.ResourceVersion)
+	if err != nil {
+		return resources.McpServer{}, fmt.Errorf("invalid McpServer current resourceVersion %q: %w", item.Metadata.ResourceVersion, err)
+	}
+	item.Metadata.ResourceVersion = nextVersion
+	if item.Metadata.Generation <= 0 {
+		item.Metadata.Generation = 1
+	}
+	if strings.TrimSpace(item.Metadata.CreatedAt) == "" {
+		item.Metadata.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	item.Status = status
+	s.items[key] = item
+	return item, nil
+}
+
 func (s *McpServerStore) Get(ctx context.Context, name string) (resources.McpServer, bool, error) {
 	key := normalizeLookupName(name)
 	if s.db != nil {

--- a/store/sql_backend.go
+++ b/store/sql_backend.go
@@ -1300,16 +1300,18 @@ func upsertMcpServerSQL(ctx context.Context, db dbExecer, name string, item reso
 		return err
 	}
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO mcp_servers(name, namespace, status_phase, payload, updated_at)
-		 VALUES($1, $2, $3, $4::jsonb, NOW())
+		`INSERT INTO mcp_servers(name, namespace, status_phase, spec_hash, payload, updated_at)
+		 VALUES($1, $2, $3, $4, $5::jsonb, NOW())
 		 ON CONFLICT(name) DO UPDATE SET
 		     namespace = EXCLUDED.namespace,
 		     status_phase = EXCLUDED.status_phase,
+		     spec_hash = EXCLUDED.spec_hash,
 		     payload = EXCLUDED.payload,
 		     updated_at = NOW()`,
 		name,
 		resources.NormalizeNamespace(item.Metadata.Namespace),
 		strings.ToLower(strings.TrimSpace(item.Status.Phase)),
+		specHash(item.Spec),
 		string(payload),
 	)
 	return err

--- a/store/versioning_test.go
+++ b/store/versioning_test.go
@@ -60,3 +60,61 @@ func TestAgentStoreVersioningAndConflict(t *testing.T) {
 		t.Fatalf("expected conflict error, got %T %v", err, err)
 	}
 }
+
+func TestMcpServerStoreUpdateStatusDoesNotBumpGeneration(t *testing.T) {
+	s := NewMcpServerStore()
+
+	created, err := s.Upsert(context.Background(), resources.McpServer{
+		APIVersion: "orloj.dev/v1",
+		Kind:       "McpServer",
+		Metadata:   resources.ObjectMeta{Name: "browsermcp"},
+		Spec: resources.McpServerSpec{
+			Transport: "stdio",
+			Command:   "npx",
+			Args:      []string{"@browsermcp/mcp"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create mcp server failed: %v", err)
+	}
+	if created.Metadata.Generation != 1 {
+		t.Fatalf("expected generation=1, got %d", created.Metadata.Generation)
+	}
+
+	statusUpdated, err := s.UpdateStatus(context.Background(), "browsermcp", resources.McpServerStatus{
+		Phase:              "Ready",
+		DiscoveredTools:    []string{"snapshot"},
+		GeneratedTools:     []string{"browsermcp--snapshot"},
+		ObservedGeneration: created.Metadata.Generation,
+	})
+	if err != nil {
+		t.Fatalf("status update failed: %v", err)
+	}
+	if statusUpdated.Metadata.ResourceVersion != "2" {
+		t.Fatalf("expected rv=2, got %q", statusUpdated.Metadata.ResourceVersion)
+	}
+	if statusUpdated.Metadata.Generation != created.Metadata.Generation {
+		t.Fatalf("status update bumped generation: before=%d after=%d", created.Metadata.Generation, statusUpdated.Metadata.Generation)
+	}
+	if statusUpdated.Status.ObservedGeneration != created.Metadata.Generation {
+		t.Fatalf("expected observed generation=%d, got %d", created.Metadata.Generation, statusUpdated.Status.ObservedGeneration)
+	}
+
+	statusUpdated.Status.Phase = "Connecting"
+	statusOnlyViaUpsert, err := s.Upsert(context.Background(), statusUpdated)
+	if err != nil {
+		t.Fatalf("status-only upsert failed: %v", err)
+	}
+	if statusOnlyViaUpsert.Metadata.Generation != created.Metadata.Generation {
+		t.Fatalf("status-only upsert bumped generation: before=%d after=%d", created.Metadata.Generation, statusOnlyViaUpsert.Metadata.Generation)
+	}
+
+	statusOnlyViaUpsert.Spec.Args = append(statusOnlyViaUpsert.Spec.Args, "--headless")
+	specUpdated, err := s.Upsert(context.Background(), statusOnlyViaUpsert)
+	if err != nil {
+		t.Fatalf("spec upsert failed: %v", err)
+	}
+	if specUpdated.Metadata.Generation != created.Metadata.Generation+1 {
+		t.Fatalf("expected spec update to bump generation to %d, got %d", created.Metadata.Generation+1, specUpdated.Metadata.Generation)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve MCP runtime status, transport, session, cleanup, policy, and store fixes
- preserve Agentflow runtime overrides and streaming behavior
- add OpenAI reasoning-effort configuration while retaining the shared complete/stream request builder

## Validation

- `go test ./runtime -run "Test(OpenAIModelGateway|NewModelGatewayFromConfigOpenAI)" -count=1 -timeout 120s`
- native gopls v0.23.0 indexing, references, and diagnostics: no diagnostics in the resolved gateway file
- `go test ./... -count=1 -timeout 120s` ran all buildable packages; the suite exits at the explicit prerequisite `frontend/embed.go: pattern dist: no matching files found` because `frontend/dist` is absent

## Preservation scope

16 files, 3 commits, based on upstream `main` at `e6b723b3df582cc262d6876715d5877b4b61226e`.