### PR TITLE
feat(console): add accessible AI transparency disclosures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Console AI transparency disclosures**: direct Session interaction and generated Session, Task, Trace, and Eval output now show accessible, disclosure-localized labels with Article 50 metadata and safe provider/model attribution when an exact agent-to-endpoint mapping exists.
+
 ## [0.19.0] - 2026-07-23
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/frontend/src/compliance/aiAttribution.ts
+++ b/frontend/src/compliance/aiAttribution.ts
@@ -1,0 +1,38 @@
+import type { Agent, ModelEndpoint } from "../api/types";
+
+export interface AiAttribution {
+  provider: string;
+  modelId?: string;
+}
+
+/**
+ * Resolve only the public provider/model fields from one unambiguous
+ * agent→model_ref→endpoint chain. Secret refs, endpoint URLs, and endpoint
+ * options are intentionally outside this helper's return type.
+ */
+export function resolveAgentAiAttribution(
+  agentName: string | null | undefined,
+  agents: readonly Agent[],
+  endpoints: readonly ModelEndpoint[],
+): AiAttribution | undefined {
+  const normalizedAgentName = agentName?.trim();
+  if (!normalizedAgentName || normalizedAgentName.toLowerCase() === "system") return undefined;
+
+  const matchingAgents = agents.filter((agent) => agent.metadata.name === normalizedAgentName);
+  if (matchingAgents.length !== 1) return undefined;
+  const agent = matchingAgents[0];
+  const modelRef = agent.spec.model_ref?.trim();
+  if (!modelRef) return undefined;
+
+  const matchingEndpoints = endpoints.filter((endpoint) => (
+    endpoint.metadata.name === modelRef
+    && (!agent.metadata.namespace || !endpoint.metadata.namespace || endpoint.metadata.namespace === agent.metadata.namespace)
+  ));
+  if (matchingEndpoints.length !== 1) return undefined;
+
+  const endpoint = matchingEndpoints[0];
+  const provider = endpoint.spec.provider?.trim();
+  const modelId = endpoint.spec.default_model?.trim();
+  if (!provider) return undefined;
+  return modelId ? { provider, modelId } : { provider };
+}

--- a/frontend/src/compliance/aiDisclosureLocale.ts
+++ b/frontend/src/compliance/aiDisclosureLocale.ts
@@ -1,0 +1,63 @@
+export const AI_DISCLOSURE_LOCALES = ["en", "de", "es", "fr", "ko", "pt", "zh"] as const;
+
+export type AiDisclosureLocale = (typeof AI_DISCLOSURE_LOCALES)[number];
+export type AiDisclosureKind = "ai-interaction" | "generated-output" | "ai-assisted-analysis" | "ai-translation";
+
+export const aiDisclosureCopy: Record<AiDisclosureLocale, Record<AiDisclosureKind, string>> = {
+  en: {
+    "ai-interaction": "AI interaction",
+    "generated-output": "AI-generated",
+    "ai-assisted-analysis": "AI-assisted analysis",
+    "ai-translation": "AI translation",
+  },
+  de: {
+    "ai-interaction": "KI-Interaktion",
+    "generated-output": "KI-generiert",
+    "ai-assisted-analysis": "KI-gestützte Analyse",
+    "ai-translation": "KI-Übersetzung",
+  },
+  es: {
+    "ai-interaction": "Interacción con IA",
+    "generated-output": "Generado por IA",
+    "ai-assisted-analysis": "Análisis asistido por IA",
+    "ai-translation": "Traducción con IA",
+  },
+  fr: {
+    "ai-interaction": "Interaction avec l’IA",
+    "generated-output": "Généré par l’IA",
+    "ai-assisted-analysis": "Analyse assistée par l’IA",
+    "ai-translation": "Traduction par l’IA",
+  },
+  ko: {
+    "ai-interaction": "AI 상호작용",
+    "generated-output": "AI 생성",
+    "ai-assisted-analysis": "AI 지원 분석",
+    "ai-translation": "AI 번역",
+  },
+  pt: {
+    "ai-interaction": "Interação com IA",
+    "generated-output": "Gerado por IA",
+    "ai-assisted-analysis": "Análise assistida por IA",
+    "ai-translation": "Tradução por IA",
+  },
+  zh: {
+    "ai-interaction": "AI 交互",
+    "generated-output": "AI 生成",
+    "ai-assisted-analysis": "AI 辅助分析",
+    "ai-translation": "AI 翻译",
+  },
+};
+
+export function resolveAiDisclosureLocale(language?: string | null): AiDisclosureLocale {
+  const primary = language?.trim().toLowerCase().split(/[-_]/, 1)[0] ?? "";
+  return AI_DISCLOSURE_LOCALES.includes(primary as AiDisclosureLocale)
+    ? primary as AiDisclosureLocale
+    : "en";
+}
+
+export function browserAiDisclosureLocale(): AiDisclosureLocale {
+  if (typeof document !== "undefined" && document.documentElement.lang) {
+    return resolveAiDisclosureLocale(document.documentElement.lang);
+  }
+  return resolveAiDisclosureLocale(typeof navigator === "undefined" ? undefined : navigator.language);
+}

--- a/frontend/src/compliance/aiTransparencySurfaces.ts
+++ b/frontend/src/compliance/aiTransparencySurfaces.ts
@@ -1,0 +1,151 @@
+export const AI_TRANSPARENCY_DECISIONS = ["included", "nested", "excluded"] as const;
+
+export type AiTransparencyDecision = (typeof AI_TRANSPARENCY_DECISIONS)[number];
+
+export interface AiTransparencySurface {
+  id: string;
+  sourceFiles: readonly string[];
+  decision: AiTransparencyDecision;
+  rationale: string;
+  parentId?: string;
+  disclosure?: "ai-interaction" | "generated-output" | "ai-assisted-analysis" | "ai-translation";
+  providerStrategy: "agent-endpoint" | "provider-agnostic" | "not-applicable";
+}
+
+/** Production inventory for Orloj console AI interactions and generated output. */
+export const aiTransparencySurfaces = [
+  {
+    id: "orloj-session-interaction",
+    sourceFiles: ["pages/SessionDetail.tsx"],
+    decision: "included",
+    rationale: "The live Session composer directly sends natural-person steering input to an agent system.",
+    disclosure: "ai-interaction",
+    providerStrategy: "provider-agnostic",
+  },
+  {
+    id: "orloj-session-assistant-message",
+    sourceFiles: ["components/SessionTimeline.tsx"],
+    decision: "included",
+    rationale: "Session timeline items with assistant role directly render streamed or persisted agent output.",
+    disclosure: "generated-output",
+    providerStrategy: "provider-agnostic",
+  },
+  {
+    id: "orloj-session-user-system-activity",
+    sourceFiles: ["components/SessionTimeline.tsx", "utils/sessionTimeline.ts"],
+    decision: "excluded",
+    rationale: "User messages, checkpoints, tool activity, lifecycle events, and errors are human or operational content.",
+    providerStrategy: "not-applicable",
+  },
+  {
+    id: "orloj-task-overview-output",
+    sourceFiles: ["pages/TaskDetail.tsx"],
+    decision: "included",
+    rationale: "Task status output directly renders aggregate agent-system output.",
+    disclosure: "generated-output",
+    providerStrategy: "provider-agnostic",
+  },
+  {
+    id: "orloj-task-agent-message",
+    sourceFiles: ["pages/TaskDetail.tsx"],
+    decision: "included",
+    rationale: "Task messages with a non-system producing agent directly render agent-authored content.",
+    disclosure: "generated-output",
+    providerStrategy: "agent-endpoint",
+  },
+  {
+    id: "orloj-task-system-message",
+    sourceFiles: ["pages/TaskDetail.tsx"],
+    decision: "excluded",
+    rationale: "System/control messages and last_error are operational rather than model output.",
+    providerStrategy: "not-applicable",
+  },
+  {
+    id: "orloj-trace-model-output",
+    sourceFiles: ["components/TraceView.tsx"],
+    decision: "included",
+    rationale: "model_output trace events expose generated model content.",
+    disclosure: "generated-output",
+    providerStrategy: "agent-endpoint",
+  },
+  {
+    id: "orloj-trace-agent-message",
+    sourceFiles: ["components/TraceView.tsx"],
+    decision: "included",
+    rationale: "agent_message trace events expose direct agent-generated message content.",
+    disclosure: "generated-output",
+    providerStrategy: "agent-endpoint",
+  },
+  {
+    id: "orloj-trace-operational-events",
+    sourceFiles: ["components/TraceView.tsx"],
+    decision: "excluded",
+    rationale: "Tool, error, timing, phase, branch, and token-usage events are operational evidence.",
+    providerStrategy: "not-applicable",
+  },
+  {
+    id: "orloj-eval-result-output",
+    sourceFiles: ["pages/EvalRunDetail.tsx"],
+    decision: "included",
+    rationale: "Evaluation sample output directly renders aggregate generated system output.",
+    disclosure: "ai-assisted-analysis",
+    providerStrategy: "provider-agnostic",
+  },
+  {
+    id: "orloj-task-yaml",
+    sourceFiles: ["pages/TaskDetail.tsx"],
+    decision: "nested",
+    parentId: "orloj-task-overview-output",
+    rationale: "The editable YAML inspector repeats mixed task config/input/output already classified at its primary surface.",
+    providerStrategy: "not-applicable",
+  },
+  {
+    id: "orloj-task-log-viewer",
+    sourceFiles: ["components/LogViewer.tsx", "pages/TaskDetail.tsx"],
+    decision: "excluded",
+    rationale: "Raw operational logs have mixed per-line provenance and cannot be accurately blanket-labelled.",
+    providerStrategy: "not-applicable",
+  },
+  {
+    id: "orloj-eval-dataset-expected-output",
+    sourceFiles: ["pages/EvalDatasetDetail.tsx"],
+    decision: "excluded",
+    rationale: "Expected outputs are human-authored evaluation fixtures, not live model output.",
+    providerStrategy: "not-applicable",
+  },
+  {
+    id: "orloj-task-approval-output",
+    sourceFiles: ["pages/TaskApprovalDetail.tsx"],
+    decision: "nested",
+    parentId: "orloj-task-overview-output",
+    rationale: "Approval detail repeats held task output for human governance rather than invoking a new model.",
+    providerStrategy: "not-applicable",
+  },
+] as const satisfies readonly AiTransparencySurface[];
+
+export const ORLOJ_AI_CENSUS_PATTERNS = [
+  /status\?\.output|status\.output/,
+  /msg\.content|message__content/,
+  /model_output|agent_message/,
+  /results\.map|\.output/,
+  /SessionTimeline|sendTurn/,
+] as const;
+
+export function validateAiTransparencyRegistry(surfaces: readonly AiTransparencySurface[] = aiTransparencySurfaces): string[] {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+  for (const surface of surfaces) {
+    if (!surface.id.trim()) errors.push("surface id is empty");
+    if (ids.has(surface.id)) errors.push(`duplicate surface id: ${surface.id}`);
+    ids.add(surface.id);
+    if (surface.sourceFiles.length === 0) errors.push(`${surface.id}: sourceFiles is empty`);
+    if (!surface.rationale.trim()) errors.push(`${surface.id}: rationale is empty`);
+    if (surface.decision === "included" && !surface.disclosure) errors.push(`${surface.id}: included surface has no disclosure kind`);
+    if (surface.decision === "nested" && !surface.parentId) errors.push(`${surface.id}: nested surface has no parentId`);
+  }
+  for (const surface of surfaces) {
+    if (surface.parentId && !ids.has(surface.parentId)) errors.push(`${surface.id}: unknown parentId ${surface.parentId}`);
+    if (surface.parentId === surface.id) errors.push(`${surface.id}: cannot be its own parent`);
+  }
+  return errors;
+}

--- a/frontend/src/components/AiDisclosure.tsx
+++ b/frontend/src/components/AiDisclosure.tsx
@@ -1,0 +1,56 @@
+import type { AiDisclosureKind, AiDisclosureLocale } from "../compliance/aiDisclosureLocale";
+import { aiDisclosureCopy, browserAiDisclosureLocale } from "../compliance/aiDisclosureLocale";
+
+interface AiDisclosureProps {
+  kind: AiDisclosureKind;
+  provider?: string | null;
+  modelId?: string | null;
+  locale?: AiDisclosureLocale;
+  compact?: boolean;
+  className?: string;
+  accessibleLabel?: string;
+  testId?: string;
+}
+
+const SAFE_METADATA_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}._+/@:-]{0,119}$/u;
+const SENSITIVE_METADATA_PATTERN = /(?:^|[-_.])(secret|token|password|credential|api[-_]?key)(?:$|[-_.])/i;
+
+export function normalizeAiAttributionValue(value: string | null | undefined): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized || normalized.includes("://") || !SAFE_METADATA_PATTERN.test(normalized)) return undefined;
+  if (SENSITIVE_METADATA_PATTERN.test(normalized)) return undefined;
+  return normalized;
+}
+
+export function AiDisclosure({
+  kind,
+  provider,
+  modelId,
+  locale = browserAiDisclosureLocale(),
+  compact = false,
+  className,
+  accessibleLabel,
+  testId,
+}: AiDisclosureProps) {
+  const safeProvider = normalizeAiAttributionValue(provider);
+  const safeModel = safeProvider ? normalizeAiAttributionValue(modelId) : undefined;
+  const label = aiDisclosureCopy[locale][kind];
+  const attribution = safeProvider ? `${safeProvider}${safeModel ? `/${safeModel}` : ""}` : undefined;
+
+  return (
+    <span
+      className={["ai-disclosure", compact ? "ai-disclosure--compact" : "", className ?? ""].filter(Boolean).join(" ")}
+      role="note"
+      aria-label={accessibleLabel ?? (attribution ? `${label} · ${attribution}` : label)}
+      data-testid={testId}
+      data-compliance="eu-ai-act-art-50"
+      data-ai-disclosure={kind}
+      {...(safeProvider
+        ? { "data-ai-provider": safeProvider, ...(safeModel ? { "data-ai-model": safeModel } : {}) }
+        : { "data-ai-attribution": "provider-agnostic" })}
+    >
+      <span>{label}</span>
+      {attribution ? <span className="ai-disclosure__attribution" aria-hidden="true">· {attribution}</span> : null}
+    </span>
+  );
+}

--- a/frontend/src/components/SessionTimeline.tsx
+++ b/frontend/src/components/SessionTimeline.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import type { RefObject } from "react";
 import type { SessionTimelineItem } from "../utils/sessionTimeline";
+import { AiDisclosure } from "./AiDisclosure";
 
 interface SessionTimelineProps {
   items: SessionTimelineItem[];
@@ -107,6 +108,7 @@ function TimelineEntry({
           )}
           {item.reset && <span className="session-timeline__reset-label">Reset</span>}
         </div>
+        {item.role === "assistant" ? <AiDisclosure kind="generated-output" compact /> : null}
         <pre className="session-message__content">{item.content}</pre>
       </article>
     );

--- a/frontend/src/components/TraceView.tsx
+++ b/frontend/src/components/TraceView.tsx
@@ -1,6 +1,8 @@
 import { useState, useMemo } from "react";
 import type { TaskTraceEvent } from "../api/types";
+import { AiDisclosure } from "./AiDisclosure";
 import { StatusBadge } from "./StatusBadge";
+import type { AiAttribution } from "../compliance/aiAttribution";
 import {
   Clock, Cpu, Wrench, AlertTriangle, ChevronDown, ChevronRight,
   Zap, Download, Search, Activity, Copy,
@@ -10,6 +12,7 @@ import clsx from "clsx";
 
 interface TraceViewProps {
   trace: TaskTraceEvent[];
+  resolveAttribution?: (agent?: string | null) => AiAttribution | undefined;
 }
 
 type EventDot = "green" | "blue" | "yellow" | "red" | "orange" | "purple" | "gray" | "accent";
@@ -319,7 +322,7 @@ function generateTokenSparkPath(series: number[], width: number, height: number)
 const SPARK_WIDTH = 120;
 const SPARK_HEIGHT = 28;
 
-export function TraceView({ trace }: TraceViewProps) {
+export function TraceView({ trace, resolveAttribution }: TraceViewProps) {
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [collapsedLanes, setCollapsedLanes] = useState<Set<string>>(new Set());
@@ -443,6 +446,8 @@ export function TraceView({ trace }: TraceViewProps) {
     const style = getEventStyle(ev.type);
     const isExpanded = expandedKeys.has(row.key);
     const isError = !!ev.error_code || ev.type === "agent_error";
+    const isGeneratedEvent = Boolean(ev.message) && (ev.type === "model_output" || ev.type === "agent_message");
+    const attribution = isGeneratedEvent ? resolveAttribution?.(ev.agent) : undefined;
     return (
       <div key={row.key}>
         <div
@@ -465,6 +470,7 @@ export function TraceView({ trace }: TraceViewProps) {
             </span>
           </div>
           <div className="trace-view__col-detail text-ellipsis">
+            {isGeneratedEvent ? <AiDisclosure kind="generated-output" provider={attribution?.provider} modelId={attribution?.modelId} compact /> : null}
             {ev.tool ?? ev.message ?? ev.step_id ?? ""}
           </div>
           <div className="trace-view__col-start mono">{formatOffset(row.startMs)}</div>

--- a/frontend/src/pages/EvalRunDetail.tsx
+++ b/frontend/src/pages/EvalRunDetail.tsx
@@ -5,6 +5,7 @@ import { useDetailReturnNav } from "../hooks/useDetailReturnNav";
 import { useEvalRun, useDeleteResource, useUpdateResource } from "../api/hooks";
 import { useAppStore } from "../store";
 import { saveNamespacedResourceYaml } from "../hooks/saveDetailYamlWithFreshRv";
+import { AiDisclosure } from "../components/AiDisclosure";
 import { StatusBadge } from "../components/StatusBadge";
 import { DetailSkeleton } from "../components/DetailSkeleton";
 import { MetricCard } from "../components/MetricCard";
@@ -227,6 +228,7 @@ export function EvalRunDetail() {
 
         {tab === "results" && (
           <div className="detail-table-wrap">
+            {results.length > 0 ? <AiDisclosure kind="ai-assisted-analysis" className="ai-disclosure--table" /> : null}
             {results.length === 0 ? (
               <p className="text-secondary" style={{ padding: "1rem" }}>No results yet.</p>
             ) : (

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -28,6 +28,7 @@ import {
   type SessionStreamState,
 } from "../api/sessionStream";
 import type { SessionCheckpoint, SessionEvent } from "../api/types";
+import { AiDisclosure } from "../components/AiDisclosure";
 import { confirmDialog } from "../components/ConfirmDialog";
 import { DetailSkeleton } from "../components/DetailSkeleton";
 import { ResourceDetailLoadError } from "../components/ResourceDetailLoadError";
@@ -350,6 +351,7 @@ export function SessionDetail() {
 
       <div className="session-live-layout">
         <section className="session-chat" aria-label="Session live execution timeline">
+          <AiDisclosure kind="ai-interaction" />
           <div className="session-chat__timeline" aria-live="polite">
             <SessionTimeline
               items={timeline}

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useDetailReturnNav } from "../hooks/useDetailReturnNav";
-import { useTask, useTaskMessages, useTaskMetrics, useTaskLogs, useAgentSystem, useDeleteResource, useUpdateResource } from "../api/hooks";
+import { useTask, useTaskMessages, useTaskMetrics, useTaskLogs, useAgentSystem, useAgents, useModelEndpoints, useDeleteResource, useUpdateResource } from "../api/hooks";
 import { useAppStore } from "../store";
 import { saveNamespacedResourceYaml } from "../hooks/saveDetailYamlWithFreshRv";
 import { toast } from "../components/Toast";
@@ -12,7 +12,9 @@ import { YamlEditor } from "../components/YamlEditor";
 import { LogViewer } from "../components/LogViewer";
 import { GraphView } from "../components/GraphView";
 import { MetricCard } from "../components/MetricCard";
+import { AiDisclosure } from "../components/AiDisclosure";
 import { TraceView } from "../components/TraceView";
+import { resolveAgentAiAttribution } from "../compliance/aiAttribution";
 import { ResourceDetailLoadError } from "../components/ResourceDetailLoadError";
 import { ArrowLeft, Clock, Activity, Hash, Zap, MessagesSquare, Network, X } from "lucide-react";
 import { EmptyState } from "../components/EmptyState";
@@ -207,6 +209,11 @@ export function TaskDetail() {
   const metrics = useTaskMetrics(routeName);
   const logs = useTaskLogs(routeName);
   const system = useAgentSystem(task?.spec.system ?? "");
+  const agents = useAgents();
+  const modelEndpoints = useModelEndpoints();
+  const resolveAttribution = useCallback((agentName?: string | null) => (
+    resolveAgentAiAttribution(agentName, agents.data ?? [], modelEndpoints.data ?? [])
+  ), [agents.data, modelEndpoints.data]);
   const confirmDelete = useDeleteConfirm();
   const deleteMutation = useDeleteResource("Task");
   const updateMutation = useUpdateResource("Task");
@@ -429,6 +436,7 @@ export function TaskDetail() {
             {task.status?.output && Object.keys(task.status.output).length > 0 && (
               <div className="detail-field detail-field--full">
                 <span className="detail-field__label">Output</span>
+                <AiDisclosure kind="generated-output" compact />
                 <pre className="detail-field__pre">{JSON.stringify(task.status.output, null, 2)}</pre>
               </div>
             )}
@@ -505,7 +513,10 @@ export function TaskDetail() {
                   : "No messages yet"}
               </p>
             )}
-            {(messages.data ?? []).map((msg, i) => (
+            {(messages.data ?? []).map((msg, i) => {
+              const attribution = resolveAttribution(msg.from_agent);
+              const isAgentMessage = Boolean(msg.content && msg.from_agent && msg.from_agent.toLowerCase() !== "system");
+              return (
               <div key={msg.message_id ?? i} className="message-item">
                 <div className="message-item__header">
                   <span className="mono">{msg.from_agent ?? "system"}</span>
@@ -516,10 +527,12 @@ export function TaskDetail() {
                     <span className="text-muted text-xs">{new Date(msg.timestamp).toLocaleString()}</span>
                   )}
                 </div>
+                {isAgentMessage ? <AiDisclosure kind="generated-output" provider={attribution?.provider} modelId={attribution?.modelId} compact /> : null}
                 {msg.content && <pre className="message-item__content">{msg.content}</pre>}
                 {msg.last_error && <p className="text-red text-xs">{msg.last_error}</p>}
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
 
@@ -560,7 +573,7 @@ export function TaskDetail() {
           )
         )}
 
-        {tab === "trace" && <TraceView trace={traceEvents} />}
+        {tab === "trace" && <TraceView trace={traceEvents} resolveAttribution={resolveAttribution} />}
 
         {tab === "logs" && logs.isError && (
           <p className="text-red">

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -5412,3 +5412,26 @@ button:focus-visible {
     margin-right: auto;
   }
 }
+
+/* Disclosure-only localization is intentionally scoped to this component; the
+   remainder of the Orloj console is still English-only. */
+.ai-disclosure {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: 1.35;
+}
+
+.ai-disclosure--compact {
+  gap: 0.25rem;
+  font-size: var(--text-2xs);
+}
+
+.ai-disclosure__attribution {
+  overflow-wrap: anywhere;
+  color: var(--text-tertiary);
+}

--- a/frontend/tests/AiDisclosure.test.tsx
+++ b/frontend/tests/AiDisclosure.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AI_DISCLOSURE_LOCALES, aiDisclosureCopy, resolveAiDisclosureLocale } from "../src/compliance/aiDisclosureLocale";
+import { AiDisclosure, normalizeAiAttributionValue } from "../src/components/AiDisclosure";
+
+describe("AiDisclosure", () => {
+  test("renders exact visible, semantic, and machine-readable metadata", () => {
+    const html = renderToStaticMarkup(
+      <AiDisclosure kind="generated-output" provider="anthropic" modelId="claude-opus-4-1" locale="en" />,
+    );
+
+    expect(html).toContain('role="note"');
+    expect(html).toContain('aria-label="AI-generated · anthropic/claude-opus-4-1"');
+    expect(html).toContain('data-compliance="eu-ai-act-art-50"');
+    expect(html).toContain('data-ai-disclosure="generated-output"');
+    expect(html).toContain('data-ai-provider="anthropic"');
+    expect(html).toContain('data-ai-model="claude-opus-4-1"');
+    expect(html).not.toContain("data-ai-attribution");
+  });
+
+  test("uses provider-agnostic metadata and never guesses Mistral", () => {
+    const html = renderToStaticMarkup(<AiDisclosure kind="ai-assisted-analysis" locale="en" />);
+    expect(html).toContain('data-ai-attribution="provider-agnostic"');
+    expect(html).not.toContain("data-ai-provider");
+    expect(html.toLowerCase()).not.toContain("mistral");
+  });
+
+  test("rejects URL and secret-like values", () => {
+    const html = renderToStaticMarkup(
+      <AiDisclosure kind="ai-interaction" provider="https://provider.example/v1" modelId="api-key-secret" locale="en" />,
+    );
+    expect(html).toContain('data-ai-attribution="provider-agnostic"');
+    expect(html).not.toContain("provider.example");
+    expect(html).not.toContain("api-key-secret");
+    expect(normalizeAiAttributionValue("credential-id")).toBeUndefined();
+  });
+
+  test("declares non-empty copy for every supported locale and falls back to English", () => {
+    for (const locale of AI_DISCLOSURE_LOCALES) {
+      for (const value of Object.values(aiDisclosureCopy[locale])) expect(value.trim().length).toBeGreaterThan(0);
+      const html = renderToStaticMarkup(<AiDisclosure kind="generated-output" locale={locale} />);
+      expect(html).toContain(aiDisclosureCopy[locale]["generated-output"]);
+    }
+    expect(resolveAiDisclosureLocale("pt-BR")).toBe("pt");
+    expect(resolveAiDisclosureLocale("zh-Hant-TW")).toBe("zh");
+    expect(resolveAiDisclosureLocale("unsupported-Latn")).toBe("en");
+  });
+});

--- a/frontend/tests/aiAttribution.test.ts
+++ b/frontend/tests/aiAttribution.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import type { Agent, ModelEndpoint } from "../src/api/types";
+import { resolveAgentAiAttribution } from "../src/compliance/aiAttribution";
+
+const agent = {
+  apiVersion: "orloj.dev/v1",
+  kind: "Agent",
+  metadata: { name: "writer", namespace: "default" },
+  spec: { model_ref: "primary-model", prompt: "synthetic fixture" },
+} as Agent;
+
+const endpoint = {
+  apiVersion: "orloj.dev/v1",
+  kind: "ModelEndpoint",
+  metadata: { name: "primary-model", namespace: "default" },
+  spec: {
+    provider: "anthropic",
+    default_model: "claude-opus-4-1",
+    base_url: "https://private-provider.example/v1",
+    auth: { secretRef: "do-not-expose" },
+  },
+} as ModelEndpoint;
+
+describe("resolveAgentAiAttribution", () => {
+  test("returns only public provider/model fields for one exact agent-endpoint chain", () => {
+    const attribution = resolveAgentAiAttribution("writer", [agent], [endpoint]);
+    expect(attribution).toEqual({ provider: "anthropic", modelId: "claude-opus-4-1" });
+    const serialized = JSON.stringify(attribution);
+    expect(serialized).not.toContain("do-not-expose");
+    expect(serialized).not.toContain("private-provider.example");
+  });
+
+  test("falls back when the agent, endpoint, or mapping is ambiguous", () => {
+    expect(resolveAgentAiAttribution("system", [agent], [endpoint])).toBeUndefined();
+    expect(resolveAgentAiAttribution("missing", [agent], [endpoint])).toBeUndefined();
+    expect(resolveAgentAiAttribution("writer", [agent, agent], [endpoint])).toBeUndefined();
+    expect(resolveAgentAiAttribution("writer", [agent], [endpoint, endpoint])).toBeUndefined();
+  });
+});

--- a/frontend/tests/aiDisclosureSurfaces.test.tsx
+++ b/frontend/tests/aiDisclosureSurfaces.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { TaskTraceEvent } from "../src/api/types";
+import type { SessionTimelineItem } from "../src/utils/sessionTimeline";
+import { SessionTimeline } from "../src/components/SessionTimeline";
+import { TraceView } from "../src/components/TraceView";
+
+function messageItem(role: string, content: string): SessionTimelineItem {
+  return {
+    key: `${role}-1`,
+    kind: "message",
+    role,
+    title: role,
+    content,
+    eventType: `${role}.message`,
+    seq: 1,
+    startSeq: 1,
+    endSeq: 1,
+    abandoned: false,
+  };
+}
+
+describe("Orloj disclosure surface integration", () => {
+  test("labels only assistant Session timeline messages", () => {
+    const html = renderToStaticMarkup(
+      <SessionTimeline
+        items={[messageItem("user", "human input"), messageItem("assistant", "agent output")]}
+        onSelectCheckpoint={() => {}}
+      />,
+    );
+    expect((html.match(/data-ai-disclosure="generated-output"/g) ?? [])).toHaveLength(1);
+    expect(html).toContain("agent output");
+    expect(html).toContain("human input");
+  });
+
+  test("labels model output trace rows with resolved attribution but not tool events", () => {
+    const trace: TaskTraceEvent[] = [
+      { timestamp: "2026-08-26T00:00:00Z", type: "model_output", agent: "writer", message: "generated trace output" },
+      { timestamp: "2026-08-26T00:00:01Z", type: "tool_call", agent: "writer", tool: "read_file", message: "operational tool event" },
+    ];
+    const html = renderToStaticMarkup(
+      <TraceView trace={trace} resolveAttribution={() => ({ provider: "anthropic", modelId: "claude-opus-4-1" })} />,
+    );
+    expect((html.match(/data-ai-disclosure="generated-output"/g) ?? [])).toHaveLength(1);
+    expect(html).toContain('data-ai-provider="anthropic"');
+    expect(html).toContain('data-ai-model="claude-opus-4-1"');
+  });
+});

--- a/frontend/tests/aiTransparencySurfaces.test.ts
+++ b/frontend/tests/aiTransparencySurfaces.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  ORLOJ_AI_CENSUS_PATTERNS,
+  aiTransparencySurfaces,
+  validateAiTransparencyRegistry,
+} from "../src/compliance/aiTransparencySurfaces";
+
+const sourceRoot = resolve(import.meta.dir, "../src");
+
+function productionSources(dir = sourceRoot, prefix = ""): Map<string, string> {
+  const files = new Map<string, string>();
+  for (const name of readdirSync(dir)) {
+    const absolute = resolve(dir, name);
+    const relative = prefix ? `${prefix}/${name}` : name;
+    if (statSync(absolute).isDirectory()) {
+      for (const [child, source] of productionSources(absolute, relative)) files.set(child, source);
+    } else if (/\.(ts|tsx)$/.test(name) && !name.includes(".test.") && relative !== "compliance/aiTransparencySurfaces.ts") {
+      files.set(relative, readFileSync(absolute, "utf8"));
+    }
+  }
+  return files;
+}
+
+function findUnregistered(files: ReadonlyMap<string, string>): string[] {
+  const registered = new Set<string>(aiTransparencySurfaces.flatMap((surface) => [...surface.sourceFiles]));
+  return [...files]
+    .filter(([, source]) => ORLOJ_AI_CENSUS_PATTERNS.some((pattern) => pattern.test(source)))
+    .map(([file]) => file)
+    .filter((file) => !registered.has(file))
+    .sort();
+}
+
+describe("Orloj AI transparency registry", () => {
+  test("is internally valid and classifies every required candidate", () => {
+    expect(validateAiTransparencyRegistry()).toEqual([]);
+    const registered = new Set<string>(aiTransparencySurfaces.flatMap((surface) => [...surface.sourceFiles]));
+    const candidates = [
+      "pages/TaskDetail.tsx",
+      "components/TraceView.tsx",
+      "components/LogViewer.tsx",
+      "pages/EvalRunDetail.tsx",
+      "pages/SessionDetail.tsx",
+      "components/SessionTimeline.tsx",
+    ];
+    expect(candidates.filter((file) => !registered.has(file))).toEqual([]);
+  });
+
+  test("fails a synthetic unregistered AI output branch", () => {
+    const synthetic = new Map(productionSources());
+    synthetic.set("pages/UnregisteredAiOutput.tsx", "export const output = task.status?.output;");
+    expect(findUnregistered(synthetic)).toContain("pages/UnregisteredAiOutput.tsx");
+  });
+
+  test("has no unregistered production branch in the deterministic census", () => {
+    expect(findUnregistered(productionSources())).toEqual([]);
+  });
+
+  test("ties every included row to a production disclosure placement", () => {
+    const files = productionSources();
+    for (const surface of aiTransparencySurfaces.filter((entry) => entry.decision === "included")) {
+      expect(
+        surface.sourceFiles.some((file) => files.get(file)?.includes("AiDisclosure")),
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add dependency-free, disclosure-only locale copy with explicit English fallback
- disclose live Session interaction/assistant messages, Task output/agent messages, model/agent trace output, and Eval result output
- resolve provider/model only through an unambiguous agent → model_ref → endpoint chain without exposing secretRef, base URL, or options
- add a production source registry, deterministic census guards, SSR surface tests, and an Unreleased changelog entry

## Verification
- `cd frontend && bun install --frozen-lockfile`
- `bun test` (12 tests)
- `bun run typecheck`
- `bun run build`
- `go test ./... -count=1 -timeout 120s`
- no `frontend/bun.lock` delta

## Safety / delivery status
No model routing, prompt, API, secret, analytics, deployment, binary, or daemon behavior changes. Aggregate and ambiguous output uses explicit provider-agnostic metadata. This localizes only disclosure copy, not the rest of the English-only console. Source-ready only: AGaaS's installed/live Orloj v0.16.1 remains unchanged pending normal merge/release/install delivery.

Tracks KB-1579 and goals G-MPTOI7J1-0001-MKOJ, G-X9W03E70-0001-FES6, G-MPTOFHRT-0001-I4MJ.
